### PR TITLE
Dynamic MCP Servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 bin
 dist
 .idea/
+/.direnv/
+/.vscode/
+/.envrc
+.DS_Store
+**/.DS_Store
+/nix/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,14 @@ linters:
     presets:
       - comments
       - std-error-handling
+  issues:
+    exclude-rules:
+      - path: cmd/docker-mcp/internal/gateway/dynamic_mcps.go
+        linters:
+          - gofmt
+      - path: cmd/docker-mcp/internal/gateway/dynamic_mcps.go
+        linters:
+          - gofumpt
 formatters:
   enable:
     - gofmt

--- a/cmd/docker-mcp/commands/feature.go
+++ b/cmd/docker-mcp/commands/feature.go
@@ -39,14 +39,14 @@ func featureEnableCommand(dockerCli command.Cli) *cobra.Command {
 Available features:
   configured-catalogs    Allow gateway to use user-managed catalogs alongside Docker catalog
   oauth-interceptor      Enable GitHub OAuth flow interception for automatic authentication
-  dynamic-tools          Enable dynamic tool discovery and execution capabilities`,
+  dynamic-tools          Enable internal MCP management tools (mcp-find, mcp-add, mcp-remove)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			featureName := args[0]
 
 			// Validate feature name
 			if !isKnownFeature(featureName) {
-				return fmt.Errorf("unknown feature: %s\n\nAvailable features:\n  configured-catalogs    Allow gateway to use user-managed catalogs\n  oauth-interceptor      Enable GitHub OAuth flow interception\n  dynamic-tools          Enable dynamic tool discovery and execution", featureName)
+				return fmt.Errorf("unknown feature: %s\n\nAvailable features:\n  configured-catalogs    Allow gateway to use user-managed catalogs\n  oauth-interceptor      Enable GitHub OAuth flow interception\n  dynamic-tools          Enable internal MCP management tools", featureName)
 			}
 
 			// Enable the feature
@@ -77,7 +77,10 @@ Available features:
 				fmt.Println("\nNo additional flags are needed - this applies to all gateway runs.")
 			case "dynamic-tools":
 				fmt.Println("\nThis feature enables dynamic tool discovery and execution capabilities.")
-				fmt.Println("When enabled, the gateway can dynamically discover and execute new tools at runtime.")
+				fmt.Println("When enabled, the gateway provides internal tools for managing MCP servers:")
+				fmt.Println("  - mcp-find: search for available MCP servers in the catalog")
+				fmt.Println("  - mcp-add: add MCP servers to the registry and reload configuration")
+				fmt.Println("  - mcp-remove: remove MCP servers from the registry and reload configuration")
 				fmt.Println("\nNo additional flags are needed - this applies to all gateway runs.")
 			}
 
@@ -148,7 +151,7 @@ func featureListCommand(dockerCli command.Cli) *cobra.Command {
 				case "oauth-interceptor":
 					fmt.Printf("  %-20s %s\n", "", "Enable GitHub OAuth flow interception for automatic authentication")
 				case "dynamic-tools":
-					fmt.Printf("  %-20s %s\n", "", "Enable dynamic tool discovery and execution capabilities")
+					fmt.Printf("  %-20s %s\n", "", "Enable internal MCP management tools (mcp-find, mcp-add, mcp-remove)")
 				}
 				fmt.Println()
 			}

--- a/cmd/docker-mcp/commands/feature.go
+++ b/cmd/docker-mcp/commands/feature.go
@@ -38,14 +38,15 @@ func featureEnableCommand(dockerCli command.Cli) *cobra.Command {
 
 Available features:
   configured-catalogs    Allow gateway to use user-managed catalogs alongside Docker catalog
-  oauth-interceptor      Enable GitHub OAuth flow interception for automatic authentication`,
+  oauth-interceptor      Enable GitHub OAuth flow interception for automatic authentication
+  dynamic-tools          Enable dynamic tool discovery and execution capabilities`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			featureName := args[0]
 
 			// Validate feature name
 			if !isKnownFeature(featureName) {
-				return fmt.Errorf("unknown feature: %s\n\nAvailable features:\n  configured-catalogs    Allow gateway to use user-managed catalogs\n  oauth-interceptor      Enable GitHub OAuth flow interception", featureName)
+				return fmt.Errorf("unknown feature: %s\n\nAvailable features:\n  configured-catalogs    Allow gateway to use user-managed catalogs\n  oauth-interceptor      Enable GitHub OAuth flow interception\n  dynamic-tools          Enable dynamic tool discovery and execution", featureName)
 			}
 
 			// Enable the feature
@@ -73,6 +74,10 @@ Available features:
 			case "oauth-interceptor":
 				fmt.Println("\nThis feature enables automatic GitHub OAuth interception when 401 errors occur.")
 				fmt.Println("When enabled, the gateway will automatically provide OAuth URLs for authentication.")
+				fmt.Println("\nNo additional flags are needed - this applies to all gateway runs.")
+			case "dynamic-tools":
+				fmt.Println("\nThis feature enables dynamic tool discovery and execution capabilities.")
+				fmt.Println("When enabled, the gateway can dynamically discover and execute new tools at runtime.")
 				fmt.Println("\nNo additional flags are needed - this applies to all gateway runs.")
 			}
 
@@ -127,7 +132,7 @@ func featureListCommand(dockerCli command.Cli) *cobra.Command {
 			fmt.Println()
 
 			// Show all known features
-			knownFeatures := []string{"configured-catalogs", "oauth-interceptor"}
+			knownFeatures := []string{"configured-catalogs", "oauth-interceptor", "dynamic-tools"}
 			for _, feature := range knownFeatures {
 				status := "disabled"
 				if isFeatureEnabledFromCli(dockerCli, feature) {
@@ -142,6 +147,8 @@ func featureListCommand(dockerCli command.Cli) *cobra.Command {
 					fmt.Printf("  %-20s %s\n", "", "Allow gateway to use user-managed catalogs alongside Docker catalog")
 				case "oauth-interceptor":
 					fmt.Printf("  %-20s %s\n", "", "Enable GitHub OAuth flow interception for automatic authentication")
+				case "dynamic-tools":
+					fmt.Printf("  %-20s %s\n", "", "Enable dynamic tool discovery and execution capabilities")
 				}
 				fmt.Println()
 			}
@@ -204,6 +211,7 @@ func isKnownFeature(feature string) bool {
 	knownFeatures := []string{
 		"configured-catalogs",
 		"oauth-interceptor",
+		"dynamic-tools",
 	}
 
 	for _, known := range knownFeatures {

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -71,7 +71,7 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if OAuth interceptor feature is enabled
 			options.OAuthInterceptorEnabled = isOAuthInterceptorFeatureEnabled(dockerCli)
-			
+
 			// Check if dynamic tools feature is enabled
 			options.DynamicTools = isDynamicToolsFeatureEnabled(dockerCli)
 

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -71,6 +71,9 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if OAuth interceptor feature is enabled
 			options.OAuthInterceptorEnabled = isOAuthInterceptorFeatureEnabled(dockerCli)
+			
+			// Check if dynamic tools feature is enabled
+			options.DynamicTools = isDynamicToolsFeatureEnabled(dockerCli)
 
 			if options.Static {
 				options.Watch = false
@@ -221,6 +224,21 @@ func isOAuthInterceptorFeatureEnabled(dockerCli command.Cli) bool {
 	}
 
 	value, exists := configFile.Features["oauth-interceptor"]
+	if !exists {
+		return false
+	}
+
+	return value == "enabled"
+}
+
+// isDynamicToolsFeatureEnabled checks if the dynamic-tools feature is enabled
+func isDynamicToolsFeatureEnabled(dockerCli command.Cli) bool {
+	configFile := dockerCli.ConfigFile()
+	if configFile == nil || configFile.Features == nil {
+		return false
+	}
+
+	value, exists := configFile.Features["dynamic-tools"]
 	if !exists {
 		return false
 	}

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -171,3 +171,58 @@ func isOAuthInterceptorFeatureEnabledFromConfig(configFile *configfile.ConfigFil
 	}
 	return value == "enabled"
 }
+
+func TestIsDynamicToolsFeatureEnabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: map[string]string{
+				"dynamic-tools": "enabled",
+			},
+		}
+		enabled := isDynamicToolsFeatureEnabledFromConfig(configFile)
+		assert.True(t, enabled, "should return true when dynamic-tools is enabled")
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: map[string]string{
+				"dynamic-tools": "disabled",
+			},
+		}
+		enabled := isDynamicToolsFeatureEnabledFromConfig(configFile)
+		assert.False(t, enabled, "should return false when dynamic-tools is disabled")
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: map[string]string{},
+		}
+		enabled := isDynamicToolsFeatureEnabledFromConfig(configFile)
+		assert.False(t, enabled, "should return false when dynamic-tools is not set")
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		enabled := isDynamicToolsFeatureEnabledFromConfig(nil)
+		assert.False(t, enabled, "should return false when config is nil")
+	})
+
+	t.Run("nil features", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: nil,
+		}
+		enabled := isDynamicToolsFeatureEnabledFromConfig(configFile)
+		assert.False(t, enabled, "should return false when features is nil")
+	})
+}
+
+// Helper function for testing (extract logic from isDynamicToolsFeatureEnabled)
+func isDynamicToolsFeatureEnabledFromConfig(configFile *configfile.ConfigFile) bool {
+	if configFile == nil || configFile.Features == nil {
+		return false
+	}
+	value, exists := configFile.Features["dynamic-tools"]
+	if !exists {
+		return false
+	}
+	return value == "enabled"
+}

--- a/cmd/docker-mcp/internal/gateway/config.go
+++ b/cmd/docker-mcp/internal/gateway/config.go
@@ -30,4 +30,5 @@ type Options struct {
 	Static                  bool
 	Central                 bool
 	OAuthInterceptorEnabled bool
+	DynamicTools            bool
 }

--- a/cmd/docker-mcp/internal/gateway/dynamic_mcps.go
+++ b/cmd/docker-mcp/internal/gateway/dynamic_mcps.go
@@ -1,0 +1,210 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/catalog"
+)
+
+// mcpFindTool implements a tool for finding MCP servers in the catalog
+func (g *Gateway) createMcpFindTool(configuration Configuration) *ToolRegistration {
+	tool := &mcp.Tool{
+		Name:        "mcp-find",
+		Description: "Find MCP servers in the current catalog by name or description. Returns matching servers with their details.",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"query": {
+					Type:        "string",
+					Description: "Search query to find servers by name or description (case-insensitive)",
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "Maximum number of results to return (default: 10)",
+				},
+			},
+			Required: []string{"query"},
+		},
+	}
+
+	handler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Parse parameters
+		var params struct {
+			Query string `json:"query"`
+			Limit int    `json:"limit"`
+		}
+		
+		if req.Params.Arguments == nil {
+			return nil, fmt.Errorf("missing arguments")
+		}
+
+		paramsBytes, err := json.Marshal(req.Params.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+		}
+
+		if err := json.Unmarshal(paramsBytes, &params); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+
+		if params.Query == "" {
+			return nil, fmt.Errorf("query parameter is required")
+		}
+
+		if params.Limit <= 0 {
+			params.Limit = 10
+		}
+
+		// Search through the catalog servers
+		query := strings.ToLower(strings.TrimSpace(params.Query))
+		var matches []ServerMatch
+		
+		for serverName, server := range configuration.servers {
+			match := false
+			score := 0
+			
+			// Check server name (exact match gets higher score)
+			serverNameLower := strings.ToLower(serverName)
+			if serverNameLower == query {
+				match = true
+				score = 100
+			} else if strings.Contains(serverNameLower, query) {
+				match = true
+				score = 50
+			}
+			
+			// Check if it has tools that might match
+			for _, tool := range server.Tools {
+				toolNameLower := strings.ToLower(tool.Name)
+				toolDescLower := strings.ToLower(tool.Description)
+				
+				if toolNameLower == query {
+					match = true
+					score = max(score, 90)
+				} else if strings.Contains(toolNameLower, query) {
+					match = true
+					score = max(score, 40)
+				} else if strings.Contains(toolDescLower, query) {
+					match = true
+					score = max(score, 30)
+				}
+			}
+			
+			// Check image name
+			if server.Image != "" {
+				imageLower := strings.ToLower(server.Image)
+				if strings.Contains(imageLower, query) {
+					match = true
+					score = max(score, 20)
+				}
+			}
+			
+			if match {
+				matches = append(matches, ServerMatch{
+					Name:   serverName,
+					Server: server,
+					Score:  score,
+				})
+			}
+		}
+
+		// Sort matches by score (higher scores first)
+		for i := 0; i < len(matches)-1; i++ {
+			for j := i + 1; j < len(matches); j++ {
+				if matches[i].Score < matches[j].Score {
+					matches[i], matches[j] = matches[j], matches[i]
+				}
+			}
+		}
+
+		// Limit results
+		if len(matches) > params.Limit {
+			matches = matches[:params.Limit]
+		}
+
+		// Format results
+		var results []map[string]interface{}
+		for _, match := range matches {
+			serverInfo := map[string]interface{}{
+				"name": match.Name,
+			}
+
+			if match.Server.Image != "" {
+				serverInfo["image"] = match.Server.Image
+			}
+
+			if match.Server.Remote.URL != "" {
+				serverInfo["remote_url"] = match.Server.Remote.URL
+			}
+
+			if match.Server.SSEEndpoint != "" {
+				serverInfo["sse_endpoint"] = match.Server.SSEEndpoint
+			}
+
+			if len(match.Server.Tools) > 0 {
+				var tools []map[string]string
+				for _, tool := range match.Server.Tools {
+					tools = append(tools, map[string]string{
+						"name":        tool.Name,
+						"description": tool.Description,
+					})
+				}
+				serverInfo["tools"] = tools
+			}
+
+			if len(match.Server.Secrets) > 0 {
+				var secrets []string
+				for _, secret := range match.Server.Secrets {
+					secrets = append(secrets, secret.Name)
+				}
+				serverInfo["required_secrets"] = secrets
+			}
+
+			serverInfo["long_lived"] = match.Server.LongLived
+			serverInfo["disable_network"] = match.Server.DisableNetwork
+
+			results = append(results, serverInfo)
+		}
+
+		response := map[string]interface{}{
+			"query":         params.Query,
+			"total_matches": len(results),
+			"servers":       results,
+		}
+
+		responseBytes, err := json.Marshal(response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal response: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(responseBytes)}},
+		}, nil
+	}
+
+	return &ToolRegistration{
+		Tool:    tool,
+		Handler: handler,
+	}
+}
+
+// ServerMatch represents a search result
+type ServerMatch struct {
+	Name   string
+	Server catalog.Server
+	Score  int
+}
+
+// max returns the maximum of two integers
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/docker-mcp/internal/gateway/dynamic_mcps.go
+++ b/cmd/docker-mcp/internal/gateway/dynamic_mcps.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -136,29 +138,6 @@ func (g *Gateway) createMcpFindTool(configuration Configuration) *ToolRegistrati
 				"name": match.Name,
 			}
 
-			if match.Server.Image != "" {
-				serverInfo["image"] = match.Server.Image
-			}
-
-			if match.Server.Remote.URL != "" {
-				serverInfo["remote_url"] = match.Server.Remote.URL
-			}
-
-			if match.Server.SSEEndpoint != "" {
-				serverInfo["sse_endpoint"] = match.Server.SSEEndpoint
-			}
-
-			if len(match.Server.Tools) > 0 {
-				var tools []map[string]string
-				for _, tool := range match.Server.Tools {
-					tools = append(tools, map[string]string{
-						"name":        tool.Name,
-						"description": tool.Description,
-					})
-				}
-				serverInfo["tools"] = tools
-			}
-
 			if len(match.Server.Secrets) > 0 {
 				var secrets []string
 				for _, secret := range match.Server.Secrets {
@@ -168,7 +147,6 @@ func (g *Gateway) createMcpFindTool(configuration Configuration) *ToolRegistrati
 			}
 
 			serverInfo["long_lived"] = match.Server.LongLived
-			serverInfo["disable_network"] = match.Server.DisableNetwork
 
 			results = append(results, serverInfo)
 		}
@@ -255,11 +233,10 @@ func (g *Gateway) createMcpAddTool(configuration Configuration, clientConfig *cl
 		}
 
 		// Append the new server to the current serverNames
-		updatedServerNames := append(configuration.serverNames, serverName)
-		
+		configuration.serverNames = append(configuration.serverNames, serverName)
+
 		// Update the current configuration state
-		configuration.serverNames = updatedServerNames
-		
+		updatedServerNames := configuration.serverNames
 		if err := g.reloadConfiguration(ctx, configuration, updatedServerNames, clientConfig); err != nil {
 			return nil, fmt.Errorf("failed to reload configuration: %w", err)
 		}
@@ -323,10 +300,10 @@ func (g *Gateway) createMcpRemoveTool(_ Configuration, clientConfig *clientConfi
 		updatedServerNames := slices.DeleteFunc(slices.Clone(g.configuration.serverNames), func(name string) bool {
 			return name == serverName
 		})
-		
+
 		// Update the current configuration state
 		g.configuration.serverNames = updatedServerNames
-		
+
 		if err := g.reloadConfiguration(ctx, g.configuration, updatedServerNames, clientConfig); err != nil {
 			return nil, fmt.Errorf("failed to reload configuration: %w", err)
 		}
@@ -334,6 +311,307 @@ func (g *Gateway) createMcpRemoveTool(_ Configuration, clientConfig *clientConfi
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
 				Text: fmt.Sprintf("Successfully removed server '%s'.", serverName),
+			}},
+		}, nil
+	}
+
+	return &ToolRegistration{
+		Tool:    tool,
+		Handler: handler,
+	}
+}
+
+// mcpOfficialRegistryImportTool implements a tool for importing servers from official registry URLs
+func (g *Gateway) createMcpOfficialRegistryImportTool(configuration Configuration, clientConfig *clientConfig) *ToolRegistration {
+	tool := &mcp.Tool{
+		Name:        "mcp-official-registry-import",
+		Description: "Import MCP servers from an official registry URL. Fetches server definitions via HTTP GET and adds them to the local catalog.",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"url": {
+					Type:        "string",
+					Description: "URL to fetch the official registry JSON from (must be a valid HTTP/HTTPS URL)",
+				},
+			},
+			Required: []string{"url"},
+		},
+	}
+
+	handler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Parse parameters
+		var params struct {
+			URL string `json:"url"`
+		}
+
+		if req.Params.Arguments == nil {
+			return nil, fmt.Errorf("missing arguments")
+		}
+
+		paramsBytes, err := json.Marshal(req.Params.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+		}
+
+		if err := json.Unmarshal(paramsBytes, &params); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+
+		if params.URL == "" {
+			return nil, fmt.Errorf("url parameter is required")
+		}
+
+		registryURL := strings.TrimSpace(params.URL)
+
+		// Validate URL scheme
+		if !strings.HasPrefix(registryURL, "http://") && !strings.HasPrefix(registryURL, "https://") {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{
+					Text: fmt.Sprintf("Error: URL must start with http:// or https://, got: %s", registryURL),
+				}},
+			}, nil
+		}
+
+		// Fetch servers from the URL
+		servers, err := g.readServersFromURL(ctx, registryURL)
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{
+					Text: fmt.Sprintf("Error fetching servers from URL %s: %v", registryURL, err),
+				}},
+			}, nil
+		}
+
+		if len(servers) == 0 {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{
+					Text: fmt.Sprintf("No servers found at URL: %s", registryURL),
+				}},
+			}, nil
+		}
+
+		// Add the imported servers to the current configuration
+		var importedServerNames []string
+		for serverName, server := range servers {
+			if _, exists := configuration.servers[serverName]; exists {
+				log(fmt.Sprintf("Warning: server '%s' from URL %s overwrites existing server", serverName, registryURL))
+			}
+			configuration.servers[serverName] = server
+			importedServerNames = append(importedServerNames, serverName)
+		}
+
+		// Update serverNames with imported servers
+		for _, serverName := range importedServerNames {
+			found := false
+			for _, existing := range configuration.serverNames {
+				if existing == serverName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				configuration.serverNames = append(configuration.serverNames, serverName)
+			}
+		}
+
+		// Reload configuration with updated server list
+		if err := g.reloadConfiguration(ctx, configuration, configuration.serverNames, clientConfig); err != nil {
+			return nil, fmt.Errorf("failed to reload configuration: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: fmt.Sprintf("Successfully imported %d servers from %s: %s", len(importedServerNames), registryURL, strings.Join(importedServerNames, ", ")),
+			}},
+		}, nil
+	}
+
+	return &ToolRegistration{
+		Tool:    tool,
+		Handler: handler,
+	}
+}
+
+// readServersFromURL fetches and parses server definitions from a URL
+func (g *Gateway) readServersFromURL(ctx context.Context, url string) (map[string]catalog.Server, error) {
+	servers := make(map[string]catalog.Server)
+
+	log(fmt.Sprintf("  - Reading servers from URL: %s", url))
+
+	// Create HTTP request with context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Set a reasonable user agent
+	req.Header.Set("User-Agent", "docker-mcp-gateway/1.0.0")
+
+	// Make the HTTP request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Try to parse as an OCI-style catalog first (similar to oci.ReadArtifact)
+	var ociCatalog struct {
+		Registry []struct {
+			Server struct {
+				Name            string                `json:"name"`
+				Image           string                `json:"image,omitempty"`
+				SSEEndpoint     string                `json:"sseEndpoint,omitempty"`
+				Remote          catalog.Remote        `json:"remote,omitempty"`
+				Tools           []catalog.Tool        `json:"tools,omitempty"`
+				Secrets         []catalog.Secret      `json:"secrets,omitempty"`
+				LongLived       bool                  `json:"longLived,omitempty"`
+				DisableNetwork  bool                  `json:"disableNetwork,omitempty"`
+				ToCatalogServer func() catalog.Server `json:"-"`
+			} `json:"server"`
+		} `json:"registry"`
+	}
+
+	if err := json.Unmarshal(body, &ociCatalog); err == nil && len(ociCatalog.Registry) > 0 {
+		// Successfully parsed as OCI-style catalog
+		for i, ociServer := range ociCatalog.Registry {
+			serverDetail := ociServer.Server
+
+			// Convert to catalog.Server manually since we can't call the method
+			server := catalog.Server{
+				Image:          serverDetail.Image,
+				SSEEndpoint:    serverDetail.SSEEndpoint,
+				Remote:         serverDetail.Remote,
+				Tools:          serverDetail.Tools,
+				Secrets:        serverDetail.Secrets,
+				LongLived:      serverDetail.LongLived,
+				DisableNetwork: serverDetail.DisableNetwork,
+			}
+
+			serverName := serverDetail.Name
+			if serverName == "" {
+				serverName = fmt.Sprintf("url-server-%d", i)
+			}
+
+			servers[serverName] = server
+			log(fmt.Sprintf("  - Added server '%s' from URL %s", serverName, url))
+		}
+		return servers, nil
+	}
+
+	// Try to parse as direct catalog.Catalog
+	var directCatalog catalog.Catalog
+	if err := json.Unmarshal(body, &directCatalog); err == nil && len(directCatalog.Servers) > 0 {
+		for serverName, server := range directCatalog.Servers {
+			servers[serverName] = server
+			log(fmt.Sprintf("  - Added server '%s' from URL %s", serverName, url))
+		}
+		return servers, nil
+	}
+
+	return nil, fmt.Errorf("unable to parse response as OCI catalog or direct catalog format")
+}
+
+// mcpConfigSetTool implements a tool for setting configuration values for MCP servers
+func (g *Gateway) createMcpConfigSetTool(configuration Configuration, clientConfig *clientConfig) *ToolRegistration {
+	tool := &mcp.Tool{
+		Name:        "mcp-config-set",
+		Description: "Set configuration values for MCP servers. Creates or updates server configuration with the specified key-value pairs.",
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"server": {
+					Type:        "string",
+					Description: "Name of the MCP server to configure",
+				},
+				"key": {
+					Type:        "string",
+					Description: "Configuration key to set",
+				},
+				"value": {
+					Description: "Configuration value to set (can be string, number, boolean, or object)",
+				},
+			},
+			Required: []string{"server", "key", "value"},
+		},
+	}
+
+	handler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Parse parameters
+		var params struct {
+			Server string      `json:"server"`
+			Key    string      `json:"key"`
+			Value  interface{} `json:"value"`
+		}
+
+		if req.Params.Arguments == nil {
+			return nil, fmt.Errorf("missing arguments")
+		}
+
+		paramsBytes, err := json.Marshal(req.Params.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+		}
+
+		if err := json.Unmarshal(paramsBytes, &params); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+
+		if params.Server == "" {
+			return nil, fmt.Errorf("server parameter is required")
+		}
+
+		if params.Key == "" {
+			return nil, fmt.Errorf("key parameter is required")
+		}
+
+		serverName := strings.TrimSpace(params.Server)
+		configKey := strings.TrimSpace(params.Key)
+
+		// Check if server exists in catalog (optional check - we can configure servers that don't exist yet)
+		_, _, serverExists := configuration.Find(serverName)
+
+		// Initialize the server's config map if it doesn't exist
+		if configuration.config[serverName] == nil {
+			configuration.config[serverName] = make(map[string]any)
+		}
+
+		// Set the configuration value
+		oldValue := configuration.config[serverName][configKey]
+		configuration.config[serverName][configKey] = params.Value
+
+		// Log the configuration change
+		log(fmt.Sprintf("  - Set config for server '%s': %s = %v", serverName, configKey, params.Value))
+
+		// Reload configuration with current server list to apply changes
+		if err := g.reloadConfiguration(ctx, configuration, configuration.serverNames, clientConfig); err != nil {
+			return nil, fmt.Errorf("failed to reload configuration: %w", err)
+		}
+
+		var resultMessage string
+		if oldValue != nil {
+			resultMessage = fmt.Sprintf("Successfully updated config for server '%s': %s = %v (was: %v)", serverName, configKey, params.Value, oldValue)
+		} else {
+			resultMessage = fmt.Sprintf("Successfully set config for server '%s': %s = %v", serverName, configKey, params.Value)
+		}
+
+		if !serverExists {
+			resultMessage += fmt.Sprintf(" (Note: server '%s' is not in the current catalog)", serverName)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: resultMessage,
 			}},
 		}, nil
 	}

--- a/cmd/docker-mcp/internal/gateway/run.go
+++ b/cmd/docker-mcp/internal/gateway/run.go
@@ -330,9 +330,21 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 		g.mcpServer.AddTool(mcpRemoveTool.Tool, mcpRemoveTool.Handler)
 		g.registeredToolNames = append(g.registeredToolNames, mcpRemoveTool.Tool.Name)
 
+		// Add mcp-official-registry-import tool
+		mcpOfficialRegistryImportTool := g.createMcpOfficialRegistryImportTool(configuration, clientConfig)
+		g.mcpServer.AddTool(mcpOfficialRegistryImportTool.Tool, mcpOfficialRegistryImportTool.Handler)
+		g.registeredToolNames = append(g.registeredToolNames, mcpOfficialRegistryImportTool.Tool.Name)
+
+		// Add mcp-config-set tool
+		mcpConfigSetTool := g.createMcpConfigSetTool(configuration, clientConfig)
+		g.mcpServer.AddTool(mcpConfigSetTool.Tool, mcpConfigSetTool.Handler)
+		g.registeredToolNames = append(g.registeredToolNames, mcpConfigSetTool.Tool.Name)
+
 		log("  > mcp-find: tool for finding MCP servers in the catalog")
 		log("  > mcp-add: tool for adding MCP servers to the registry")
 		log("  > mcp-remove: tool for removing MCP servers from the registry")
+		log("  > mcp-official-registry-import: tool for importing servers from official registry URLs")
+		log("  > mcp-config-set: tool for setting configuration values for MCP servers")
 	}
 
 	for _, prompt := range capabilities.Prompts {

--- a/cmd/docker-mcp/internal/gateway/run.go
+++ b/cmd/docker-mcp/internal/gateway/run.go
@@ -318,7 +318,19 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 		g.mcpServer.AddTool(mcpFindTool.Tool, mcpFindTool.Handler)
 		g.registeredToolNames = append(g.registeredToolNames, mcpFindTool.Tool.Name)
 		
+		// Add mcp-add tool
+		mcpAddTool := g.createMcpAddTool(configuration)
+		g.mcpServer.AddTool(mcpAddTool.Tool, mcpAddTool.Handler)
+		g.registeredToolNames = append(g.registeredToolNames, mcpAddTool.Tool.Name)
+		
+		// Add mcp-remove tool
+		mcpRemoveTool := g.createMcpRemoveTool(configuration)
+		g.mcpServer.AddTool(mcpRemoveTool.Tool, mcpRemoveTool.Handler)
+		g.registeredToolNames = append(g.registeredToolNames, mcpRemoveTool.Tool.Name)
+		
 		log("  > mcp-find: tool for finding MCP servers in the catalog")
+		log("  > mcp-add: tool for adding MCP servers to the registry")
+		log("  > mcp-remove: tool for removing MCP servers from the registry")
 	}
 
 	for _, prompt := range capabilities.Prompts {

--- a/cmd/docker-mcp/internal/gateway/run.go
+++ b/cmd/docker-mcp/internal/gateway/run.go
@@ -312,22 +312,22 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 	// Add internal tools when dynamic-tools feature is enabled
 	if g.DynamicTools {
 		log("- Adding internal tools (dynamic-tools feature enabled)")
-		
+
 		// Add mcp-find tool
 		mcpFindTool := g.createMcpFindTool(configuration)
 		g.mcpServer.AddTool(mcpFindTool.Tool, mcpFindTool.Handler)
 		g.registeredToolNames = append(g.registeredToolNames, mcpFindTool.Tool.Name)
-		
+
 		// Add mcp-add tool
 		mcpAddTool := g.createMcpAddTool(configuration)
 		g.mcpServer.AddTool(mcpAddTool.Tool, mcpAddTool.Handler)
 		g.registeredToolNames = append(g.registeredToolNames, mcpAddTool.Tool.Name)
-		
+
 		// Add mcp-remove tool
 		mcpRemoveTool := g.createMcpRemoveTool(configuration)
 		g.mcpServer.AddTool(mcpRemoveTool.Tool, mcpRemoveTool.Handler)
 		g.registeredToolNames = append(g.registeredToolNames, mcpRemoveTool.Tool.Name)
-		
+
 		log("  > mcp-find: tool for finding MCP servers in the catalog")
 		log("  > mcp-add: tool for adding MCP servers to the registry")
 		log("  > mcp-remove: tool for removing MCP servers from the registry")

--- a/cmd/docker-mcp/internal/gateway/run.go
+++ b/cmd/docker-mcp/internal/gateway/run.go
@@ -309,6 +309,18 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 		g.registeredToolNames = append(g.registeredToolNames, tool.Tool.Name)
 	}
 
+	// Add internal tools when dynamic-tools feature is enabled
+	if g.DynamicTools {
+		log("- Adding internal tools (dynamic-tools feature enabled)")
+		
+		// Add mcp-find tool
+		mcpFindTool := g.createMcpFindTool(configuration)
+		g.mcpServer.AddTool(mcpFindTool.Tool, mcpFindTool.Handler)
+		g.registeredToolNames = append(g.registeredToolNames, mcpFindTool.Tool.Name)
+		
+		log("  > mcp-find: tool for finding MCP servers in the catalog")
+	}
+
 	for _, prompt := range capabilities.Prompts {
 		g.mcpServer.AddPrompt(prompt.Prompt, prompt.Handler)
 		g.registeredPromptNames = append(g.registeredPromptNames, prompt.Prompt.Name)

--- a/docs/generator/reference/docker_mcp_feature_enable.yaml
+++ b/docs/generator/reference/docker_mcp_feature_enable.yaml
@@ -6,6 +6,7 @@ long: |-
     Available features:
       configured-catalogs    Allow gateway to use user-managed catalogs alongside Docker catalog
       oauth-interceptor      Enable GitHub OAuth flow interception for automatic authentication
+      dynamic-tools          Enable internal MCP management tools (mcp-find, mcp-add, mcp-remove)
 usage: docker mcp feature enable <feature-name>
 pname: docker mcp feature
 plink: docker_mcp_feature.yaml

--- a/docs/generator/reference/mcp_feature_enable.md
+++ b/docs/generator/reference/mcp_feature_enable.md
@@ -6,6 +6,7 @@ Enable an experimental feature.
 Available features:
   configured-catalogs    Allow gateway to use user-managed catalogs alongside Docker catalog
   oauth-interceptor      Enable GitHub OAuth flow interception for automatic authentication
+  dynamic-tools          Enable internal MCP management tools (mcp-find, mcp-add, mcp-remove)
 
 
 <!---MARKER_GEN_END-->

--- a/test/servers/elicit/Dockerfile
+++ b/test/servers/elicit/Dockerfile
@@ -24,5 +24,7 @@ WORKDIR /root/
 # Copy the binary from builder stage
 COPY --from=builder /app/server .
 
+LABEL io.modelcontextprotocol.server.name="io.github.slimslenderslacks/poci"
+
 # Run the binary
 ENTRYPOINT ["./server"]


### PR DESCRIPTION
# Background

Today, our concept of a Catalog is a set of MCP servers that _could_ be exposed by the MCP Gateway. However, there is currently no way for a gateway client to dynamically adjust the set of exposed MCPs. Users can adjust the set of exposed MCPs when the gateway starts.

```bash
docker mcp gateway run --registry ./registry.yaml
```

```bash
docker mcp gateway run --servers server1,server2,etc
```

However, the gateway does not currently expose a _tool_ for agents to search the catalog and find tools, prompts, or resources _dynamically_. For those outside of the MCP space, this would seem crazy. What exactly is the point of a gateway, much less a catalog, if clients can discover anything in it? Well, it's probably not as crazy as it seems. The MCP protocol has the following three requests.

* `tools/list`
* `resources/list`
* `promts/list`

Note that these are not _search_ methods. What this means in practice is that early clients selected MCPs at startup time. The _list_ methods have always had notifications to let clients respond to updates; however, most early clients did not listen to these notifications. The first six months of MCP was very _static_ on the client side. You can see some of this history in client files like [mcp.json files](./mcp-json-files.md) that represent these very _static_ views of the MCP-osphere.

# MPC Gateways

There's nothing static about our gateway. If you start up a gateway with no registry.yaml file or no `--servers` flag, your lists methods might start empty. But you have to ask yourself a few questions.

* _Why not populate the `list` methods with the entire catalog?_ It overwhelms LLMs if the client/agent is not doing any filtering.
* _Why not let the client `add` MCPs to their session?_ Good question! Three months ago, typical mcp.json files had one or two entries. Developers were fine with static configs because they were just playing around with two or three mcps anyway.

In the meantime, we've become accustomed to interacting with agents much more dynamically. It also makes sense to make our sessions more dynamic.

> **User:** Do we have any tools for letting me interact with Slack.
> **Assistant:** Yes, there is a slack tool in your catalog. Do you want to know details?
> **User:** Yes.
> **Assistant:** The io.github.modelcontextprotocol/slack server requires a Slack app installed into your Slack workspace, and access to a bot token. If you have this secret, I can redirect you to to a url to enter that.
> ...

The shift here is that small `mcp.json`-like working sets (4 or 5 MCPs), shift towards larger catalogs of _trusted_ MCP servers.

The other update is that more clients are now watching for list update notifications. The value of having a gateway connected to entire catalogs of servers goes way up!


## Find/Add/Remove

[MCP jetpack](https://mcpjetpack.com/), from our team mates Saurabh and Sundeep, has already explored this space. The first three tools I'm adding are very simple.

* **find** find an MCP server from the currently attached catalog
* **add** make the content of the MCP server available in the current session
* **remove** remove the content of the MCP server from the current session

The **find** tool is a no-brainer. The **add** and **remove** tools are predominantly there for safety, and to integrate with clients that are still relying on the _list_ methods. Plus, if users call a tool that is in our catalog but has not been added to the session, we still do _not_ call it today.

These tools are available anytime the gateway runs when the dynamic tools feature is enabled.

```
docker mcp feature enable dynamic-tools
```

> [!NOTE]
> The `find` command is for finding MCP servers, not for finding _tools_

I can imagine a world where agents don't need `add` or `remove` tools - this feels like needless book-keeping. However, there are a lot of agent loops that rely on the output of the `list` commands being highly curated. In practice, I'm still finding this to be useful.