### PR TITLE
Support multiple config directories for a client

### DIFF
--- a/cmd/docker-mcp/client/config.yml
+++ b/cmd/docker-mcp/client/config.yml
@@ -112,10 +112,13 @@ system:
     paths:
       linux: 
         - $HOME/.lmstudio/mcp.json
+        - $HOME/.cache/lm-studio/mcp.json
       darwin: 
         - $HOME/.lmstudio/mcp.json
+        - $HOME/.cache/lm-studio/mcp.json
       windows: 
         - $USERPROFILE\.lmstudio\mcp.json
+        - $USERPROFILE\.cache\lm-studio\mcp.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON

--- a/cmd/docker-mcp/client/config.yml
+++ b/cmd/docker-mcp/client/config.yml
@@ -7,9 +7,12 @@ system:
     - /Applications/Claude.app
     - $AppData\Claude\
     paths:
-      linux: $HOME/.config/claude/claude_desktop_config.json
-      darwin: $HOME/Library/Application Support/Claude/claude_desktop_config.json
-      windows: $APPDATA\Claude\claude_desktop_config.json
+      linux: 
+        - $HOME/.config/claude/claude_desktop_config.json
+      darwin: 
+        - $HOME/Library/Application Support/Claude/claude_desktop_config.json
+      windows: 
+        - $APPDATA\Claude\claude_desktop_config.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON
@@ -22,9 +25,12 @@ system:
     - $HOME/.continue
     - $USERPROFILE\.continue
     paths:
-      linux: $HOME/.continue/config.yaml
-      darwin: $HOME/.continue/config.yaml
-      windows: $USERPROFILE\.continue\config.yaml
+      linux: 
+        - $HOME/.continue/config.yaml
+      darwin: 
+        - $HOME/.continue/config.yaml
+      windows: 
+        - $USERPROFILE\.continue\config.yaml
     yq:
       list: .mcpServers
       set: .mcpServers = (.mcpServers // []) | .mcpServers += [{"name":$NAME}+$JSON]
@@ -37,9 +43,12 @@ system:
     - /Applications/Cursor.app
     - $AppData/Cursor/
     paths:
-      linux: $HOME/.cursor/mcp.json
-      darwin: $HOME/.cursor/mcp.json
-      windows: $USERPROFILE\.cursor\mcp.json
+      linux: 
+        - $HOME/.cursor/mcp.json
+      darwin: 
+        - $HOME/.cursor/mcp.json
+      windows: 
+        - $USERPROFILE\.cursor\mcp.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON
@@ -52,9 +61,12 @@ system:
     - $HOME/.gemini
     - $USERPROFILE\.gemini
     paths:
-      linux: $HOME/.gemini/settings.json
-      darwin: $HOME/.gemini/settings.json
-      windows: $USERPROFILE\.gemini\settings.json
+      linux: 
+        - $HOME/.gemini/settings.json
+      darwin: 
+        - $HOME/.gemini/settings.json
+      windows: 
+        - $USERPROFILE\.gemini\settings.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON
@@ -67,9 +79,12 @@ system:
     - $HOME/.config/goose
     - $USERPROFILE\.config\goose
     paths:
-      linux: $HOME/.config/goose/config.yaml
-      darwin: $HOME/.config/goose/config.yaml
-      windows: $USERPROFILE\.config\goose\config.yaml
+      linux: 
+        - $HOME/.config/goose/config.yaml
+      darwin: 
+        - $HOME/.config/goose/config.yaml
+      windows: 
+        - $USERPROFILE\.config\goose\config.yaml
     yq:
       list: '.extensions | to_entries | map(select(.value.bundled != true)) | map(.value + {"name": .key})'
       set: '.extensions[$SIMPLE_NAME] = {
@@ -91,11 +106,16 @@ system:
     icon: https://raw.githubusercontent.com/docker/mcp-gateway/main/img/client/lmstudio.png
     installCheckPaths:
     - $HOME/.lmstudio
+    - $HOME/.cache/lm-studio
     - $USERPROFILE\.lmstudio
+    - $USERPROFILE\.cache\lm-studio
     paths:
-      linux: $HOME/.lmstudio/mcp.json
-      darwin: $HOME/.lmstudio/mcp.json
-      windows: $USERPROFILE\.lmstudio\mcp.json
+      linux: 
+        - $HOME/.lmstudio/mcp.json
+      darwin: 
+        - $HOME/.lmstudio/mcp.json
+      windows: 
+        - $USERPROFILE\.lmstudio\mcp.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON
@@ -108,9 +128,12 @@ system:
     - $HOME/.sema4ai
     - $USERPROFILE\AppData\Local\sema4ai
     paths:
-      linux: $HOME/.sema4ai/sema4ai-studio/mcp_servers.json
-      darwin: $HOME/.sema4ai/sema4ai-studio/mcp_servers.json
-      windows: $USERPROFILE\AppData\Local\sema4ai\sema4ai-studio\mcp_servers.json
+      linux: 
+        - $HOME/.sema4ai/sema4ai-studio/mcp_servers.json
+      darwin: 
+        - $HOME/.sema4ai/sema4ai-studio/mcp_servers.json
+      windows: 
+        - $USERPROFILE\AppData\Local\sema4ai\sema4ai-studio\mcp_servers.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON+{"transport":"stdio"}

--- a/cmd/docker-mcp/client/global_test.go
+++ b/cmd/docker-mcp/client/global_test.go
@@ -1,0 +1,213 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestGlobalCfg creates a standard globalCfg for testing
+func newTestGlobalCfg() globalCfg {
+	return globalCfg{
+		DisplayName: "Test Client",
+		YQ: YQ{
+			List: ".mcpServers | to_entries | map(.value + {\"name\": .key})",
+			Set:  ".mcpServers[$NAME] = $JSON",
+			Del:  "del(.mcpServers[$NAME])",
+		},
+	}
+}
+
+// setPathsForCurrentOS sets the appropriate OS-specific paths field for testing
+func setPathsForCurrentOS(cfg *globalCfg, paths []string) {
+	switch runtime.GOOS {
+	case "windows":
+		cfg.Windows = paths
+	case "darwin":
+		cfg.Darwin = paths
+	default:
+		cfg.Linux = paths
+	}
+}
+
+func TestGlobalCfgProcessor_MultiplePaths(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name          string
+		setupFiles    map[string]string
+		configPaths   []string
+		expectedFound bool
+		expectedError bool
+	}{
+		{
+			name: "single_path_exists",
+			setupFiles: map[string]string{
+				"config.json": `{"mcpServers": {"test": {"command": "echo"}}}`,
+			},
+			configPaths:   []string{"config.json"},
+			expectedFound: true,
+		},
+		{
+			name: "multiple_paths_first_exists",
+			setupFiles: map[string]string{
+				"config1.json": `{"mcpServers": {"test": {"command": "echo"}}}`,
+				"config2.json": `{"mcpServers": {"other": {"command": "ls"}}}`,
+			},
+			configPaths:   []string{"config1.json", "config2.json"},
+			expectedFound: true,
+		},
+		{
+			name: "multiple_paths_second_exists",
+			setupFiles: map[string]string{
+				"config2.json": `{"mcpServers": {"fallback": {"command": "fallback"}}}`,
+			},
+			configPaths:   []string{"config1.json", "config2.json"},
+			expectedFound: true,
+		},
+		{
+			name:          "no_paths_exist",
+			setupFiles:    map[string]string{},
+			configPaths:   []string{"config1.json", "config2.json"},
+			expectedFound: false,
+		},
+		{
+			name: "file_is_directory",
+			setupFiles: map[string]string{
+				"config1.json/": "", // Directory instead of file
+				"config2.json":  `{"mcpServers": {"backup": {"command": "backup"}}}`,
+			},
+			configPaths:   []string{"config1.json", "config2.json"},
+			expectedFound: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testDir := filepath.Join(tempDir, tc.name)
+			require.NoError(t, os.MkdirAll(testDir, 0o755))
+
+			var paths []string
+			for _, path := range tc.configPaths {
+				paths = append(paths, filepath.Join(testDir, path))
+			}
+
+			for path, content := range tc.setupFiles {
+				fullPath := filepath.Join(testDir, path)
+				if filepath.Ext(path) == "/" {
+					require.NoError(t, os.MkdirAll(fullPath, 0o755))
+				} else {
+					require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644))
+				}
+			}
+
+			cfg := newTestGlobalCfg()
+			setPathsForCurrentOS(&cfg, paths)
+
+			processor, err := NewGlobalCfgProcessor(cfg)
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			result := processor.ParseConfig()
+
+			if tc.expectedFound {
+				assert.True(t, result.IsInstalled)
+				assert.Nil(t, result.Err)
+				assert.NotNil(t, result.cfg)
+			} else {
+				assert.False(t, result.IsInstalled)
+			}
+		})
+	}
+}
+
+func TestGlobalCfgProcessor_Update_MultiplePaths(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config1Path := filepath.Join(tempDir, "config1.json")
+	config2Path := filepath.Join(tempDir, "config2.json")
+
+	require.NoError(t, os.WriteFile(config1Path, []byte(`{"mcpServers": {"existing": {"command": "test"}}}`), 0o644))
+
+	cfg := newTestGlobalCfg()
+	paths := []string{config1Path, config2Path}
+	setPathsForCurrentOS(&cfg, paths)
+
+	processor, err := NewGlobalCfgProcessor(cfg)
+	require.NoError(t, err)
+
+	err = processor.Update("new-server", &MCPServerSTDIO{
+		Name:    "new-server",
+		Command: "docker",
+		Args:    []string{"mcp", "gateway", "run"},
+	})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(config1Path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "new-server")
+
+	_, err = os.ReadFile(config2Path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestGlobalCfgProcessor_Update_NoExistingFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config1Path := filepath.Join(tempDir, "config1.json")
+	config2Path := filepath.Join(tempDir, "config2.json")
+
+	cfg := newTestGlobalCfg()
+	paths := []string{config1Path, config2Path}
+	setPathsForCurrentOS(&cfg, paths)
+
+	processor, err := NewGlobalCfgProcessor(cfg)
+	require.NoError(t, err)
+
+	err = processor.Update("new-server", &MCPServerSTDIO{
+		Name:    "new-server",
+		Command: "docker",
+		Args:    []string{"mcp", "gateway", "run"},
+	})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(config1Path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "new-server")
+
+	_, err = os.ReadFile(config2Path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestGlobalCfgProcessor_EmptyPaths(t *testing.T) {
+	cfg := newTestGlobalCfg()
+
+	_, err := NewGlobalCfgProcessor(cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no paths configured for OS")
+}
+
+func TestGlobalCfgProcessor_SinglePath(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"mcpServers": {"test": {"command": "echo"}}}`), 0o644))
+
+	cfg := newTestGlobalCfg()
+	setPathsForCurrentOS(&cfg, []string{configPath})
+
+	processor, err := NewGlobalCfgProcessor(cfg)
+	require.NoError(t, err)
+
+	result := processor.ParseConfig()
+	assert.True(t, result.IsInstalled)
+	assert.True(t, result.IsOsSupported)
+	assert.Nil(t, result.Err)
+}


### PR DESCRIPTION
**What I did**

Handling a request from a LM Studio folks (we have them listed as a client) to support multiple mcp.json config paths. They mentioned that users who started using their app long time ago would have their mcp servers config file in `~/.cache/lm-studio/mcp.json` rather than in `~/.lmstudio/mcp.json` for new users. This PR tries to handle both scenarios.

[Slack thread](https://docker.slack.com/archives/C094T317518/p1753146779467779) for more context

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**