### PR TITLE
Fix stdio transport for container (no port set)

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -27,7 +27,6 @@ func gatewayCommand(docker docker.Client) *cobra.Command {
 				Cpus:             1,
 				Memory:           "2Gb",
 				Transport:        "stdio",
-				Port:             8811,
 				LogCalls:         true,
 				BlockSecrets:     true,
 				VerifySignatures: true,

--- a/cmd/docker-mcp/internal/gateway/run.go
+++ b/cmd/docker-mcp/internal/gateway/run.go
@@ -200,7 +200,11 @@ func (g *Gateway) Run(ctx context.Context) error {
 
 	case "sse":
 		if g.Port == 0 {
-			return errors.New("missing 'port' for 'sse' server")
+			if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" {
+				g.Port = 8811
+			} else {
+				return errors.New("missing 'port' for 'sse' server")
+			}
 		}
 
 		log("> Start sse server on port", g.Port)
@@ -208,7 +212,11 @@ func (g *Gateway) Run(ctx context.Context) error {
 
 	case "streaming":
 		if g.Port == 0 {
-			return errors.New("missing 'port' for streaming server")
+			if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" {
+				g.Port = 8811
+			} else {
+				return errors.New("missing 'port' for streaming server")
+			}
 		}
 
 		log("> Start streaming server on port", g.Port)

--- a/examples/container/README.md
+++ b/examples/container/README.md
@@ -11,7 +11,7 @@ docker run -d \
     -p 8811:8811 \
     --restart=always \
     --name=mcp-gateway \
-    -v /var/run/docker.sock:/var/run/docker.sock \
+    --use-api-socket \
     -v $HOME/.docker/mcp:/mcp:ro \
     docker/mcp-gateway \
     --catalog=/mcp/catalogs/docker-mcp.yaml \

--- a/examples/docker-in-docker/compose.yaml
+++ b/examples/docker-in-docker/compose.yaml
@@ -5,6 +5,7 @@ services:
     ports:
       - "8080:8080"
     command:
+      - --port=8080
       - --transport=sse
       - --servers=fetch
       - --memory=512Mb


### PR DESCRIPTION
* the default 8811 port for containers broke the stdio transport logic

**What I did**

So as not to break the current logic, I'm only defaulting to port 8811 if DOCKER_MCP_IN_CONTAINER=1 and only for sse and streaming transports