### PR TITLE
Provide ResourceURL when registering DCR

### DIFF
--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -96,7 +96,7 @@ func performAtomicDCRAndAuthorize(ctx context.Context, serverName string, scopes
 		ProviderName:          providerName,
 		AuthorizationEndpoint: credentials.AuthorizationEndpoint,
 		TokenEndpoint:         credentials.TokenEndpoint,
-		ResourceUrl:           credentials.ServerURL,
+		ResourceURL:           credentials.ServerURL,
 	}
 
 	if err := client.RegisterDCRClient(ctx, serverName, dcrRequest); err != nil {

--- a/pkg/desktop/auth.go
+++ b/pkg/desktop/auth.go
@@ -81,7 +81,7 @@ type RegisterDCRRequest struct {
 	AuthorizationServer   string `json:"authorizationServer,omitempty"`
 	AuthorizationEndpoint string `json:"authorizationEndpoint,omitempty"`
 	TokenEndpoint         string `json:"tokenEndpoint,omitempty"`
-	ResourceUrl           string `json:"resourceUrl,omitempty"`
+	ResourceURL           string `json:"resourceUrl,omitempty"`
 }
 
 type DCRClient struct {


### PR DESCRIPTION
**What I did**
- When MCP Gateway registers a DCR client with Docker desktop the `resourceUrl` is not being sent
**Related issue**
- Fixes missing `resourceUrl` for OAuth Provider 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**