### PR TITLE
Add client name to telemetry metrics.

### DIFF
--- a/cmd/docker-mcp/internal/gateway/handlers.go
+++ b/cmd/docker-mcp/internal/gateway/handlers.go
@@ -80,6 +80,7 @@ func (g *Gateway) mcpServerToolHandler(serverConfig *catalog.ServerConfig, serve
 				attribute.String("mcp.server.name", serverConfig.Name),
 				attribute.String("mcp.server.type", serverType),
 				attribute.String("mcp.tool.name", req.Params.Name),
+				attribute.String("mcp.client.name", req.Session.InitializeParams().ClientInfo.Name),
 			),
 		)
 
@@ -107,6 +108,7 @@ func (g *Gateway) mcpServerToolHandler(serverConfig *catalog.ServerConfig, serve
 				attribute.String("mcp.server.name", serverConfig.Name),
 				attribute.String("mcp.server.type", serverType),
 				attribute.String("mcp.tool.name", req.Params.Name),
+				attribute.String("mcp.client.name", req.Session.InitializeParams().ClientInfo.Name),
 			),
 		)
 
@@ -153,7 +155,7 @@ func (g *Gateway) mcpServerPromptHandler(serverConfig *catalog.ServerConfig, ser
 		defer span.End()
 
 		// Record prompt get counter
-		telemetry.RecordPromptGet(ctx, req.Params.Name, serverConfig.Name)
+		telemetry.RecordPromptGet(ctx, req.Params.Name, serverConfig.Name, req.Session.InitializeParams().ClientInfo.Name)
 
 		client, err := g.clientPool.AcquireClient(ctx, serverConfig, getClientConfig(nil, req.Session, server))
 		if err != nil {
@@ -168,7 +170,7 @@ func (g *Gateway) mcpServerPromptHandler(serverConfig *catalog.ServerConfig, ser
 
 		// Record duration
 		duration := time.Since(startTime).Milliseconds()
-		telemetry.RecordPromptDuration(ctx, req.Params.Name, serverConfig.Name, float64(duration))
+		telemetry.RecordPromptDuration(ctx, req.Params.Name, serverConfig.Name, float64(duration), req.Session.InitializeParams().ClientInfo.Name)
 
 		if err != nil {
 			span.RecordError(err)
@@ -214,7 +216,7 @@ func (g *Gateway) mcpServerResourceHandler(serverConfig *catalog.ServerConfig, s
 		defer span.End()
 
 		// Record counter with server attribution
-		telemetry.RecordResourceRead(ctx, req.Params.URI, serverConfig.Name)
+		telemetry.RecordResourceRead(ctx, req.Params.URI, serverConfig.Name, req.Session.InitializeParams().ClientInfo.Name)
 
 		client, err := g.clientPool.AcquireClient(ctx, serverConfig, getClientConfig(nil, req.Session, server))
 		if err != nil {
@@ -229,7 +231,7 @@ func (g *Gateway) mcpServerResourceHandler(serverConfig *catalog.ServerConfig, s
 
 		// Record duration regardless of error
 		duration := time.Since(startTime).Milliseconds()
-		telemetry.RecordResourceDuration(ctx, req.Params.URI, serverConfig.Name, float64(duration))
+		telemetry.RecordResourceDuration(ctx, req.Params.URI, serverConfig.Name, float64(duration), req.Session.InitializeParams().ClientInfo.Name)
 
 		if err != nil {
 			span.RecordError(err)

--- a/cmd/docker-mcp/internal/gateway/handlers_prompt_telemetry_test.go
+++ b/cmd/docker-mcp/internal/gateway/handlers_prompt_telemetry_test.go
@@ -48,7 +48,7 @@ func TestPromptHandlerTelemetry(t *testing.T) {
 
 		// Record prompt call
 		ctx := context.Background()
-		telemetry.RecordPromptGet(ctx, promptName, serverConfig.Name)
+		telemetry.RecordPromptGet(ctx, promptName, serverConfig.Name, "test-client")
 
 		// Collect metrics
 		var rm metricdata.ResourceMetrics
@@ -79,6 +79,8 @@ func TestPromptHandlerTelemetry(t *testing.T) {
 						attribute.String("mcp.prompt.name", promptName))
 					assert.Contains(t, attrs,
 						attribute.String("mcp.server.origin", serverConfig.Name))
+					assert.Contains(t, attrs,
+						attribute.String("mcp.client.name", "test-client"))
 				}
 			}
 		}
@@ -110,7 +112,7 @@ func TestPromptHandlerTelemetry(t *testing.T) {
 
 		// Record prompt duration
 		ctx := context.Background()
-		telemetry.RecordPromptDuration(ctx, promptName, serverConfig.Name, duration)
+		telemetry.RecordPromptDuration(ctx, promptName, serverConfig.Name, duration, "test-client")
 
 		// Collect metrics
 		var rm metricdata.ResourceMetrics
@@ -142,6 +144,8 @@ func TestPromptHandlerTelemetry(t *testing.T) {
 						attribute.String("mcp.prompt.name", promptName))
 					assert.Contains(t, attrs,
 						attribute.String("mcp.server.origin", serverConfig.Name))
+					assert.Contains(t, attrs,
+						attribute.String("mcp.client.name", "test-client"))
 				}
 			}
 		}

--- a/cmd/docker-mcp/internal/gateway/handlers_telemetry_test.go
+++ b/cmd/docker-mcp/internal/gateway/handlers_telemetry_test.go
@@ -170,6 +170,7 @@ func TestTelemetryMetricRecording(t *testing.T) {
 	serverName := "test-server"
 	serverType := "docker"
 	toolName := "test-tool"
+	clientName := "test-client"
 
 	// Record metrics as the handler would
 	telemetry.ToolCallCounter.Add(ctx, 1,
@@ -177,6 +178,7 @@ func TestTelemetryMetricRecording(t *testing.T) {
 			attribute.String("mcp.server.name", serverName),
 			attribute.String("mcp.server.type", serverType),
 			attribute.String("mcp.tool.name", toolName),
+			attribute.String("mcp.client.name", clientName),
 		),
 	)
 
@@ -186,6 +188,7 @@ func TestTelemetryMetricRecording(t *testing.T) {
 			attribute.String("mcp.server.name", serverName),
 			attribute.String("mcp.server.type", serverType),
 			attribute.String("mcp.tool.name", toolName),
+			attribute.String("mcp.client.name", clientName),
 		),
 	)
 
@@ -210,6 +213,7 @@ func TestTelemetryMetricRecording(t *testing.T) {
 				assertMetricAttribute(t, attrs, "mcp.server.name", serverName)
 				assertMetricAttribute(t, attrs, "mcp.server.type", serverType)
 				assertMetricAttribute(t, attrs, "mcp.tool.name", toolName)
+				assertMetricAttribute(t, attrs, "mcp.client.name", clientName)
 
 			case "mcp.tool.duration":
 				foundHistogram = true
@@ -303,6 +307,7 @@ func TestToolCallDurationMeasurement(t *testing.T) {
 			attribute.String("mcp.server.name", "test-server"),
 			attribute.String("mcp.server.type", "docker"),
 			attribute.String("mcp.tool.name", "test-tool"),
+			attribute.String("mcp.client.name", "test-client"),
 		),
 	)
 

--- a/cmd/docker-mcp/internal/interceptors/telemetry.go
+++ b/cmd/docker-mcp/internal/interceptors/telemetry.go
@@ -32,20 +32,24 @@ func TelemetryMiddleware() mcp.Middleware {
 				telemetry.RecordInitialize(ctx, params)
 				tracked = true
 			case "tools/list":
+				session := req.GetSession().(*mcp.ServerSession)
 				ctx, span = telemetry.StartListSpan(ctx, "tools")
-				telemetry.RecordListTools(ctx)
+				telemetry.RecordListTools(ctx, session.InitializeParams().ClientInfo.Name)
 				tracked = true
 			case "prompts/list":
+				session := req.GetSession().(*mcp.ServerSession)
 				ctx, span = telemetry.StartListSpan(ctx, "prompts")
-				telemetry.RecordListPrompts(ctx)
+				telemetry.RecordListPrompts(ctx, session.InitializeParams().ClientInfo.Name)
 				tracked = true
 			case "resources/list":
+				session := req.GetSession().(*mcp.ServerSession)
 				ctx, span = telemetry.StartListSpan(ctx, "resources")
-				telemetry.RecordListResources(ctx)
+				telemetry.RecordListResources(ctx, session.InitializeParams().ClientInfo.Name)
 				tracked = true
 			case "resourceTemplates/list":
+				session := req.GetSession().(*mcp.ServerSession)
 				ctx, span = telemetry.StartListSpan(ctx, "resourceTemplates")
-				telemetry.RecordListResourceTemplates(ctx)
+				telemetry.RecordListResourceTemplates(ctx, session.InitializeParams().ClientInfo.Name)
 				tracked = true
 			}
 

--- a/cmd/docker-mcp/internal/telemetry/telemetry.go
+++ b/cmd/docker-mcp/internal/telemetry/telemetry.go
@@ -507,7 +507,7 @@ func RecordInitialize(ctx context.Context, params *mcp.InitializeParams) {
 }
 
 // RecordListTools records a list tools call
-func RecordListTools(ctx context.Context) {
+func RecordListTools(ctx context.Context, clientName string) {
 	if ListToolsCounter == nil {
 		if os.Getenv("DOCKER_MCP_TELEMETRY_DEBUG") != "" {
 			fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] WARNING: ListToolsCounter is nil - metrics not initialized\n")
@@ -519,7 +519,10 @@ func RecordListTools(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] List tools called - adding to counter\n")
 	}
 
-	ListToolsCounter.Add(ctx, 1)
+	ListToolsCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("mcp.client.name", clientName),
+		))
 
 	if os.Getenv("DOCKER_MCP_TELEMETRY_DEBUG") != "" {
 		fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] List tools counter incremented\n")
@@ -581,7 +584,7 @@ func RecordCatalogServers(ctx context.Context, catalogName string, serverCount i
 }
 
 // RecordPromptGet records a prompt get operation
-func RecordPromptGet(ctx context.Context, promptName string, serverName string) {
+func RecordPromptGet(ctx context.Context, promptName string, serverName string, clientName string) {
 	if PromptGetCounter == nil {
 		return // Telemetry not initialized
 	}
@@ -594,11 +597,12 @@ func RecordPromptGet(ctx context.Context, promptName string, serverName string) 
 		metric.WithAttributes(
 			attribute.String("mcp.prompt.name", promptName),
 			attribute.String("mcp.server.origin", serverName),
+			attribute.String("mcp.client.name", clientName),
 		))
 }
 
 // RecordPromptDuration records the duration of a prompt operation
-func RecordPromptDuration(ctx context.Context, promptName string, serverName string, durationMs float64) {
+func RecordPromptDuration(ctx context.Context, promptName string, serverName string, durationMs float64, clientName string) {
 	if PromptDuration == nil {
 		return // Telemetry not initialized
 	}
@@ -612,6 +616,7 @@ func RecordPromptDuration(ctx context.Context, promptName string, serverName str
 		metric.WithAttributes(
 			attribute.String("mcp.prompt.name", promptName),
 			attribute.String("mcp.server.origin", serverName),
+			attribute.String("mcp.client.name", clientName),
 		))
 }
 
@@ -652,7 +657,7 @@ func RecordPromptList(ctx context.Context, serverName string, promptCount int) {
 }
 
 // RecordListPrompts records a list prompts call (similar to RecordListTools)
-func RecordListPrompts(ctx context.Context) {
+func RecordListPrompts(ctx context.Context, clientName string) {
 	if ListPromptsCounter == nil {
 		if os.Getenv("DOCKER_MCP_TELEMETRY_DEBUG") != "" {
 			fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] WARNING: ListPromptsCounter is nil - metrics not initialized\n")
@@ -664,7 +669,10 @@ func RecordListPrompts(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] List prompts called - adding to counter\n")
 	}
 
-	ListPromptsCounter.Add(ctx, 1)
+	ListPromptsCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("mcp.client.name", clientName),
+		))
 
 	if os.Getenv("DOCKER_MCP_TELEMETRY_DEBUG") != "" {
 		fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] List prompts counter incremented\n")
@@ -672,7 +680,7 @@ func RecordListPrompts(ctx context.Context) {
 }
 
 // RecordListResources records a list resources call
-func RecordListResources(ctx context.Context) {
+func RecordListResources(ctx context.Context, clientName string) {
 	if ListResourcesCounter == nil {
 		return // Telemetry not initialized
 	}
@@ -681,11 +689,14 @@ func RecordListResources(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] List resources called\n")
 	}
 
-	ListResourcesCounter.Add(ctx, 1)
+	ListResourcesCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("mcp.client.name", clientName),
+		))
 }
 
 // RecordResourceRead records a resource read operation
-func RecordResourceRead(ctx context.Context, resourceURI string, serverName string) {
+func RecordResourceRead(ctx context.Context, resourceURI string, serverName string, clientName string) {
 	if ResourceReadCounter == nil {
 		return // Telemetry not initialized
 	}
@@ -698,11 +709,12 @@ func RecordResourceRead(ctx context.Context, resourceURI string, serverName stri
 		metric.WithAttributes(
 			attribute.String("mcp.resource.uri", resourceURI),
 			attribute.String("mcp.server.origin", serverName),
+			attribute.String("mcp.client.name", clientName),
 		))
 }
 
 // RecordResourceDuration records the duration of a resource operation
-func RecordResourceDuration(ctx context.Context, resourceURI string, serverName string, durationMs float64) {
+func RecordResourceDuration(ctx context.Context, resourceURI string, serverName string, durationMs float64, clientName string) {
 	if ResourceDuration == nil {
 		return // Telemetry not initialized
 	}
@@ -716,6 +728,7 @@ func RecordResourceDuration(ctx context.Context, resourceURI string, serverName 
 		metric.WithAttributes(
 			attribute.String("mcp.resource.uri", resourceURI),
 			attribute.String("mcp.server.origin", serverName),
+			attribute.String("mcp.client.name", clientName),
 		))
 }
 
@@ -756,7 +769,7 @@ func RecordResourceList(ctx context.Context, serverName string, resourceCount in
 }
 
 // RecordListResourceTemplates records a list resource templates call
-func RecordListResourceTemplates(ctx context.Context) {
+func RecordListResourceTemplates(ctx context.Context, clientName string) {
 	if ListResourceTemplatesCounter == nil {
 		return // Telemetry not initialized
 	}
@@ -765,11 +778,14 @@ func RecordListResourceTemplates(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "[MCP-TELEMETRY] List resource templates called\n")
 	}
 
-	ListResourceTemplatesCounter.Add(ctx, 1)
+	ListResourceTemplatesCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("mcp.client.name", clientName),
+		))
 }
 
 // RecordResourceTemplateRead records a resource template read operation
-func RecordResourceTemplateRead(ctx context.Context, uriTemplate string, serverName string) {
+func RecordResourceTemplateRead(ctx context.Context, uriTemplate string, serverName string, clientName string) {
 	if ResourceTemplateReadCounter == nil {
 		return // Telemetry not initialized
 	}
@@ -782,11 +798,12 @@ func RecordResourceTemplateRead(ctx context.Context, uriTemplate string, serverN
 		metric.WithAttributes(
 			attribute.String("mcp.resource_template.uri", uriTemplate),
 			attribute.String("mcp.server.origin", serverName),
+			attribute.String("mcp.client.name", clientName),
 		))
 }
 
 // RecordResourceTemplateDuration records the duration of a resource template operation
-func RecordResourceTemplateDuration(ctx context.Context, uriTemplate string, serverName string, durationMs float64) {
+func RecordResourceTemplateDuration(ctx context.Context, uriTemplate string, serverName string, durationMs float64, clientName string) {
 	if ResourceTemplateDuration == nil {
 		return // Telemetry not initialized
 	}
@@ -800,6 +817,7 @@ func RecordResourceTemplateDuration(ctx context.Context, uriTemplate string, ser
 		metric.WithAttributes(
 			attribute.String("mcp.resource_template.uri", uriTemplate),
 			attribute.String("mcp.server.origin", serverName),
+			attribute.String("mcp.client.name", clientName),
 		))
 }
 


### PR DESCRIPTION
### What I did
Added the client name (e.g. `claude-ai`) to telemetry metrics under the attribute `mcp.client.name`.

### Metrics Affected
- `mcp.tool.calls`
- `mcp.tool.duration`
- `mcp.list.tools`
- `mcp.prompt.gets`
- `mcp.prompt.duration`
- `mcp.list.prompts`
- `mcp.list.resources`
- `mcp.resource.reads`
- `mcp.resource.duration`
- `mcp.list.resource_templates`
- `mcp.resource_template.reads`
- `mcp.resource_template.duration`