### PR TITLE
Deprecate stdio over TCP

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -56,7 +57,11 @@ func gatewayCommand(docker docker.Client) *cobra.Command {
 		Short: "Run the gateway",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if options.Port == 0 && options.Transport != "stdio" {
+			if options.Transport == "stdio" {
+				if options.Port != 0 {
+					return errors.New("cannot use --port with --transport=stdio")
+				}
+			} else if options.Port == 0 {
 				options.Port = 8811
 			}
 

--- a/cmd/docker-mcp/internal/gateway/transport.go
+++ b/cmd/docker-mcp/internal/gateway/transport.go
@@ -7,17 +7,15 @@ import (
 	"net/http"
 
 	"github.com/mark3labs/mcp-go/server"
-
-	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/sockets"
 )
 
-func (g *Gateway) startStdioServer(ctx context.Context, newMCPServer func() *server.MCPServer, stdin io.Reader, stdout io.Writer) error {
-	return server.NewStdioServer(newMCPServer()).Listen(ctx, stdin, stdout)
+func (g *Gateway) startStdioServer(ctx context.Context, mcpServer *server.MCPServer, stdin io.Reader, stdout io.Writer) error {
+	return server.NewStdioServer(mcpServer).Listen(ctx, stdin, stdout)
 }
 
-func (g *Gateway) startSseServer(ctx context.Context, newMCPServer func() *server.MCPServer, ln net.Listener) error {
+func (g *Gateway) startSseServer(ctx context.Context, mcpServer *server.MCPServer, ln net.Listener) error {
 	mux := http.NewServeMux()
-	sseServer := server.NewSSEServer(newMCPServer())
+	sseServer := server.NewSSEServer(mcpServer)
 	mux.Handle("/sse", sseServer.SSEHandler())
 	mux.Handle("/message", sseServer.MessageHandler())
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -40,9 +38,9 @@ func (g *Gateway) startSseServer(ctx context.Context, newMCPServer func() *serve
 	return httpServer.Serve(ln)
 }
 
-func (g *Gateway) startStreamingServer(ctx context.Context, newMCPServer func() *server.MCPServer, ln net.Listener) error {
+func (g *Gateway) startStreamingServer(ctx context.Context, mcpServer *server.MCPServer, ln net.Listener) error {
 	mux := http.NewServeMux()
-	mux.Handle("/mcp", server.NewStreamableHTTPServer(newMCPServer()))
+	mux.Handle("/mcp", server.NewStreamableHTTPServer(mcpServer))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/mcp", http.StatusTemporaryRedirect)
 	})
@@ -62,31 +60,4 @@ func (g *Gateway) startStreamingServer(ctx context.Context, newMCPServer func() 
 		ln.Close()
 	}()
 	return httpServer.Serve(ln)
-}
-
-func (g *Gateway) startStdioOverTCPServer(ctx context.Context, newMCPServer func() *server.MCPServer, ln net.Listener) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			conn, err := sockets.AcceptWithContext(ctx, ln)
-			if err != nil {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				logf("Error accepting the connection: %v", err)
-				continue
-			}
-
-			newServer := server.NewStdioServer(newMCPServer())
-			go func() {
-				defer conn.Close()
-
-				if err := newServer.Listen(ctx, conn, conn); err != nil {
-					logf("Error listening: %v", err)
-				}
-			}()
-		}
-	}
 }


### PR DESCRIPTION
**What I did**

Remove the stdio over TCP mode. It's more of a hack, has a couple of nasty issues and makes the code more complicated.

**Related issue**

https://github.com/docker/mcp-gateway/issues/60