### PR TITLE
OAuth scopes flag

### DIFF
--- a/cmd/docker-mcp/commands/oauth.go
+++ b/cmd/docker-mcp/commands/oauth.go
@@ -47,7 +47,7 @@ func authorizeOauthCommand() *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.StringVar(&opts.Scopes, "scopes", "", "OAuth scopes to request (comma-separated)")
+	flags.StringVar(&opts.Scopes, "scopes", "", "OAuth scopes to request (space-separated)")
 	return cmd
 }
 

--- a/cmd/docker-mcp/commands/oauth.go
+++ b/cmd/docker-mcp/commands/oauth.go
@@ -35,14 +35,20 @@ func lsOauthCommand() *cobra.Command {
 }
 
 func authorizeOauthCommand() *cobra.Command {
-	return &cobra.Command{
+	var opts struct {
+		Scopes string
+	}
+	cmd := &cobra.Command{
 		Use:   "authorize <app>",
 		Short: "Authorize the specified OAuth app.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return oauth.Authorize(cmd.Context(), args[0])
+			return oauth.Authorize(cmd.Context(), args[0], opts.Scopes)
 		},
 	}
+	flags := cmd.Flags()
+	flags.StringVar(&opts.Scopes, "scopes", "", "OAuth scopes to request (comma-separated)")
+	return cmd
 }
 
 func revokeOauthCommand() *cobra.Command {

--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -7,10 +7,10 @@ import (
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/desktop"
 )
 
-func Authorize(ctx context.Context, app string) error {
+func Authorize(ctx context.Context, app string, scopes string) error {
 	client := desktop.NewAuthClient()
 
-	authResponse, err := client.PostOAuthApp(ctx, app, "")
+	authResponse, err := client.PostOAuthApp(ctx, app, scopes)
 	if err != nil {
 		return err
 	}

--- a/docs/generator/reference/docker_mcp_oauth_authorize.yaml
+++ b/docs/generator/reference/docker_mcp_oauth_authorize.yaml
@@ -4,6 +4,16 @@ long: Authorize the specified OAuth app.
 usage: docker mcp oauth authorize <app>
 pname: docker mcp oauth
 plink: docker_mcp_oauth.yaml
+options:
+    - option: scopes
+      value_type: string
+      description: OAuth scopes to request (space-separated)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 hidden: true
 experimental: false


### PR DESCRIPTION
**What I did**

Allow for manual setup of scopes for all oauth apps

Example commands:
```
docker mcp oauth authorize github --scopes=repo
```
multiple scopes (space separated)
```
docker mcp oauth authorize github --scopes="user:follow read:project"
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**