### PR TITLE
Fix parsing bug that breaks Docker Desktop client listing

### DIFF
--- a/cmd/docker-mcp/client/config_test.go
+++ b/cmd/docker-mcp/client/config_test.go
@@ -32,7 +32,8 @@ func Test_yq_list(t *testing.T) {
 						Args:    []string{"mcp", "gateway", "run"},
 					},
 				},
-				SSEServers: []MCPServerSSE{},
+				SSEServers:  []MCPServerSSE{},
+				HTTPServers: []MCPServerHTTP{},
 			},
 		},
 		{
@@ -47,7 +48,8 @@ func Test_yq_list(t *testing.T) {
 						Args:    []string{"mcp", "gateway", "run"},
 					},
 				},
-				SSEServers: []MCPServerSSE{},
+				SSEServers:  []MCPServerSSE{},
+				HTTPServers: []MCPServerHTTP{},
 			},
 		},
 		{
@@ -65,7 +67,8 @@ func Test_yq_list(t *testing.T) {
 						Name: "my-server",
 					},
 				},
-				SSEServers: []MCPServerSSE{},
+				SSEServers:  []MCPServerSSE{},
+				HTTPServers: []MCPServerHTTP{},
 			},
 		},
 		{
@@ -93,6 +96,7 @@ func Test_yq_list(t *testing.T) {
 						Headers: map[string]string{"VERSION": "1.2"},
 					},
 				},
+				HTTPServers: []MCPServerHTTP{},
 			},
 		},
 	}

--- a/cmd/docker-mcp/client/ls.go
+++ b/cmd/docker-mcp/client/ls.go
@@ -135,7 +135,7 @@ func prettyPrintBaseData(vendor string, data MCPClientCfgBase) {
 	circle := redCircle
 	nrServers := 0
 	if data.cfg != nil {
-		nrServers = len(data.cfg.STDIOServers) + len(data.cfg.SSEServers)
+		nrServers = len(data.cfg.STDIOServers) + len(data.cfg.SSEServers) + len(data.cfg.HTTPServers)
 	}
 	if nrServers > 0 {
 		circle = orangeCircle
@@ -154,6 +154,9 @@ func prettyPrintBaseData(vendor string, data MCPClientCfgBase) {
 	}
 	for _, server := range data.cfg.SSEServers {
 		fmt.Printf("   %s: %s (sse)\n", server.Name, server.String())
+	}
+	for _, server := range data.cfg.HTTPServers {
+		fmt.Printf("   %s: %s (http)\n", server.Name, server.String())
 	}
 }
 

--- a/cmd/docker-mcp/client/parse.go
+++ b/cmd/docker-mcp/client/parse.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -14,6 +15,7 @@ import (
 type MCPJSONLists struct {
 	STDIOServers []MCPServerSTDIO
 	SSEServers   []MCPServerSSE
+	HTTPServers  []MCPServerHTTP
 }
 
 type MCPServerSTDIO struct {
@@ -41,7 +43,17 @@ type MCPServerSSE struct {
 	Headers map[string]string `json:"headers"`
 }
 
+type MCPServerHTTP struct {
+	Name    string            `json:"name"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers"`
+}
+
 func (c *MCPServerSSE) String() string {
+	return c.URL
+}
+
+func (c *MCPServerHTTP) String() string {
 	return c.URL
 }
 
@@ -56,6 +68,7 @@ func UnmarshalMCPJSONList(data []byte) (*MCPJSONLists, error) {
 	cfg := &MCPJSONLists{
 		STDIOServers: []MCPServerSTDIO{},
 		SSEServers:   []MCPServerSSE{},
+		HTTPServers:  []MCPServerHTTP{},
 	}
 	for _, raw := range temp {
 		itemType, _ := getType(raw) // type is an optional field, default to stdio if not explicitly set
@@ -72,6 +85,12 @@ func UnmarshalMCPJSONList(data []byte) (*MCPJSONLists, error) {
 				return nil, err
 			}
 			cfg.SSEServers = append(cfg.SSEServers, server)
+		case "http":
+			var server MCPServerHTTP
+			if err := json.Unmarshal(raw, &server); err != nil {
+				return nil, err
+			}
+			cfg.HTTPServers = append(cfg.HTTPServers, server)
 		default:
 			fmt.Fprintf(os.Stderr, "unknown server type for %q\n", itemType)
 		}

--- a/cmd/docker-mcp/client/parse_test.go
+++ b/cmd/docker-mcp/client/parse_test.go
@@ -24,12 +24,18 @@ func Test_UnmarshalMCPJSONList(t *testing.T) {
    "name": "my-server",
    "type": "stdio"
  },
-	{
-     "name":"my-remote-server",
-     "type": "sse",
-     "url": "http://api.contoso.com/sse",
-     "headers": { "VERSION": "1.2" }
-   }
+ {
+   "name":"my-remote-server",
+   "type": "sse",
+   "url": "http://api.contoso.com/sse",
+   "headers": { "VERSION": "1.2" }
+ },
+ {
+   "name":"my-remote-server",
+   "type": "http",
+   "url": "http://api.contoso.com/http",
+   "headers": { "VERSION": "1.2" }
+ }
 ]`,
 			result: &MCPJSONLists{
 				STDIOServers: []MCPServerSTDIO{
@@ -37,6 +43,9 @@ func Test_UnmarshalMCPJSONList(t *testing.T) {
 				},
 				SSEServers: []MCPServerSSE{
 					{Name: "my-remote-server", URL: "http://api.contoso.com/sse", Headers: map[string]string{"VERSION": "1.2"}},
+				},
+				HTTPServers: []MCPServerHTTP{
+					{Name: "my-remote-server", URL: "http://api.contoso.com/http", Headers: map[string]string{"VERSION": "1.2"}},
 				},
 			},
 		},


### PR DESCRIPTION
**What I did**
Docker Desktop's MCP client listing UI was broken because of spurious output in the `docker mcp client ls --global` command when a `type` wasn't recognized.

For example, if the Claude config contained an `http` type like:
```
{
  "mcpServers": {
    "my-server": {
      "type": "http",
      "url": "https://docker.com"
    }
  }
}
```

Then `docker mcp client ls --global` would produce:
```
unknown server type for "http"
{
<rest of the json>...
```

I fixed it by printing the warning on stderr instead of stdout. While I was in there, I also added support for printing `http` configurations in the client listing.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
https://github.com/docker/for-win/issues/14908

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**