### PR TITLE
Expose enabled flag for all tools

### DIFF
--- a/cmd/docker-mcp/commands/server.go
+++ b/cmd/docker-mcp/commands/server.go
@@ -74,7 +74,7 @@ func serverCommand(docker docker.Client) *cobra.Command {
 		Short: "Get information about a server",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			info, err := server.Inspect(cmd.Context(), args[0])
+			info, err := server.Inspect(cmd.Context(), docker, args[0])
 			if err != nil {
 				return err
 			}

--- a/cmd/docker-mcp/server/inspect.go
+++ b/cmd/docker-mcp/server/inspect.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
-
-	"slices"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/catalog"
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/config"

--- a/cmd/docker-mcp/server/inspect.go
+++ b/cmd/docker-mcp/server/inspect.go
@@ -10,11 +10,15 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 
+	"slices"
+
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/catalog"
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/config"
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/docker"
 )
 
 type Info struct {
-	Tools  []any  `json:"tools"`
+	Tools  []Tool `json:"tools"`
 	Readme string `json:"readme"`
 }
 
@@ -22,7 +26,21 @@ func (s Info) ToJSON() ([]byte, error) {
 	return json.MarshalIndent(s, "", "  ")
 }
 
-func Inspect(ctx context.Context, serverName string) (Info, error) {
+type ToolArgument struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Desc string `json:"desc"`
+}
+
+type Tool struct {
+	Name        string                     `json:"name"`
+	Description string                     `json:"description"`
+	Arguments   []ToolArgument             `json:"arguments,omitempty"`
+	Annotations map[string]json.RawMessage `json:"annotations,omitempty"`
+	Enabled     bool                       `json:"enabled"`
+}
+
+func Inspect(ctx context.Context, dockerClient docker.Client, serverName string) (Info, error) {
 	catalogYAML, err := catalog.ReadCatalogFile(catalog.DockerCatalogName)
 	if err != nil {
 		return Info{}, err
@@ -39,7 +57,7 @@ func Inspect(ctx context.Context, serverName string) (Info, error) {
 	}
 
 	var (
-		tools     []any
+		tools     []Tool
 		readmeRaw []byte
 		errs      errgroup.Group
 	)
@@ -51,6 +69,27 @@ func Inspect(ctx context.Context, serverName string) (Info, error) {
 
 		if err := json.Unmarshal(toolsRaw, &tools); err != nil {
 			return err
+		}
+
+		toolsYAML, err := config.ReadTools(ctx, dockerClient)
+		if err != nil {
+			return err
+		}
+
+		toolsConfig, err := config.ParseToolsConfig(toolsYAML)
+		if err != nil {
+			return err
+		}
+
+		serverTools, exists := toolsConfig.ServerTools[serverName]
+		for i := range tools {
+			// If server is not present => all tools are enabled
+			if !exists {
+				tools[i].Enabled = true
+				continue
+			}
+			// If server is present => only listed tools are enabled
+			tools[i].Enabled = slices.Contains(serverTools, tools[i].Name)
 		}
 
 		return nil


### PR DESCRIPTION
**What I did**

Building on top of the changes I did in https://github.com/docker/mcp-gateway/pull/62 now I am exposing an "enabled" flag for each tools so I could consume it in Docker Desktop and allow uses to enable/disable specific tools.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**