### PR TITLE
Prepare for other types of remote MCP servers

### DIFF
--- a/cmd/docker-mcp/internal/catalog/types.go
+++ b/cmd/docker-mcp/internal/catalog/types.go
@@ -15,7 +15,8 @@ type topLevel struct {
 type Server struct {
 	Image          string   `yaml:"image" json:"image"`
 	LongLived      bool     `yaml:"longLived,omitempty" json:"longLived,omitempty"`
-	SSEEndpoint    string   `yaml:"sseEndpoint,omitempty" json:"sseEndpoint,omitempty"`
+	Remote         Remote   `yaml:"remote,omitempty" json:"remote,omitempty"`
+	SSEEndpoint    string   `yaml:"sseEndpoint,omitempty" json:"sseEndpoint,omitempty"` // Deprecated: Use Remote instead
 	Secrets        []Secret `yaml:"secrets,omitempty" json:"secrets,omitempty"`
 	Env            []Env    `yaml:"env,omitempty" json:"env,omitempty"`
 	Command        []string `yaml:"command,omitempty" json:"command,omitempty"`
@@ -33,6 +34,11 @@ type Secret struct {
 type Env struct {
 	Name  string `yaml:"name" json:"name"`
 	Value string `yaml:"value" json:"value"`
+}
+
+type Remote struct {
+	URL       string `yaml:"url" json:"url"`
+	Transport string `yaml:"transport,omitempty" json:"transport,omitempty"`
 }
 
 // POCI tools

--- a/cmd/docker-mcp/internal/gateway/clientpool.go
+++ b/cmd/docker-mcp/internal/gateway/clientpool.go
@@ -312,7 +312,15 @@ func (cg *clientGetter) GetClient(ctx context.Context) (mcpclient.Client, error)
 			var client mcpclient.Client
 
 			if cg.serverConfig.Spec.SSEEndpoint != "" {
+				// Deprecated: Use Remote instead
 				client = mcpclient.NewSSEClient(cg.serverConfig.Name, cg.serverConfig.Spec.SSEEndpoint)
+			} else if cg.serverConfig.Spec.Remote.URL != "" {
+				switch cg.serverConfig.Spec.Remote.Transport {
+				case "sse":
+					client = mcpclient.NewSSEClient(cg.serverConfig.Name, cg.serverConfig.Spec.Remote.URL)
+				default:
+					return nil, fmt.Errorf("unsupported remote transport: %s", cg.serverConfig.Spec.Remote.Transport)
+				}
 			} else if cg.cp.Static {
 				client = mcpclient.NewStdioCmdClient(cg.serverConfig.Name, "socat", nil, "STDIO", fmt.Sprintf("TCP:mcp-%s:4444", cg.serverConfig.Name))
 			} else {

--- a/cmd/docker-mcp/internal/gateway/configuration.go
+++ b/cmd/docker-mcp/internal/gateway/configuration.go
@@ -73,7 +73,7 @@ func (c *Configuration) Find(serverName string) (*ServerConfig, *map[string]cata
 	}
 
 	// Is it an MCP Server?
-	if server.Image != "" || server.SSEEndpoint != "" {
+	if server.Image != "" || server.SSEEndpoint != "" || server.Remote.URL != "" {
 		return &ServerConfig{
 			Name: serverName,
 			Spec: server,

--- a/examples/remote_mcp/catalog.yaml
+++ b/examples/remote_mcp/catalog.yaml
@@ -4,4 +4,6 @@ registry:
   gitmcpmoby:
     description: Connect to the moby repo.
     title: GitMCP Moby
-    sseEndpoint: "https://gitmcp.io/moby/moby"
+    remote:
+      url: "https://gitmcp.io/moby/moby"
+      transport: sse


### PR DESCRIPTION
Change the catalog's structure to prepare for streaming http remote servers and for authentication. 