### PR TITLE
Guess the home dir when HOME is not set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,8 +24,13 @@ linters:
     - testifylint
     - intrange
     - thelper
+    - forbidigo
 
   settings:
+    forbidigo:
+      forbid:
+        - pattern: ^os\.UserHomeDir
+          message: "Do not use os.UserHomeDir(). Use user.HomeDir() instead."
     gocritic:
       disabled-checks:
         - ifElseChain

--- a/cmd/docker-mcp/catalog/catalog.go
+++ b/cmd/docker-mcp/catalog/catalog.go
@@ -2,7 +2,6 @@ package catalog
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/yq"
 )
 
@@ -63,7 +63,7 @@ func setCatalogMetaData(yamlData []byte, meta MetaData) ([]byte, error) {
 }
 
 func toCatalogFilePath(name string) (string, error) {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/docker-mcp/catalog/config.go
+++ b/cmd/docker-mcp/catalog/config.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 )
 
 const (
@@ -24,10 +26,11 @@ type Catalog struct {
 }
 
 func ReadConfig() (*Config, error) {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return nil, err
 	}
+
 	configFilePath := filepath.Join(homeDir, ".docker", configDir, configFile)
 	data, err := os.ReadFile(configFilePath)
 	if os.IsNotExist(err) {
@@ -86,10 +89,11 @@ func WriteCatalogFile(name string, content []byte) error {
 }
 
 func assertConfigDirsExist() error {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return err
 	}
+
 	dir := filepath.Join(homeDir, ".docker", configDir, catalogsDir)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return os.MkdirAll(dir, 0o755)
@@ -105,10 +109,11 @@ func writeConfig(cfg *Config) error {
 	if err := assertConfigDirsExist(); err != nil {
 		return err
 	}
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return err
 	}
+
 	configFilePath := filepath.Join(homeDir, ".docker", configDir, configFile)
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {

--- a/cmd/docker-mcp/internal/catalog/catalog.go
+++ b/cmd/docker-mcp/internal/catalog/catalog.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 )
 
 func Get(ctx context.Context) (Catalog, error) {
@@ -78,10 +80,11 @@ func readFileOrURL(ctx context.Context, fileOrURL string) ([]byte, error) {
 		return buf, nil
 
 	default:
-		homeDir, err := os.UserHomeDir()
+		homeDir, err := user.HomeDir()
 		if err != nil {
 			return nil, err
 		}
+
 		path := filepath.Join(homeDir, ".docker", "mcp", "catalogs", fileOrURL)
 
 		buf, err := os.ReadFile(path)

--- a/cmd/docker-mcp/internal/config/readwrite.go
+++ b/cmd/docker-mcp/internal/config/readwrite.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 )
 
 func ReadConfig(ctx context.Context, dockerClient VolumeInspecter) ([]byte, error) {
@@ -68,7 +70,7 @@ func FilePath(name string) (string, error) {
 		return name, nil
 	}
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := user.HomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/docker-mcp/internal/desktop/sockets_darwin.go
+++ b/cmd/docker-mcp/internal/desktop/sockets_darwin.go
@@ -1,13 +1,14 @@
 package desktop
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 )
 
 func getDockerDesktopPaths() (DockerDesktopPaths, error) {
-	home, err := os.UserHomeDir()
+	home, err := user.HomeDir()
 	if err != nil {
 		return DockerDesktopPaths{}, err
 	}

--- a/cmd/docker-mcp/internal/desktop/sockets_linux.go
+++ b/cmd/docker-mcp/internal/desktop/sockets_linux.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 )
 
 func getDockerDesktopPaths() (DockerDesktopPaths, error) {
@@ -14,7 +16,7 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 			return DockerDesktopPaths{}, err
 		}
 
-		home, err := os.UserHomeDir()
+		home, err := user.HomeDir()
 		if err != nil {
 			return DockerDesktopPaths{}, err
 		}

--- a/cmd/docker-mcp/internal/docker/run.go
+++ b/cmd/docker-mcp/internal/docker/run.go
@@ -2,12 +2,12 @@ package docker
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 
 	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/desktop"
+	"github.com/docker/mcp-cli/cmd/docker-mcp/internal/user"
 )
 
 func RunOnDockerDesktop(ctx context.Context, args ...string) ([]byte, error) {
@@ -18,7 +18,7 @@ func RunOnDockerDesktop(ctx context.Context, args ...string) ([]byte, error) {
 	if runtime.GOOS == "windows" {
 		host = "npipe:////./pipe/docker_engine_linux"
 	} else {
-		home, err := os.UserHomeDir()
+		home, err := user.HomeDir()
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/docker-mcp/internal/user/home.go
+++ b/cmd/docker-mcp/internal/user/home.go
@@ -1,0 +1,31 @@
+package user
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func HomeDir() (string, error) {
+	//nolint:forbidigo
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Probably HOME/USERPROFILE environment variable is hidden by the MCP client to improve security.
+		// In that case, let's assume the current binary (docker-mcp) is in the standard docker cli plugins location
+		// and derive the home directory from there.
+		currentBinary := os.Args[0]
+		if currentBinary == "" {
+			return "", err
+		}
+
+		plugins := filepath.Dir(currentBinary)
+		dotDocker := filepath.Dir(plugins)
+		if filepath.Base(dotDocker) != ".docker" {
+			return "", err
+		}
+
+		home := filepath.Dir(dotDocker)
+		return home, nil
+	}
+
+	return home, nil
+}


### PR DESCRIPTION
MCP clients seem to have realized that every env variable has the potential to be a PII. The HOME one clearly is because it contains the user's id.
So they have started to remove all of them when running MCP servers.

That's clearly not convenient for us.

Let's try to guess the location of user's home when the HOME env var is not set.