### PR TITLE
Tools filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ The MCP CLI uses several configuration files:
 
 - **`docker-mcp.yaml`**: Server catalog defining available MCP servers
 - **`registry.yaml`**: Registry of enabled servers
-- **`config.yaml`**: Gateway configuration and options
+- **`config.yaml`**: Configuration per server
+- **`tools.yaml`**: Enabled tools per server
 
 Configuration files are typically stored in `~/.docker/mcp/`. This is in this directory that Docker Desktop's
 MCP Toolkit with store its configuration.

--- a/cmd/docker-mcp/backup/dump.go
+++ b/cmd/docker-mcp/backup/dump.go
@@ -26,6 +26,11 @@ func Dump(ctx context.Context, docker docker.Client) ([]byte, error) {
 		return nil, err
 	}
 
+	toolsConfig, err := config.ReadTools(ctx, docker)
+	if err != nil {
+		return nil, err
+	}
+
 	catalogConfig, err := catalog.ReadConfig()
 	if err != nil {
 		return nil, err
@@ -74,6 +79,7 @@ func Dump(ctx context.Context, docker docker.Client) ([]byte, error) {
 		Registry:     string(registryContent),
 		Catalog:      string(catalogContent),
 		CatalogFiles: catalogFiles,
+		Tools:        string(toolsConfig),
 		Secrets:      secrets,
 		Policy:       policy,
 	}

--- a/cmd/docker-mcp/backup/restore.go
+++ b/cmd/docker-mcp/backup/restore.go
@@ -21,6 +21,9 @@ func Restore(ctx context.Context, backupData []byte) error {
 	if err := config.WriteRegistry([]byte(backup.Registry)); err != nil {
 		return err
 	}
+	if err := config.WriteTools([]byte(backup.Tools)); err != nil {
+		return err
+	}
 
 	catalogBefore, err := catalog.ReadConfig()
 	if err != nil {

--- a/cmd/docker-mcp/backup/types.go
+++ b/cmd/docker-mcp/backup/types.go
@@ -7,6 +7,7 @@ type Backup struct {
 	Registry     string            `json:"registry"`
 	Catalog      string            `json:"catalog"`
 	CatalogFiles map[string]string `json:"catalogFiles"`
+	Tools        string            `json:"tools"`
 	Secrets      []desktop.Secret  `json:"secrets"`
 	Policy       string            `json:"policy"`
 }

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -40,6 +40,7 @@ func gatewayCommand(docker docker.Client) *cobra.Command {
 			CatalogPath:  "docker-mcp.yaml",
 			RegistryPath: "registry.yaml",
 			ConfigPath:   "config.yaml",
+			ToolsPath:    "tools.yaml",
 			SecretsPath:  "docker-desktop",
 			Options: gateway.Options{
 				Cpus:         1,
@@ -65,6 +66,7 @@ func gatewayCommand(docker docker.Client) *cobra.Command {
 	runCmd.Flags().StringVar(&options.CatalogPath, "catalog", options.CatalogPath, "path to the docker-mcp.yaml catalog (absolute or relative to ~/.docker/mcp/catalogs/)")
 	runCmd.Flags().StringVar(&options.RegistryPath, "registry", options.RegistryPath, "path to the registry.yaml (absolute or relative to ~/.docker/mcp/)")
 	runCmd.Flags().StringVar(&options.ConfigPath, "config", options.ConfigPath, "path to the config.yaml (absolute or relative to ~/.docker/mcp/)")
+	runCmd.Flags().StringVar(&options.ToolsPath, "tools-config", options.ToolsPath, "path to the tools.yaml (absolute or relative to ~/.docker/mcp/)")
 	runCmd.Flags().StringVar(&options.SecretsPath, "secrets", options.SecretsPath, "colon separated paths to search for secrets. Can be `docker-desktop` or a path to a .env file (default to using Docker Deskop's secrets API)")
 	runCmd.Flags().StringSliceVar(&options.ToolNames, "tools", options.ToolNames, "List of tools to enable")
 	runCmd.Flags().StringArrayVar(&options.Interceptors, "interceptor", options.Interceptors, "List of interceptors to use (format: when:type:path, e.g. 'before:exec:/bin/path')")

--- a/cmd/docker-mcp/commands/root.go
+++ b/cmd/docker-mcp/commands/root.go
@@ -77,7 +77,7 @@ func Root(ctx context.Context, cwd string, dockerCli command.Cli) *cobra.Command
 	cmd.AddCommand(policyCommand())
 	cmd.AddCommand(secretCommand(dockerClient))
 	cmd.AddCommand(serverCommand(dockerClient))
-	cmd.AddCommand(toolsCommand())
+	cmd.AddCommand(toolsCommand(dockerClient))
 	cmd.AddCommand(versionCommand())
 
 	if os.Getenv("DOCKER_MCP_SHOW_HIDDEN") == "1" {

--- a/cmd/docker-mcp/commands/tools.go
+++ b/cmd/docker-mcp/commands/tools.go
@@ -61,26 +61,26 @@ func toolsCommand(docker docker.Client) *cobra.Command {
 
 	var enableServerName string
 	enableCmd := &cobra.Command{
-		Use:   "enable",
-		Short: "enable a tool",
-		Args:  cobra.ExactArgs(1),
+		Use:   "enable [tool1] [tool2] ...",
+		Short: "enable one or more tools",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return tools.Enable(cmd.Context(), docker, args, enableServerName)
 		},
 	}
-	enableCmd.Flags().StringVar(&enableServerName, "server", "", "Specify which server provides the tool (optional, will auto-discover if not provided)")
+	enableCmd.Flags().StringVar(&enableServerName, "server", "", "Specify which server provides the tools (optional, will auto-discover if not provided)")
 	cmd.AddCommand(enableCmd)
 
 	var disableServerName string
 	disableCmd := &cobra.Command{
-		Use:   "disable",
-		Short: "disable a tool",
-		Args:  cobra.ExactArgs(1),
+		Use:   "disable [tool1] [tool2] ...",
+		Short: "disable one or more tools",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return tools.Disable(cmd.Context(), docker, args, disableServerName)
 		},
 	}
-	disableCmd.Flags().StringVar(&disableServerName, "server", "", "Specify which server provides the tool (optional, will auto-discover if not provided)")
+	disableCmd.Flags().StringVar(&disableServerName, "server", "", "Specify which server provides the tools (optional, will auto-discover if not provided)")
 	cmd.AddCommand(disableCmd)
 
 	return cmd

--- a/cmd/docker-mcp/commands/tools.go
+++ b/cmd/docker-mcp/commands/tools.go
@@ -3,13 +3,14 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/docker"
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/tools"
 )
 
-func toolsCommand() *cobra.Command {
+func toolsCommand(docker docker.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tools",
-		Short: "List/count/call MCP tools",
+		Short: "Manage tools",
 	}
 
 	var (
@@ -57,6 +58,30 @@ func toolsCommand() *cobra.Command {
 			return tools.Call(cmd.Context(), version, gatewayArgs, verbose, args)
 		},
 	})
+
+	var enableServerName string
+	enableCmd := &cobra.Command{
+		Use:   "enable",
+		Short: "enable a tool",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return tools.Enable(cmd.Context(), docker, args, enableServerName)
+		},
+	}
+	enableCmd.Flags().StringVar(&enableServerName, "server", "", "Specify which server provides the tool (optional, will auto-discover if not provided)")
+	cmd.AddCommand(enableCmd)
+
+	var disableServerName string
+	disableCmd := &cobra.Command{
+		Use:   "disable",
+		Short: "disable a tool",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return tools.Disable(cmd.Context(), docker, args, disableServerName)
+		},
+	}
+	disableCmd.Flags().StringVar(&disableServerName, "server", "", "Specify which server provides the tool (optional, will auto-discover if not provided)")
+	cmd.AddCommand(disableCmd)
 
 	return cmd
 }

--- a/cmd/docker-mcp/internal/config/readwrite.go
+++ b/cmd/docker-mcp/internal/config/readwrite.go
@@ -11,6 +11,10 @@ import (
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/user"
 )
 
+func ReadTools(ctx context.Context, docker docker.Client) ([]byte, error) {
+	return ReadConfigFile(ctx, docker, "tools.yaml")
+}
+
 func ReadConfig(ctx context.Context, docker docker.Client) ([]byte, error) {
 	return ReadConfigFile(ctx, docker, "config.yaml")
 }
@@ -35,6 +39,10 @@ func ReadCatalogFile(name string) ([]byte, error) {
 	}
 
 	return readFileOrEmpty(path)
+}
+
+func WriteTools(content []byte) error {
+	return writeConfigFile("tools.yaml", content)
 }
 
 func WriteConfig(content []byte) error {

--- a/cmd/docker-mcp/internal/config/tools.go
+++ b/cmd/docker-mcp/internal/config/tools.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+type ToolsConfig struct {
+	ServerTools map[string][]string `yaml:",inline"`
+}
+
+func ParseToolsConfig(toolsYaml []byte) (ToolsConfig, error) {
+	var serverTools ToolsConfig
+	if err := yaml.Unmarshal(toolsYaml, &serverTools); err != nil {
+		return ToolsConfig{}, err
+	}
+
+	return serverTools, nil
+}

--- a/cmd/docker-mcp/internal/gateway/config.go
+++ b/cmd/docker-mcp/internal/gateway/config.go
@@ -6,6 +6,7 @@ type Config struct {
 	CatalogPath  string
 	ConfigPath   string
 	RegistryPath string
+	ToolsPath    string
 	SecretsPath  string
 }
 

--- a/cmd/docker-mcp/internal/gateway/run.go
+++ b/cmd/docker-mcp/internal/gateway/run.go
@@ -35,6 +35,7 @@ func NewGateway(config Config, docker docker.Client) *Gateway {
 			RegistryPath: config.RegistryPath,
 			ConfigPath:   config.ConfigPath,
 			SecretsPath:  config.SecretsPath,
+			ToolsPath:    config.ToolsPath,
 			Watch:        config.Watch,
 			docker:       docker,
 		},

--- a/cmd/docker-mcp/tools/enable.go
+++ b/cmd/docker-mcp/tools/enable.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+
+	"slices"
+
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/catalog"
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/config"
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/docker"
+)
+
+func Disable(ctx context.Context, docker docker.Client, toolNames []string, serverName string) error {
+	return update(ctx, docker, nil, toolNames, serverName)
+}
+
+func Enable(ctx context.Context, docker docker.Client, toolNames []string, serverName string) error {
+	return update(ctx, docker, toolNames, nil, serverName)
+}
+
+func findServerByTool(mcpCatalog catalog.Catalog, toolName string) (string, error) {
+	for serverName, server := range mcpCatalog.Servers {
+		for _, tool := range server.Tools {
+			if tool.Name == toolName {
+				return serverName, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("tool %q not found in any server", toolName)
+}
+
+func validateToolExistsInServer(mcpCatalog catalog.Catalog, serverName string, toolName string) error {
+	if _, exists := mcpCatalog.Servers[serverName]; !exists {
+		return fmt.Errorf("server %q not found in catalog", serverName)
+	}
+
+	for _, tool := range mcpCatalog.Servers[serverName].Tools {
+		if tool.Name == toolName {
+			return nil
+		}
+	}
+	return fmt.Errorf("tool %q not found in server %q", toolName, serverName)
+}
+
+func update(ctx context.Context, docker docker.Client, add []string, remove []string, serverName string) error {
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	if err != nil {
+		return fmt.Errorf("reading tools: %w", err)
+	}
+
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	if err != nil {
+		return fmt.Errorf("parsing tools: %w", err)
+	}
+
+	if toolsConfig.ServerTools == nil {
+		toolsConfig.ServerTools = make(map[string][]string)
+	}
+
+	mcpCatalog, err := catalog.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("reading catalog: %w", err)
+	}
+
+	for _, toolName := range add {
+		var targetServerName string
+
+		if serverName != "" {
+			if err := validateToolExistsInServer(mcpCatalog, serverName, toolName); err != nil {
+				return err
+			}
+			targetServerName = serverName
+		} else {
+			discoveredServerName, err := findServerByTool(mcpCatalog, toolName)
+			if err != nil {
+				return err
+			}
+			targetServerName = discoveredServerName
+		}
+
+		toolAlreadyEnabled := slices.Contains(toolsConfig.ServerTools[targetServerName], toolName)
+		if toolAlreadyEnabled {
+			continue
+		}
+
+		toolsConfig.ServerTools[targetServerName] = append(toolsConfig.ServerTools[targetServerName], toolName)
+	}
+
+	for _, toolName := range remove {
+		var targetServerName string
+
+		if serverName != "" {
+			if err := validateToolExistsInServer(mcpCatalog, serverName, toolName); err != nil {
+				return err
+			}
+			targetServerName = serverName
+		} else {
+			discoveredServerName, err := findServerByTool(mcpCatalog, toolName)
+			if err != nil {
+				return err
+			}
+			targetServerName = discoveredServerName
+		}
+
+		if _, exists := toolsConfig.ServerTools[targetServerName]; !exists {
+			serverTools := mcpCatalog.Servers[targetServerName].Tools
+			var allToolNames []string
+			for _, tool := range serverTools {
+				allToolNames = append(allToolNames, tool.Name)
+			}
+
+			toolsConfig.ServerTools[targetServerName] = []string{}
+			for _, tool := range allToolNames {
+				if tool != toolName {
+					toolsConfig.ServerTools[targetServerName] = append(toolsConfig.ServerTools[targetServerName], tool)
+				}
+			}
+			continue
+		}
+
+		tools := toolsConfig.ServerTools[targetServerName]
+		newTools := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			if tool != toolName {
+				newTools = append(newTools, tool)
+			}
+		}
+		toolsConfig.ServerTools[targetServerName] = newTools
+	}
+
+	for serverName := range toolsConfig.ServerTools {
+		sort.Strings(toolsConfig.ServerTools[serverName])
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(toolsConfig.ServerTools); err != nil {
+		return fmt.Errorf("encoding tools: %w", err)
+	}
+
+	if err := config.WriteTools(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing tools: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/docker-mcp/tools/tools_test.go
+++ b/cmd/docker-mcp/tools/tools_test.go
@@ -1,0 +1,286 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/docker/docker/api/types/volume"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/config"
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/docker"
+)
+
+func TestEnableToolsEmpty(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"search_duckduckgo"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+}
+
+func TestEnableToolsExistingServer(t *testing.T) {
+	ctx, _, docker := setup(t,
+		withToolsConfig("duckduckgo:\n  - other_tool"),
+		withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"search_duckduckgo"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestEnableToolsExistingTool(t *testing.T) {
+	ctx, _, docker := setup(t,
+		withToolsConfig("duckduckgo:\n  - other_tool"),
+		withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"other_tool"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Len(t, toolsConfig.ServerTools["duckduckgo"], 1)
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestEnableToolsDuplicateTool(t *testing.T) {
+	ctx, _, docker := setup(t,
+		withEmptyToolsConfig(),
+		withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"other_tool"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+	assert.NotContains(t, toolsConfig.ServerTools["other_server"], "other_tool")
+
+	err = Enable(ctx, docker, []string{"other_tool"}, "other_server")
+	require.NoError(t, err)
+
+	toolsYAML, err = config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err = config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+	assert.Contains(t, toolsConfig.ServerTools["other_server"], "other_tool")
+}
+
+func TestEnableToolNotFound(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"nonexistent_tool"}, "duckduckgo")
+	require.ErrorContains(t, err, "tool \"nonexistent_tool\" not found in server \"duckduckgo\"")
+}
+
+func TestEnableServerNotFound(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"nonexistent_tool"}, "nonexistent_server")
+	require.ErrorContains(t, err, "server \"nonexistent_server\" not found in catalog")
+}
+
+func TestEnableToolAutoDiscoverServer(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"search_duckduckgo"}, "")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+}
+
+func TestEnableToolAutoDiscoverServerExistingServer(t *testing.T) {
+	ctx, _, docker := setup(t, withToolsConfig("duckduckgo:\n  - other_tool"), withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"search_duckduckgo"}, "")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestEnableToolAutoDiscoverServerExistingTool(t *testing.T) {
+	ctx, _, docker := setup(t,
+		withToolsConfig("duckduckgo:\n  - other_tool"),
+		withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"other_tool"}, "")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Len(t, toolsConfig.ServerTools["duckduckgo"], 1)
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestEnableToolAutoDiscoverNotFound(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Enable(ctx, docker, []string{"nonexistent_tool"}, "")
+	require.ErrorContains(t, err, "tool \"nonexistent_tool\" not found in any server")
+}
+
+func TestDisableEmpty(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Disable(ctx, docker, []string{"search_duckduckgo"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.NotContains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestDisableToolExistingServer(t *testing.T) {
+	ctx, _, docker := setup(t,
+		withToolsConfig("duckduckgo:\n  - search_duckduckgo\n  - other_tool"),
+		withSampleCatalog())
+
+	err := Disable(ctx, docker, []string{"search_duckduckgo"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.NotContains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestDisableToolExistingServerToolAlreadyDisabled(t *testing.T) {
+	ctx, _, docker := setup(t,
+		withToolsConfig("duckduckgo:\n  - search_duckduckgo"),
+		withSampleCatalog())
+
+	err := Disable(ctx, docker, []string{"other_tool"}, "duckduckgo")
+	require.NoError(t, err)
+
+	toolsYAML, err := config.ReadTools(ctx, docker)
+	require.NoError(t, err)
+	toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+	require.NoError(t, err)
+
+	assert.Contains(t, toolsConfig.ServerTools["duckduckgo"], "search_duckduckgo")
+	assert.NotContains(t, toolsConfig.ServerTools["duckduckgo"], "other_tool")
+}
+
+func TestDisableServerNotFound(t *testing.T) {
+	ctx, _, docker := setup(t, withEmptyToolsConfig(), withSampleCatalog())
+
+	err := Disable(ctx, docker, []string{"nonexistent_tool"}, "nonexistent_server")
+	require.ErrorContains(t, err, "server \"nonexistent_server\" not found in catalog")
+}
+
+// Fixtures and helpers
+
+func setup(t *testing.T, options ...option) (context.Context, string, docker.Client) {
+	t.Helper()
+
+	docker := &fakeDocker{}
+
+	home := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	} else {
+		t.Setenv("HOME", home)
+	}
+
+	for _, o := range options {
+		o(t, home, docker)
+	}
+
+	return t.Context(), home, docker
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	err := os.MkdirAll(filepath.Dir(path), 0o755)
+	require.NoError(t, err)
+	err = os.WriteFile(path, content, 0o644)
+	require.NoError(t, err)
+}
+
+type fakeDocker struct {
+	docker.Client
+	volume     volume.Volume
+	inspectErr error
+}
+
+func (f *fakeDocker) InspectVolume(context.Context, string) (volume.Volume, error) {
+	return f.volume, f.inspectErr
+}
+
+type option func(*testing.T, string, *fakeDocker)
+
+func withEmptyToolsConfig() option {
+	return withToolsConfig("")
+}
+
+func withToolsConfig(yaml string) option {
+	return func(t *testing.T, home string, _ *fakeDocker) {
+		t.Helper()
+		writeFile(t, filepath.Join(home, ".docker/mcp/tools.yaml"), []byte(yaml))
+	}
+}
+
+func withSampleCatalog() option {
+	return func(t *testing.T, home string, _ *fakeDocker) {
+		t.Helper()
+		catalogContent := `registry:
+  duckduckgo:
+    tools:
+      - name: "search_duckduckgo"
+        description: "Search DuckDuckGo"
+      - name: "other_tool"
+        description: "Another tool"
+  other_server:
+    tools:
+      - name: "other_tool"
+        description: "Another tool"
+`
+		writeFile(t, filepath.Join(home, ".docker/mcp/catalogs/docker-mcp.yaml"), []byte(catalogContent))
+	}
+}

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -17,6 +17,7 @@ docker run -d \
     --catalog=/mcp/catalogs/docker-mcp.yaml \
     --config=/mcp/config.yaml \
     --registry=/mcp/registry.yaml \
+    --tools-config=/mcp/tools.yaml \
     --secrets=docker-desktop \
     --watch=true \
     --transport=sse \

--- a/examples/mcp_toolkit/compose.yaml
+++ b/examples/mcp_toolkit/compose.yaml
@@ -10,6 +10,7 @@ services:
       - --catalog=/mcp/catalogs/docker-mcp.yaml
       - --config=/mcp/config.yaml
       - --registry=/mcp/registry.yaml
+      - --tools-config=/mcp/tools.yaml
       - --secrets=docker-desktop
       - --watch=true
       - --transport=sse


### PR DESCRIPTION
**What I did**

Tool filtering

Add new commands: `docker mcp tools enable <toolName>` and `docker mcp tools disable <toolName>`. They auto-discover the first matching server using the catalog. Also they accept a `--server` flag. It helps with duplicate tool names where the auto-discover might fail to find the server the user wants.

The enabled tools are stored in a `tools.yaml` file which contains all the enabled tools grouped by server. Example file:
```
curl: []
filesystem:
  - directory_tree
  - get_file_info
  - list_allowed_directories
  - list_directory
  - read_file
  - read_multiple_files
  - search_files
```
read as:
```
curl has all of its tools disabled
filesystem has some of its tools enabled
if a server is not mentioned in the file, then all of its tools are enabled
```

The gateway reads and respects this file. When launching the gateway, the existing `--tools` option (which accepts the tools names) takes precedence over the `tools.yaml` file. This works the same way as the `--servers` option and the `registry.yaml`.

Nice to haves: remove the server if all of its tools are enabled

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**