### PR TITLE
Fix program data env missing for some clients.

### DIFF
--- a/cmd/docker-mcp/client/config.go
+++ b/cmd/docker-mcp/client/config.go
@@ -116,6 +116,7 @@ func newMCPGatewayServer() *MCPServerSTDIO {
 		env = map[string]string{
 			"LOCALAPPDATA": os.Getenv("LOCALAPPDATA"),
 			"ProgramFiles": os.Getenv("ProgramFiles"),
+			"ProgramData":  os.Getenv("ProgramData"),
 		}
 	}
 	return &MCPServerSTDIO{


### PR DESCRIPTION
**What I did**
Fixed a [user reported issue](https://github.com/docker/for-win/issues/14860) where MCP Hosts are stripping the `ProgramData` environment variable on Windows. When we create the config, we need this environment variable (used for getting secrets, DD paths, etc).

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Fixes https://github.com/docker/for-win/issues/14860

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/8b2ef9ee-ffdd-4f1f-afa8-386984cd16fc)
