### PR TITLE
Default verify-signatures off when in a container.

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -35,13 +35,12 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 			CatalogPath: []string{catalog.DockerCatalogURL},
 			SecretsPath: "docker-desktop:/run/secrets/mcp_secret:/.env",
 			Options: gateway.Options{
-				Cpus:             1,
-				Memory:           "2Gb",
-				Transport:        "stdio",
-				LogCalls:         true,
-				BlockSecrets:     true,
-				VerifySignatures: true,
-				Verbose:          true,
+				Cpus:         1,
+				Memory:       "2Gb",
+				Transport:    "stdio",
+				LogCalls:     true,
+				BlockSecrets: true,
+				Verbose:      true,
 			},
 		}
 	} else {


### PR DESCRIPTION
**What I did**
Made the verify-signatures flag off by default in a container, making it consistent with running it directly on a host.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**