### PR TITLE
Show error when OAuth provider doesn't exist

### DIFF
--- a/cmd/docker-mcp/internal/desktop/raw_client.go
+++ b/cmd/docker-mcp/internal/desktop/raw_client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -52,12 +51,6 @@ func (c *RawClient) Get(ctx context.Context, endpoint string, v any) error {
 	}
 	defer response.Body.Close()
 
-	// Check for HTTP errors
-	if response.StatusCode >= 400 {
-		buf, _ := io.ReadAll(response.Body)
-		return fmt.Errorf("HTTP %d: %s", response.StatusCode, string(buf))
-	}
-
 	buf, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
@@ -97,12 +90,6 @@ func (c *RawClient) Post(ctx context.Context, endpoint string, v any, result any
 	}
 	defer response.Body.Close()
 
-	// Check for HTTP errors
-	if response.StatusCode >= 400 {
-		buf, _ := io.ReadAll(response.Body)
-		return fmt.Errorf("HTTP %d: %s", response.StatusCode, string(buf))
-	}
-
 	if result == nil {
 		_, err := io.Copy(io.Discard, response.Body)
 		return err
@@ -135,12 +122,6 @@ func (c *RawClient) Delete(ctx context.Context, endpoint string) error {
 		return err
 	}
 	defer response.Body.Close()
-
-	// Check for HTTP errors
-	if response.StatusCode >= 400 {
-		buf, _ := io.ReadAll(response.Body)
-		return fmt.Errorf("HTTP %d: %s", response.StatusCode, string(buf))
-	}
 
 	_, err = io.Copy(io.Discard, response.Body)
 	return err

--- a/cmd/docker-mcp/internal/desktop/raw_client.go
+++ b/cmd/docker-mcp/internal/desktop/raw_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -51,6 +52,12 @@ func (c *RawClient) Get(ctx context.Context, endpoint string, v any) error {
 	}
 	defer response.Body.Close()
 
+	// Check for HTTP errors
+	if response.StatusCode >= 400 {
+		buf, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("HTTP %d: %s", response.StatusCode, string(buf))
+	}
+
 	buf, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
@@ -90,6 +97,12 @@ func (c *RawClient) Post(ctx context.Context, endpoint string, v any, result any
 	}
 	defer response.Body.Close()
 
+	// Check for HTTP errors
+	if response.StatusCode >= 400 {
+		buf, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("HTTP %d: %s", response.StatusCode, string(buf))
+	}
+
 	if result == nil {
 		_, err := io.Copy(io.Discard, response.Body)
 		return err
@@ -122,6 +135,12 @@ func (c *RawClient) Delete(ctx context.Context, endpoint string) error {
 		return err
 	}
 	defer response.Body.Close()
+
+	// Check for HTTP errors
+	if response.StatusCode >= 400 {
+		buf, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("HTTP %d: %s", response.StatusCode, string(buf))
+	}
 
 	_, err = io.Copy(io.Discard, response.Body)
 	return err

--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -3,7 +3,6 @@ package oauth
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/desktop"
 )
@@ -13,10 +12,6 @@ func Authorize(ctx context.Context, app string, scopes string) error {
 
 	authResponse, err := client.PostOAuthApp(ctx, app, scopes, false)
 	if err != nil {
-		// Check if error is about provider not found
-		if strings.Contains(err.Error(), "not found") {
-			return fmt.Errorf("OAuth provider does not exist")
-		}
 		return err
 	}
 

--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/desktop"
 )
@@ -12,7 +13,16 @@ func Authorize(ctx context.Context, app string, scopes string) error {
 
 	authResponse, err := client.PostOAuthApp(ctx, app, scopes, false)
 	if err != nil {
+		// Check if error is about provider not found
+		if strings.Contains(err.Error(), "not found") {
+			return fmt.Errorf("OAuth provider does not exist")
+		}
 		return err
+	}
+
+	// Check if the response contains a valid browser URL
+	if authResponse.BrowserURL == "" {
+		return fmt.Errorf("OAuth provider does not exist")
 	}
 
 	fmt.Printf("Opening your browser for authentication. If it doesn't open automatically, please visit: %s\n", authResponse.BrowserURL)


### PR DESCRIPTION
**What I did**
If the user types in `docker mcp oauth authorize something_that_doesnt_exist`, it prints "Opening your browser for authentication. If it doesn't open automatically, please visit" instead of "OAuth provider does not exist".

**Tested**
OAuth Provider exists:
```
./docker-mcp oauth authorize github
Opening your browser for authentication. If it doesn't open automatically, please visit: <link>
```

OAuth Provider doesn't exist:
```
./docker-mcp oauth authorize github2
OAuth provider does not exist
```
