### PR TITLE
docker mcp catalog update: allow updates to docker-mcp default url

### DIFF
--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -58,7 +58,7 @@ func updateCatalog(ctx context.Context, name string, catalog Catalog) error {
 	if name == DockerCatalogName && (url == "" || !isValidURL(url)) {
 		url = DockerCatalogURL
 	}
-	
+
 	if isValidURL(url) {
 		catalogContent, err = DownloadFile(ctx, url)
 	} else {


### PR DESCRIPTION
## Background

When running "docker mcp catalog update" with a catalog.json where the docker-mcp url has been updated, we found that we were reverting to the previous url. This change means that the url in catalog.json is always used _unless_ it's missing.