### PR TITLE
HandleNotify happens automatically

### DIFF
--- a/cmd/docker-mcp/internal/mcp/mcp_client.go
+++ b/cmd/docker-mcp/internal/mcp/mcp_client.go
@@ -15,10 +15,6 @@ type Client interface {
 	AddRoots(roots []*mcp.Root)
 }
 
-func newServerRequest[P mcp.Params](ss *mcp.ServerSession, params P) *mcp.ServerRequest[P] {
-	return &mcp.ServerRequest[P]{Session: ss, Params: params}
-}
-
 // CapabilityRefresher interface allows the notification handlers to refresh server capabilities
 type CapabilityRefresher interface {
 	RefreshCapabilities(ctx context.Context, server *mcp.Server, serverSession *mcp.ServerSession) error
@@ -35,17 +31,17 @@ func notifications(serverSession *mcp.ServerSession, server *mcp.Server, refresh
 			// Handle create messages if needed
 			return nil, fmt.Errorf("create messages not supported")
 		},
-		ToolListChangedHandler: func(ctx context.Context, req *mcp.ToolListChangedRequest) {
+		ToolListChangedHandler: func(ctx context.Context, _ *mcp.ToolListChangedRequest) {
 			if refresher != nil && server != nil && serverSession != nil {
 				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
 			}
 		},
-		ResourceListChangedHandler: func(ctx context.Context, req *mcp.ResourceListChangedRequest) {
-			if refresher != nil && server != nil && serverSession != nil{
+		ResourceListChangedHandler: func(ctx context.Context, _ *mcp.ResourceListChangedRequest) {
+			if refresher != nil && server != nil && serverSession != nil {
 				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
 			}
 		},
-		PromptListChangedHandler: func(ctx context.Context, req *mcp.PromptListChangedRequest) {
+		PromptListChangedHandler: func(ctx context.Context, _ *mcp.PromptListChangedRequest) {
 			if refresher != nil && server != nil && serverSession != nil {
 				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
 			}

--- a/cmd/docker-mcp/internal/mcp/mcp_client.go
+++ b/cmd/docker-mcp/internal/mcp/mcp_client.go
@@ -36,27 +36,18 @@ func notifications(serverSession *mcp.ServerSession, server *mcp.Server, refresh
 			return nil, fmt.Errorf("create messages not supported")
 		},
 		ToolListChangedHandler: func(ctx context.Context, req *mcp.ToolListChangedRequest) {
-			if refresher != nil && server != nil {
+			if refresher != nil && server != nil && serverSession != nil {
 				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
-			}
-			if serverSession != nil {
-				_ = mcp.HandleNotify(ctx, "notifications/tools/list_changed", newServerRequest(serverSession, req.Params))
 			}
 		},
 		ResourceListChangedHandler: func(ctx context.Context, req *mcp.ResourceListChangedRequest) {
-			if refresher != nil && server != nil {
+			if refresher != nil && server != nil && serverSession != nil{
 				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
-			}
-			if serverSession != nil {
-				_ = mcp.HandleNotify(ctx, "notifications/resources/list_changed", newServerRequest(serverSession, req.Params))
 			}
 		},
 		PromptListChangedHandler: func(ctx context.Context, req *mcp.PromptListChangedRequest) {
-			if refresher != nil && server != nil {
+			if refresher != nil && server != nil && serverSession != nil {
 				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
-			}
-			if serverSession != nil {
-				_ = mcp.HandleNotify(ctx, "notifications/prompts/list_changed", newServerRequest(serverSession, req.Params))
 			}
 		},
 		ProgressNotificationHandler: func(ctx context.Context, req *mcp.ProgressNotificationClientRequest) {


### PR DESCRIPTION
The HandleNotify calls are not required to be explicitly. If an MCP server generates a change notification, we will now update the capabilities of the gateway server, and these notifications will be automatically sent to the clients.  These calls were duplicate change notifications.