### PR TITLE
Feat: Support for User

### DIFF
--- a/cmd/docker-mcp/internal/catalog/types.go
+++ b/cmd/docker-mcp/internal/catalog/types.go
@@ -21,6 +21,7 @@ type Server struct {
 	Env            []Env    `yaml:"env,omitempty" json:"env,omitempty"`
 	Command        []string `yaml:"command,omitempty" json:"command,omitempty"`
 	Volumes        []string `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	User           string   `yaml:"user,omitempty" json:"user,omitempty"`
 	DisableNetwork bool     `yaml:"disableNetwork,omitempty" json:"disableNetwork,omitempty"`
 	AllowHosts     []string `yaml:"allowHosts,omitempty" json:"allowHosts,omitempty"`
 	Tools          []Tool   `yaml:"tools,omitempty" json:"tools,omitempty"`
@@ -89,6 +90,7 @@ type Container struct {
 	Image   string   `yaml:"image" json:"image"`
 	Command []string `yaml:"command" json:"command"`
 	Volumes []string `yaml:"volumes" json:"volumes"`
+	User    string   `yaml:"user,omitempty" json:"user,omitempty"`
 }
 
 func (p *Properties) ToMap() map[string]any {

--- a/cmd/docker-mcp/internal/gateway/clientpool.go
+++ b/cmd/docker-mcp/internal/gateway/clientpool.go
@@ -180,6 +180,14 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 		args = append(args, "-v", mount)
 	}
 
+	// User
+	if tool.Container.User != "" {
+		userVal := fmt.Sprintf("%v", eval.Evaluate(tool.Container.User, arguments))
+		if userVal != "" {
+			args = append(args, "-u", userVal)
+		}
+	}
+
 	// Image
 	args = append(args, tool.Container.Image)
 
@@ -301,6 +309,17 @@ func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, readOnly *b
 			args = append(args, "-v", mount+":ro")
 		} else {
 			args = append(args, "-v", mount)
+		}
+	}
+
+	// User
+	if serverConfig.Spec.User != "" {
+		val := serverConfig.Spec.User
+		if strings.Contains(val, "{{") && strings.Contains(val, "}}") {
+			val = fmt.Sprintf("%v", eval.Evaluate(val, serverConfig.Config))
+		}
+		if val != "" {
+			args = append(args, "-u", val)
 		}
 	}
 

--- a/cmd/docker-mcp/internal/gateway/clientpool_test.go
+++ b/cmd/docker-mcp/internal/gateway/clientpool_test.go
@@ -145,6 +145,21 @@ hub:
 	assert.Empty(t, env)
 }
 
+func TestApplyConfigUser(t *testing.T) {
+	catalogYAML := `
+user: "1001:2002"
+  `
+
+	args, env := argsAndEnv(t, "svc", catalogYAML, "", nil, nil)
+
+	assert.Equal(t, []string{
+		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
+		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=svc", "-l", "docker-mcp-transport=stdio",
+		"-u", "1001:2002",
+	}, args)
+	assert.Empty(t, env)
+}
+
 func argsAndEnv(t *testing.T, name, catalogYAML, configYAML string, secrets map[string]string, readOnly *bool) ([]string, []string) {
 	t.Helper()
 


### PR DESCRIPTION
Support user with evaluation e.g:

```
user: '{{aks.container_user}}'
```

Fixes #103 

Happy to adopt the implementation if we think we there could be better way.

## Testing Done:

```
→ cat ~/.docker/mcp/catalogs/docker-mcp.yaml  | grep 'user:' -C 3
    volumes:
      - '{{aks.azure_dir}}:/home/mcp/.azure'
      - '{{aks.kubeconfig}}:/home/mcp/.kube/config'
    user: '{{aks.container_user}}'
    prompts: 0
    resources: {}
    config:
--
          access_level:
            type: string
            description: Access level for the MCP server, One of [ readonly, readwrite, admin ]
          container_user:
            type: string
            description: Username or UID of the user to run the MCP server container as. This is useful for ensuring that the server has the correct permissions to access the Azure and kubeconfig files. (e.g. 10000 or azureuser)
          allow_namespaces:

```

```
→ cat ~/.docker/mcp/config.yaml 
aks:
  azure_dir: /home/qasim/.azure
  kubeconfig: /home/qasim/.kube/config
  access_level: readonly
  container_user: 1000
```

```
- Those servers are enabled: aks
- Listing MCP tools...
  - Running mcp/aks with [run --rm -i --init --security-opt no-new-privileges --cpus 1 --memory 2Gb --pull never -l docker-mcp=true -l docker-mcp-tool-type=mcp -l docker-mcp-name=aks -l docker-mcp-transport=stdio --user 1000 -v /home/qasim/.azure:/home/mcp/.azure -v /home/qasim/.kube/config:/home/mcp/.kube/config] and command [--transport=stdio --access-level=readonly --allow-namespaces= --additional-tools=]

```

```
- Listing MCP tools...
  - Running mcp/aks with [run --rm -i --init --security-opt no-new-privileges --cpus 1 --memory 2Gb --pull never -l docker-mcp=true -l docker-mcp-tool-type=mcp -l docker-mcp-name=aks -l docker-mcp-transport=stdio --user 1000 -v /home/qasim/.azure:/home/mcp/.azure -v /home/qasim/.kube/config:/home/mcp/.kube/config] and command [--transport=stdio --access-level=readonly --allow-namespaces= --additional-tools=]
  > aks: (15 tools) (2 prompts)
```