### PR TITLE
Handle --verbose flag in tools call

### DIFF
--- a/cmd/docker-mcp/tools/start.go
+++ b/cmd/docker-mcp/tools/start.go
@@ -15,7 +15,7 @@ func start(ctx context.Context, version string, gatewayArgs []string, verbose bo
 	if version == "2" {
 		if verbose {
 			args = []string{"mcp", "gateway", "run", "--verbose"}
-	        } else {
+		} else {
 			args = []string{"mcp", "gateway", "run"}
 		}
 	} else {

--- a/cmd/docker-mcp/tools/start.go
+++ b/cmd/docker-mcp/tools/start.go
@@ -2,22 +2,34 @@ package tools
 
 import (
 	"context"
+	"os"
 	"os/exec"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/internal/logs"
 )
 
-func start(ctx context.Context, version string, gatewayArgs []string, _ bool) (*mcp.ClientSession, error) {
+func start(ctx context.Context, version string, gatewayArgs []string, verbose bool) (*mcp.ClientSession, error) {
 	var args []string
 	if version == "2" {
-		args = []string{"mcp", "gateway", "run"}
+		if verbose {
+			args = []string{"mcp", "gateway", "run", "--verbose"}
+	        } else {
+			args = []string{"mcp", "gateway", "run"}
+		}
 	} else {
 		args = []string{"run", "-i", "--rm", "alpine/socat", "STDIO", "TCP:host.docker.internal:8811"}
 	}
 	args = append(args, gatewayArgs...)
 
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	if verbose {
+		cmd.Stderr = logs.NewPrefixer(os.Stderr, "- mcp-gateway: ")
+	}
+
 	c := mcp.NewClient(&mcp.Implementation{Name: "mcp-gateway-client", Version: "1.0.0"}, nil)
-	transport := &mcp.CommandTransport{Command: exec.CommandContext(ctx, "docker", args...)}
+	transport := &mcp.CommandTransport{Command: cmd}
 	session, err := c.Connect(ctx, transport, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What I did**

The `docker mcp tools call` was not observing --verbose.  This fix streams the stderr of the internal stdio mcp gateway to the tool stderr stream.

I think the idea

**Related issue**

This is to handle #120 
