### PR TITLE
Add custom Headers to Remotes

### DIFF
--- a/cmd/docker-mcp/internal/mcp/remote.go
+++ b/cmd/docker-mcp/internal/mcp/remote.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -60,11 +61,25 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	var mcpTransport mcp.Transport
 	var err error
 
+	// Create HTTP client with custom headers
+	httpClient := &http.Client{
+		Transport: &headerRoundTripper{
+			base:    http.DefaultTransport,
+			headers: headers,
+		},
+	}
+
 	switch strings.ToLower(transport) {
 	case "sse":
-		mcpTransport = &mcp.SSEClientTransport{Endpoint: url}
+		mcpTransport = &mcp.SSEClientTransport{
+			Endpoint:   url,
+			HTTPClient: httpClient,
+		}
 	case "http", "streamable", "streaming", "streamable-http":
-		mcpTransport = &mcp.StreamableClientTransport{Endpoint: url}
+		mcpTransport = &mcp.StreamableClientTransport{
+			Endpoint:   url,
+			HTTPClient: httpClient,
+		}
 	default:
 		return fmt.Errorf("unsupported remote transport: %s", transport)
 	}
@@ -101,4 +116,22 @@ func expandEnv(value string, secrets map[string]string) string {
 	return os.Expand(value, func(name string) string {
 		return secrets[name]
 	})
+}
+
+// headerRoundTripper is an http.RoundTripper that adds custom headers to all requests
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid modifying the original
+	newReq := req.Clone(req.Context())
+	
+	// Add custom headers
+	for key, value := range h.headers {
+		newReq.Header.Set(key, value)
+	}
+	
+	return h.base.RoundTrip(newReq)
 }

--- a/cmd/docker-mcp/internal/mcp/remote.go
+++ b/cmd/docker-mcp/internal/mcp/remote.go
@@ -127,11 +127,9 @@ type headerRoundTripper struct {
 func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Clone the request to avoid modifying the original
 	newReq := req.Clone(req.Context())
-	
 	// Add custom headers
 	for key, value := range h.headers {
 		newReq.Header.Set(key, value)
 	}
-	
 	return h.base.RoundTrip(newReq)
 }

--- a/cmd/docker-mcp/remote_headers_integration_test.go
+++ b/cmd/docker-mcp/remote_headers_integration_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegrationRemoteWithCustomHeaders tests that custom headers (including Authorization 
+// with Bearer tokens from secrets) are properly transmitted to remote MCP servers.
+func TestIntegrationRemoteWithCustomHeaders(t *testing.T) {
+	thisIsAnIntegrationTest(t)
+	
+	// Start a test MCP server that can validate the Authorization header
+	server := newTestMCPServer(t)
+	defer server.close()
+	
+	// Create temporary directory for test files
+	tmp := t.TempDir()
+	
+	// Create a secrets file with our test token
+	testToken := "test-bearer-token-12345"
+	writeFile(t, tmp, ".env", fmt.Sprintf("AUTH_TOKEN=%s", testToken))
+	
+	// Create a custom catalog with a remote server that uses Authorization header
+	catalogContent := fmt.Sprintf(`
+name: test-catalog
+registry:
+  test-server:
+    remote:
+      url: %s
+      transport_type: streamable
+      headers:
+        Authorization: "Bearer $AUTH_TOKEN"
+    secrets:
+      - name: AUTH_TOKEN
+        env: AUTH_TOKEN
+`, server.url)
+	
+	writeFile(t, tmp, "catalog.yaml", catalogContent)
+	
+	// Optional: uncomment for debugging
+	// fmt.Printf("DEBUG: Catalog content:\n%s\n", catalogContent)
+	// fmt.Printf("DEBUG: Server URL: %s\n", server.url)
+	
+	// Run the gateway with our custom catalog and call a tool
+	gatewayArgs := []string{
+		"--servers=test-server",
+		"--secrets=" + filepath.Join(tmp, ".env"),
+		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+	}
+	
+	out := runDockerMCP(t, "tools", "call", "--gateway-arg="+strings.Join(gatewayArgs, ","), "get_auth_header")
+	
+	// Verify that the server received our Authorization header
+	assert.Contains(t, out, fmt.Sprintf("Bearer %s", testToken), "Server should receive the Authorization header with Bearer token")
+}
+
+// testMCPServer is a minimal MCP server implementation using go-sdk that can validate received headers
+type testMCPServer struct {
+	server       *http.Server
+	listener     net.Listener
+	url          string
+	receivedAuth string
+	mu           sync.RWMutex
+	mcpServer    *mcp.Server
+}
+
+func newTestMCPServer(t *testing.T) *testMCPServer {
+	t.Helper()
+	
+	s := &testMCPServer{}
+	
+	// Create a listener to get a random port
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "Failed to create listener")
+	
+	s.listener = listener
+	s.url = fmt.Sprintf("http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
+	
+	// Create MCP server using go-sdk
+	s.mcpServer = mcp.NewServer(&mcp.Implementation{
+		Name:    "test-mcp-server",
+		Version: "1.0.0",
+	}, nil)
+	
+	// Add our test tool that returns the Authorization header
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name:        "get_auth_header",
+		Description: "Returns the Authorization header received by the server",
+		InputSchema: &jsonschema.Schema{
+			Type:       "object",
+			Properties: map[string]*jsonschema.Schema{},
+		},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+		// Get the Authorization header from the server's stored value
+		s.mu.RLock()
+		authHeader := s.receivedAuth
+		s.mu.RUnlock()
+		
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: authHeader},
+			},
+		}, nil, nil
+	})
+	
+	// Create HTTP handler using StreamableHTTPHandler from go-sdk
+	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		// Store the Authorization header for our test
+		s.mu.Lock()
+		s.receivedAuth = r.Header.Get("Authorization")
+		s.mu.Unlock()
+		
+		return s.mcpServer
+	}, nil)
+	
+	s.server = &http.Server{
+		Handler: handler,
+	}
+	
+	// Start server in background
+	go func() {
+		if err := s.server.Serve(listener); err != http.ErrServerClosed {
+			t.Errorf("Server failed: %v", err)
+		}
+	}()
+	
+	// Wait a moment for server to start
+	time.Sleep(100 * time.Millisecond)
+	
+	return s
+}
+
+func (s *testMCPServer) close() {
+	if s.server != nil {
+		s.server.Shutdown(context.Background())
+	}
+	if s.listener != nil {
+		s.listener.Close()
+	}
+}

--- a/cmd/docker-mcp/remote_headers_integration_test.go
+++ b/cmd/docker-mcp/remote_headers_integration_test.go
@@ -17,22 +17,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIntegrationRemoteWithCustomHeaders tests that custom headers (including Authorization 
+// TestIntegrationRemoteWithCustomHeaders tests that custom headers (including Authorization
 // with Bearer tokens from secrets) are properly transmitted to remote MCP servers.
 func TestIntegrationRemoteWithCustomHeaders(t *testing.T) {
 	thisIsAnIntegrationTest(t)
-	
 	// Start a test MCP server that can validate the Authorization header
 	server := newTestMCPServer(t)
 	defer server.close()
-	
 	// Create temporary directory for test files
 	tmp := t.TempDir()
-	
+
 	// Create a secrets file with our test token
 	testToken := "test-bearer-token-12345"
 	writeFile(t, tmp, ".env", fmt.Sprintf("AUTH_TOKEN=%s", testToken))
-	
+
 	// Create a custom catalog with a remote server that uses Authorization header
 	catalogContent := fmt.Sprintf(`
 name: test-catalog
@@ -47,22 +45,22 @@ registry:
       - name: AUTH_TOKEN
         env: AUTH_TOKEN
 `, server.url)
-	
+
 	writeFile(t, tmp, "catalog.yaml", catalogContent)
-	
+
 	// Optional: uncomment for debugging
 	// fmt.Printf("DEBUG: Catalog content:\n%s\n", catalogContent)
 	// fmt.Printf("DEBUG: Server URL: %s\n", server.url)
-	
+
 	// Run the gateway with our custom catalog and call a tool
 	gatewayArgs := []string{
 		"--servers=test-server",
 		"--secrets=" + filepath.Join(tmp, ".env"),
 		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
 	}
-	
+
 	out := runDockerMCP(t, "tools", "call", "--gateway-arg="+strings.Join(gatewayArgs, ","), "get_auth_header")
-	
+
 	// Verify that the server received our Authorization header
 	assert.Contains(t, out, fmt.Sprintf("Bearer %s", testToken), "Server should receive the Authorization header with Bearer token")
 }
@@ -79,22 +77,22 @@ type testMCPServer struct {
 
 func newTestMCPServer(t *testing.T) *testMCPServer {
 	t.Helper()
-	
+
 	s := &testMCPServer{}
-	
+
 	// Create a listener to get a random port
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err, "Failed to create listener")
-	
+
 	s.listener = listener
 	s.url = fmt.Sprintf("http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
-	
+
 	// Create MCP server using go-sdk
 	s.mcpServer = mcp.NewServer(&mcp.Implementation{
 		Name:    "test-mcp-server",
 		Version: "1.0.0",
 	}, nil)
-	
+
 	// Add our test tool that returns the Authorization header
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name:        "get_auth_header",
@@ -103,49 +101,49 @@ func newTestMCPServer(t *testing.T) *testMCPServer {
 			Type:       "object",
 			Properties: map[string]*jsonschema.Schema{},
 		},
-	}, func(ctx context.Context, req *mcp.CallToolRequest, args any) (*mcp.CallToolResult, any, error) {
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
 		// Get the Authorization header from the server's stored value
 		s.mu.RLock()
 		authHeader := s.receivedAuth
 		s.mu.RUnlock()
-		
+
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: authHeader},
 			},
 		}, nil, nil
 	})
-	
+
 	// Create HTTP handler using StreamableHTTPHandler from go-sdk
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		// Store the Authorization header for our test
 		s.mu.Lock()
 		s.receivedAuth = r.Header.Get("Authorization")
 		s.mu.Unlock()
-		
+
 		return s.mcpServer
 	}, nil)
-	
+
 	s.server = &http.Server{
 		Handler: handler,
 	}
-	
+
 	// Start server in background
 	go func() {
 		if err := s.server.Serve(listener); err != http.ErrServerClosed {
 			t.Errorf("Server failed: %v", err)
 		}
 	}()
-	
+
 	// Wait a moment for server to start
 	time.Sleep(100 * time.Millisecond)
-	
+
 	return s
 }
 
 func (s *testMCPServer) close() {
 	if s.server != nil {
-		s.server.Shutdown(context.Background())
+		_ = s.server.Shutdown(context.Background())
 	}
 	if s.listener != nil {
 		s.listener.Close()


### PR DESCRIPTION
* fixes #97

**What I did**

I've added a test to verify that secrets are correctly interpolating and that custom headers declared in the catalog are being sent on remote mcp requests.