### PR TITLE
Add an endpoint for health

### DIFF
--- a/cmd/docker-mcp/internal/health/health.go
+++ b/cmd/docker-mcp/internal/health/health.go
@@ -1,0 +1,19 @@
+package health
+
+import "sync/atomic"
+
+type State struct {
+	healthy atomic.Bool
+}
+
+func (h *State) IsHealthy() bool {
+	return h.healthy.Load()
+}
+
+func (h *State) SetHealthy() {
+	h.healthy.Store(true)
+}
+
+func (h *State) SetUnhealthy() {
+	h.healthy.Store(false)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,4 +10,5 @@
 + `postgresql` - Query a PostgreSQL DB through a PostgreSQL MCP Server, through the Gateway, from a python client.
 + `docker-in-docker` - Run the MCP Gateway and the MCP server into the same Docker in Docker container.
 + `interceptors` - Configure interceptors on Tool Calls.
++ `health` - Health checks with Compose.
 + `compose-static` - Run the MCP Gateway, with Compose, in `static` mode. (Experimental)

--- a/examples/health/Dockerfile
+++ b/examples/health/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-alpine@sha256:9b4929a72599b6c6389ece4ecbf415fd1355129f22bb92bb137eea098f05e975
+
+RUN pip install mcp[cli]
+
+WORKDIR /app
+COPY main.py ./
+ENTRYPOINT ["python", "main.py"]

--- a/examples/health/README.md
+++ b/examples/health/README.md
@@ -1,0 +1,10 @@
+# Docker Compose and Health checks
+
+This example shows how to rely on the Gateway's health check endpoint
+to wait before starting clients.
+
+## How to run
+
+```console
+docker compose up --build
+```

--- a/examples/health/docker-compose.yaml
+++ b/examples/health/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  client:
+    build: .
+    environment:
+      - MCP_HOST=http://gateway:9011/mcp
+    depends_on:
+      gateway:
+        condition: service_healthy
+
+  gateway:
+    image: docker/mcp-gateway
+    command:
+      - --transport=streaming
+      - --servers=fetch
+      - --port=9011
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: wget http://localhost:9011/health
+      interval: 1s
+      timeout: 10s
+      retries: 60
+      start_period: 2s

--- a/examples/health/main.py
+++ b/examples/health/main.py
@@ -1,0 +1,24 @@
+import os
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+async def main():
+    async with streamablehttp_client(os.getenv("MCP_HOST")) as (
+        read_stream,
+        write_stream,
+        _,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "fetch", {"url": "https://en.wikipedia.org/wiki/Health_Check"}
+            )
+            print(result.content[0].text)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
**What I did**

+ Added a `/health` endpoint to the MCP Gateway.
+ Made sure it responds http 200 only when it's up and running and ready to list/call tools.

**Related issue**
fixes #33 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![IMG_1378](https://github.com/user-attachments/assets/9ce8c494-7d50-44d0-839e-41b2e5665f50)

