### PR TITLE
Show `server list` command

### DIFF
--- a/cmd/docker-mcp/commands/server.go
+++ b/cmd/docker-mcp/commands/server.go
@@ -45,7 +45,6 @@ func serverCommand(docker docker.Client) *cobra.Command {
 
 			return nil
 		},
-		Hidden: true,
 	}
 	lsCommand.Flags().BoolVar(&outputJSON, "json", false, "Output in JSON format")
 	cmd.AddCommand(lsCommand)


### PR DESCRIPTION
Remove the hidden flag from the server list command

**What I did**
Removed `Hidden: true` so that `docker mcp server` would show documentation for `docker mcp server list`

**Related issue**
None