### PR TITLE
Gateway hosts Self-Contained Images (no catalog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ docker mcp gateway run
 docker mcp gateway run --port 8080 --transport streaming
 ```
 
-More about [the MCP Gateway](docs/mcp-gateway.md).
+* more about [the MCP Gateway](docs/mcp-gateway.md)
+* [running an unpublished local image](docs/self-configured.md)
 
 ### Server Management
 

--- a/docs/config-flow.md
+++ b/docs/config-flow.md
@@ -1,0 +1,68 @@
+# Gateway startup
+
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Config
+    participant Configurator
+    participant Server
+    participant Listener
+
+    Gateway->>Listener: Start listening immediately if not-stdio
+    Gateway->>Configurator: Read
+    Configurator-->>Config: hello
+    Config-->>Gateway: configured
+    Configurator->>Watcher: channel
+    Watcher-->>Gateway: watch channel config changes
+    Gateway->>Gateway: pullAndVerify(config)
+    Gateway->>Gateway: reloadConfiguration(config)
+    Gateway->>Server: start
+    Gateway->>Listener: healthy
+```
+
+## Reading Config
+
+The `Read` method in `Configurator` is responsible for building an initial `Configuration`
+
+* serverNames
+* catalog.Servers (this is our catalog)
+    * read from catalog.yaml files
+    * read from oci artifacts
+* config map
+* tool filters
+* secret providers
+    * DD
+    * file
+
+## reloadConfiguration
+
+The gateway `reloadConfiguration` extracts capabilities from the current configuration, and updates the Server. It starts up the server to do this.
+
+When running servers raise change notifications, the capabilities also have to be reloaded.
+
+# Dynamic Server Add
+
+Another place where the capabilities should be considered _dynamic_ is with the `mcp-server-add` tool. This tool loads new mcp servers into a gateway session.
+
+```mermaid
+sequenceDiagram
+    AddTool->>Config: find
+    AddTool->>Config: append server
+    AddTool->>Config: update secrets
+    AddTool->>Gateway: reloadConfiguration
+    Gateway-->>Config: is used
+```
+
+During `reloadConfiguration` all updates to capabilities will cause change events to be sent to any clients connected to this server.
+
+# Images without Catalogs
+
+A Docker Image can contain it's own catalog description. If this is the case case the server oci reference is sufficient to populate the catalog.  In this case, `docker mcp gateway run --server docker.io/namespace/image:latest` will be sufficient to bootstrap the gateway. The requirement on this server is that it has a label like the following:
+
+```
+LABEL io.docker.server.metadata="{... server metadata ...}"
+```
+
+When the Configuration is first read, server names that are hub oci references will pulled, the label will be extracted, and we'll update both the list of serverNames, and the set of servers.
+
+

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -26,6 +26,9 @@ docker mcp gateway run --verbose --log-calls
 
 # Run in watch mode (auto-reload on config changes)
 docker mcp gateway run --watch
+
+# Run a standalone dockerized MCP server (no catalog required)
+docker mcp gateway run --server docker.io/namespace/repository:latest
 ```
 
 ## How to connect to an MCP Client?

--- a/docs/self-configured.md
+++ b/docs/self-configured.md
@@ -1,0 +1,52 @@
+## Self-Contained MCP Docker Image
+
+Before publishing an MCP server image, users can still run the MCP.
+
+```bash
+docker mcp gateway run --servers docker.io/namespace/repository:latest
+```
+
+* the `docker.io/` prefix is required here but we will inspect the tag `namespace/repository:latest` at runtime.
+
+## no catalog required
+
+In the example above, the namespace/repository:latest is not yet published, but it is available.
+
+The image must containi the following label.
+
+```
+LABEL io.docker.server.metadata="{... server metadata ...}"
+```
+
+### Example
+
+Build the image with the server metadata added to the label.
+
+```bash
+docker build \
+  --label "io.docker.server.metadata=$(cat <<'EOF'
+name: my-mcp-server
+description: "Custom MCP server for things"
+command: ["python", "/app/server.py"]
+env:
+  - name: LOG_LEVEL
+    value: "{{my-mcp-server.log-levell}}"
+  - name: DEBUG
+    value: "false"
+secrets:
+  - name: my-mcp-server.API_KEY
+    env: API_KEY
+config:
+  - name: my-mcp-server
+    type: object
+    properties:
+      log-level:
+        type: string
+    required:
+      - level
+EOF
+)" \
+  -t namespace/repository:latest .
+```
+
+* the `image` property is not required. This image is self-describing.

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
@@ -26,6 +27,7 @@ type Client interface {
 	InspectContainer(ctx context.Context, containerID string) (container.InspectResponse, error)
 	ReadLogs(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
 	ImageExists(ctx context.Context, name string) (bool, error)
+	InspectImage(ctx context.Context, name string) (image.InspectResponse, error)
 	PullImage(ctx context.Context, name string) error
 	PullImages(ctx context.Context, names ...string) error
 	CreateNetwork(ctx context.Context, name string, internal bool, labels map[string]string) error

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -46,6 +46,10 @@ func (c *dockerClient) PullImage(ctx context.Context, name string) error {
 	})
 }
 
+func (c *dockerClient) InspectImage(ctx context.Context, name string) (image.InspectResponse, error) {
+	return c.apiClient().ImageInspect(ctx, name)
+}
+
 func (c *dockerClient) pullImage(ctx context.Context, imageName string, registryAuthFn func() string) error {
 	inspect, err := c.apiClient().ImageInspect(ctx, imageName)
 	if err != nil && !cerrdefs.IsNotFound(err) {

--- a/pkg/gateway/configuration.go
+++ b/pkg/gateway/configuration.go
@@ -228,11 +228,24 @@ func (c *FileBasedConfiguration) readOnce(ctx context.Context) (Configuration, e
 		}
 	}
 
+	// check for docker.io self-contained servers
+	selfContainedCatalog, updatedServerNames, err := oci.SelfContainedCatalog(ctx, c.docker, serverNames)
+	if err != nil {
+		return Configuration{}, fmt.Errorf("reading oci server: %w", err)
+	}
+	serverNames = updatedServerNames
+
+	// read local caalog files
 	mcpCatalog, err := c.readCatalog(ctx)
 	if err != nil {
 		return Configuration{}, fmt.Errorf("reading catalog: %w", err)
 	}
+
+	// merge self-contained servers with local catalog
 	servers := mcpCatalog.Servers
+	for k, v := range selfContainedCatalog.Servers {
+		servers[k] = v
+	}
 
 	// Read servers from OCI references if any are provided
 	ociServers, err := c.readServersFromOci(ctx)

--- a/pkg/oci/self_contained.go
+++ b/pkg/oci/self_contained.go
@@ -1,0 +1,60 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/docker"
+)
+
+func SelfContainedCatalog(ctx context.Context, dockerClient docker.Client, serverNames []string) (catalog.Catalog, []string, error) {
+	result := catalog.Catalog{
+		Servers: make(map[string]catalog.Server),
+	}
+	var resultServerNames []string
+
+	for _, serverName := range serverNames {
+		if strings.HasPrefix(serverName, "docker.io/") {
+			ociRef := strings.TrimPrefix(serverName, "docker.io/")
+
+			if err := dockerClient.PullImage(ctx, ociRef); err != nil {
+				return catalog.Catalog{}, nil, fmt.Errorf("failed to pull OCI image %s: %w", ociRef, err)
+			}
+
+			inspect, err := dockerClient.InspectImage(ctx, ociRef)
+			if err != nil {
+				return catalog.Catalog{}, nil, fmt.Errorf("failed to inspect OCI image %s: %w", ociRef, err)
+			}
+
+			metadataLabel, exists := inspect.Config.Labels["io.docker.server.metadata"]
+			if !exists {
+				return catalog.Catalog{}, nil, fmt.Errorf("server name %s looks like an OCI ref but is missing the io.docker.server.metadata label", serverName)
+			}
+
+			var server catalog.Server
+			if err := yaml.Unmarshal([]byte(metadataLabel), &server); err != nil {
+				return catalog.Catalog{}, nil, fmt.Errorf("failed to parse metadata label for %s: %w", serverName, err)
+			}
+
+			server.Image = ociRef
+
+			// Determine the server name to use
+			finalServerName := serverName
+			if server.Name != "" {
+				finalServerName = server.Name
+			}
+
+			result.Servers[finalServerName] = server
+			resultServerNames = append(resultServerNames, finalServerName)
+		} else {
+			// Non-OCI server names are passed through as-is
+			resultServerNames = append(resultServerNames, serverName)
+		}
+	}
+
+	return result, resultServerNames, nil
+}


### PR DESCRIPTION
**What I did**

Run an mcp gateway with servers that are not yet in any catalog.

```
# Run a standalone dockerized MCP server (no catalog required)
docker mcp gateway run --servers docker.io/namespace/repository:latest
```

In the example above, the user has pushed `docker.io/namespace/repository:latest` but it is not yet published to a catalog. It has just been pushed to Hub.

The image must contain the following label.

```
LABEL io.docker.server.metadata="{... server metadata ...}"
```

The server metadata is `application/yaml` content adhering to the Docker server format.  An example is provided below. One way to do this would be to add the label at build time.

```bash
docker build \
  --label "io.docker.server.metadata=$(cat <<'EOF'
name: my-mcp-server
description: "Custom MCP server for things"
command: ["python", "/app/server.py"]
env:
  - name: LOG_LEVEL
    value: "{{my-mcp-server.log-levell}}"
  - name: DEBUG
    value: "false"
secrets:
  - name: my-mcp-server.API_KEY
    env: API_KEY
config:
  - name: my-mcp-server
    type: object
    properties:
      log-level:
        type: string
    required:
      - level
EOF
)" \
  -t my-image .
```

The image property is not required since it is assumed that this image _is_ the mcp server.

**Related issue**

#135 

