### PR TITLE
Clarification on catalog management doc

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -21,7 +21,7 @@ This creates a YAML file with real server definitions that you can:
 
 ## Feature Activation
 
-Custom catalog functionality requires enabling the `configured-catalogs` feature:
+Custom catalogs can be managed by enabling the `configured-catalogs` feature:
 
 ```bash
 # Enable the feature


### PR DESCRIPTION
**What I did**
Since custom catalogs can also be used from the `--catalog` cli flag, I thought we could clarify the verbiage here.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**