### PR TITLE
Extract code related to args

### DIFF
--- a/pkg/gateway/args.go
+++ b/pkg/gateway/args.go
@@ -1,0 +1,159 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/eval"
+	"github.com/docker/mcp-gateway/pkg/gateway/proxies"
+)
+
+func baseArgs(name string, opts Options) []string {
+	args := []string{
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=" + name,
+		"-l", "docker-mcp-transport=stdio",
+	}
+
+	if opts.Cpus > 0 {
+		args = append(args, "--cpus", fmt.Sprintf("%d", opts.Cpus))
+	}
+	if opts.Memory != "" {
+		args = append(args, "--memory", opts.Memory)
+	}
+	if os.Getenv("DOCKER_MCP_IN_DIND") == "1" {
+		args = append(args, "--privileged")
+	}
+
+	return args
+}
+
+func ArgsAndEnvForMCPServer(serverConfig *catalog.ServerConfig, readOnly *bool, targetConfig proxies.TargetConfig, opts Options, networks []string) ([]string, []string) {
+	args := baseArgs(serverConfig.Name, opts)
+
+	var env []string
+
+	// Security options
+	if serverConfig.Spec.DisableNetwork {
+		args = append(args, "--network", "none")
+	} else {
+		// Attach the MCP servers to the same network as the gateway.
+		for _, network := range networks {
+			args = append(args, "--network", network)
+		}
+	}
+	if targetConfig.NetworkName != "" {
+		args = append(args, "--network", targetConfig.NetworkName)
+	}
+	for _, link := range targetConfig.Links {
+		args = append(args, "--link", link)
+	}
+	for _, env := range targetConfig.Env {
+		args = append(args, "-e", env)
+	}
+	if targetConfig.DNS != "" {
+		args = append(args, "--dns", targetConfig.DNS)
+	}
+
+	// Secrets
+	for _, s := range serverConfig.Spec.Secrets {
+		args = append(args, "-e", s.Env)
+
+		secretValue, ok := serverConfig.Secrets[s.Name]
+		if ok {
+			env = append(env, fmt.Sprintf("%s=%s", s.Env, secretValue))
+		} else {
+			logf("Warning: Secret '%s' not found for server '%s', setting %s=<UNKNOWN>", s.Name, serverConfig.Name, s.Env)
+			env = append(env, fmt.Sprintf("%s=%s", s.Env, "<UNKNOWN>"))
+		}
+	}
+
+	// Env
+	for _, e := range serverConfig.Spec.Env {
+		var value string
+		if strings.Contains(e.Value, "{{") && strings.Contains(e.Value, "}}") {
+			value = fmt.Sprintf("%v", eval.Evaluate(e.Value, serverConfig.Config))
+		} else {
+			value = expandEnv(e.Value, env)
+		}
+
+		if value != "" {
+			args = append(args, "-e", e.Name)
+			env = append(env, fmt.Sprintf("%s=%s", e.Name, value))
+		}
+	}
+
+	// Volumes
+	for _, mount := range eval.EvaluateList(serverConfig.Spec.Volumes, serverConfig.Config) {
+		if mount == "" {
+			continue
+		}
+
+		if readOnly != nil && *readOnly && !strings.HasSuffix(mount, ":ro") {
+			args = append(args, "-v", mount+":ro")
+		} else {
+			args = append(args, "-v", mount)
+		}
+	}
+
+	// User
+	if serverConfig.Spec.User != "" {
+		val := serverConfig.Spec.User
+		if strings.Contains(val, "{{") && strings.Contains(val, "}}") {
+			val = fmt.Sprintf("%v", eval.Evaluate(val, serverConfig.Config))
+		}
+		if val != "" {
+			args = append(args, "-u", val)
+		}
+	}
+
+	return args, env
+}
+
+func ArgsForPOCI(ctx context.Context, tool catalog.Tool, params any, opts Options, networks []string) []string {
+	args := baseArgs(tool.Name, opts)
+
+	// Attach the MCP servers to the same network as the gateway.
+	for _, network := range networks {
+		args = append(args, "--network", network)
+	}
+
+	// Convert params to map[string]any
+	arguments, ok := params.(map[string]any)
+	if !ok {
+		arguments = make(map[string]any)
+	}
+
+	// Volumes
+	for _, mount := range eval.EvaluateList(tool.Container.Volumes, arguments) {
+		if mount == "" {
+			continue
+		}
+
+		args = append(args, "-v", mount)
+	}
+
+	// User
+	if tool.Container.User != "" {
+		userVal := fmt.Sprintf("%v", eval.Evaluate(tool.Container.User, arguments))
+		if userVal != "" {
+			args = append(args, "-u", userVal)
+		}
+	}
+
+	// Image
+	args = append(args, tool.Container.Image)
+
+	// Command
+	command := eval.EvaluateList(tool.Container.Command, arguments)
+	args = append(args, command...)
+
+	return args
+}

--- a/pkg/gateway/args_test.go
+++ b/pkg/gateway/args_test.go
@@ -36,11 +36,18 @@ grafana:
 		"grafana.api_key": "API_KEY",
 	}
 
-	args, env := argsAndEnv(t, "grafana", catalogYAML, configYAML, secrets, nil)
+	args, env := argsAndEnvForMCPServer(t, "grafana", catalogYAML, configYAML, secrets, nil)
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=grafana", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=grafana",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 		"-e", "GRAFANA_API_KEY", "-e", "GRAFANA_URL",
 	}, args)
 	assert.Equal(t, []string{"GRAFANA_API_KEY=API_KEY", "GRAFANA_URL=TEST"}, env)
@@ -56,11 +63,18 @@ secrets:
 		"mongodb.connection_string": "HOST:PORT",
 	}
 
-	args, env := argsAndEnv(t, "mongodb", catalogYAML, "", secrets, nil)
+	args, env := argsAndEnvForMCPServer(t, "mongodb", catalogYAML, "", secrets, nil)
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=mongodb", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=mongodb",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 		"-e", "MDB_MCP_CONNECTION_STRING",
 	}, args)
 	assert.Equal(t, []string{"MDB_MCP_CONNECTION_STRING=HOST:PORT"}, env)
@@ -80,11 +94,18 @@ env:
 		"notion.internal_integration_token": "ntn_DUMMY",
 	}
 
-	args, env := argsAndEnv(t, "notion", catalogYAML, "", secrets, nil)
+	args, env := argsAndEnvForMCPServer(t, "notion", catalogYAML, "", secrets, nil)
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=notion", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=notion",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 		"-e", "INTERNAL_INTEGRATION_TOKEN", "-e", "OPENAPI_MCP_HEADERS",
 	}, args)
 	assert.Equal(t, []string{"INTERNAL_INTEGRATION_TOKEN=ntn_DUMMY", `OPENAPI_MCP_HEADERS={"Authorization": "Bearer ntn_DUMMY", "Notion-Version": "2022-06-28"}`}, env)
@@ -100,11 +121,18 @@ hub:
   log_path: /local/logs
 `
 
-	args, env := argsAndEnv(t, "hub", catalogYAML, configYAML, nil, nil)
+	args, env := argsAndEnvForMCPServer(t, "hub", catalogYAML, configYAML, nil, nil)
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=hub",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 		"-v", "/local/logs:/logs:ro",
 	}, args)
 	assert.Empty(t, env)
@@ -116,11 +144,18 @@ volumes:
   - '{{hub.log_path|mount_as:/logs:ro}}'
   `
 
-	args, env := argsAndEnv(t, "hub", catalogYAML, "", nil, nil)
+	args, env := argsAndEnvForMCPServer(t, "hub", catalogYAML, "", nil, nil)
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=hub",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 	}, args)
 	assert.Empty(t, env)
 }
@@ -135,11 +170,18 @@ hub:
   log_path: /local/logs
 `
 
-	args, env := argsAndEnv(t, "hub", catalogYAML, configYAML, nil, readOnly())
+	args, env := argsAndEnvForMCPServer(t, "hub", catalogYAML, configYAML, nil, readOnly())
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=hub",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 		"-v", "/local/logs:/logs:ro",
 	}, args)
 	assert.Empty(t, env)
@@ -150,31 +192,37 @@ func TestApplyConfigUser(t *testing.T) {
 user: "1001:2002"
   `
 
-	args, env := argsAndEnv(t, "svc", catalogYAML, "", nil, nil)
+	args, env := argsAndEnvForMCPServer(t, "svc", catalogYAML, "", nil, nil)
 
 	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=svc", "-l", "docker-mcp-transport=stdio",
+		"run", "--rm", "-i", "--init",
+		"--security-opt", "no-new-privileges",
+		"--pull", "never",
+		"-l", "docker-mcp=true",
+		"-l", "docker-mcp-tool-type=mcp",
+		"-l", "docker-mcp-name=svc",
+		"-l", "docker-mcp-transport=stdio",
+		"--cpus", "1",
+		"--memory", "2Gb",
 		"-u", "1001:2002",
 	}, args)
 	assert.Empty(t, env)
 }
 
-func argsAndEnv(t *testing.T, name, catalogYAML, configYAML string, secrets map[string]string, readOnly *bool) ([]string, []string) {
+func argsAndEnvForMCPServer(t *testing.T, name, catalogYAML, configYAML string, secrets map[string]string, readOnly *bool) ([]string, []string) {
 	t.Helper()
 
-	clientPool := &clientPool{
-		Options: Options{
-			Cpus:   1,
-			Memory: "2Gb",
-		},
-	}
-	return clientPool.argsAndEnv(&catalog.ServerConfig{
+	serverConfig := catalog.ServerConfig{
 		Name:    name,
 		Spec:    parseSpec(t, catalogYAML),
 		Config:  parseConfig(t, configYAML),
 		Secrets: secrets,
-	}, readOnly, proxies.TargetConfig{})
+	}
+
+	return ArgsAndEnvForMCPServer(&serverConfig, readOnly, proxies.TargetConfig{}, Options{
+		Cpus:   1,
+		Memory: "2Gb",
+	}, nil)
 }
 
 func parseSpec(t *testing.T, contentYAML string) catalog.Server {


### PR DESCRIPTION
**What I did**

Extract the code that computes the arguments to start an MCP Server or a POCI.

+ This makes it easier to test
+ Can be used as a library
+ Moves the code for POCIs next to the code for MCP Servers
