### PR TITLE
Push the gateway image on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,7 @@ jobs:
 
       - name: Build
         run: make docker-mcp-cross
+
+      - name: Push Gateway image
+        if: github.ref == 'refs/heads/main'
+        run: make push-mcp-gateway


### PR DESCRIPTION
**What I did**

Made sure the `docker/mcp-gateway` image is pushed when new commits are merged to `main`

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![IMG_1369](https://github.com/user-attachments/assets/80ca8b44-e892-43bd-a5a6-ca33e9a16b71)
