### PR TITLE
Fix bug in OAuth discovery

### DIFF
--- a/pkg/oauth/discovery.go
+++ b/pkg/oauth/discovery.go
@@ -61,9 +61,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 
 	// If not 401, OAuth is not required (Authorization is OPTIONAL per MCP spec Section 2.1)
 	if resp.StatusCode != http.StatusUnauthorized {
-		return &Discovery{
-			RequiresOAuth: false,
-		}, nil
+		return nil, fmt.Errorf("server did not return 401 - OAuth not required")
 	}
 
 	// STEP 2: Parse WWW-Authenticate header (if present)
@@ -115,8 +113,6 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 
 	// STEP 6: Build discovery result with all available information
 	discovery := &Discovery{
-		RequiresOAuth: true,
-
 		// Use resource metadata if available, otherwise use defaults
 		ResourceURL:         defaultAuthServerURL,
 		ResourceServer:      defaultAuthServerURL,

--- a/pkg/oauth/types.go
+++ b/pkg/oauth/types.go
@@ -8,9 +8,6 @@ package oauth
 // - RFC 8414: OAuth 2.0 Authorization Server Metadata
 // - MCP Authorization Specification Section 4.1: Authorization Server Discovery
 type Discovery struct {
-	// Discovery result
-	RequiresOAuth bool
-
 	// From RFC 9728 - OAuth Protected Resource Metadata
 	ResourceURL         string   // The protected resource URL
 	ResourceServer      string   // Resource server identifier


### PR DESCRIPTION
Fixes a bug where a DCR client is still created if we connect to a server without OAuth.

Later during the registration phase it will throw a confusing error "no registration endpoint found for <server_name>".

This change returns a clearer error earlier and avoids the creation of the DCR client.