### PR TITLE
Oauth notifications WIP

### DIFF
--- a/pkg/desktop/auth.go
+++ b/pkg/desktop/auth.go
@@ -52,6 +52,17 @@ func (c *Tools) ListOAuthApps(ctx context.Context) ([]OAuthApp, error) {
 	return result, err
 }
 
+func (c *Tools) GetOAuthApp(ctx context.Context, app string) (*OAuthApp, error) {
+	AvoidResourceSaverMode(ctx)
+
+	var result OAuthApp
+	err := c.rawClient.Get(ctx, fmt.Sprintf("/apps/%v", app), &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *Tools) PostOAuthApp(ctx context.Context, app, scopes string, disableAutoOpen bool) (AuthResponse, error) {
 	AvoidResourceSaverMode(ctx)
 

--- a/pkg/gateway/configuration.go
+++ b/pkg/gateway/configuration.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -104,11 +103,6 @@ type FileBasedConfiguration struct {
 	McpOAuthDcrEnabled bool
 
 	docker docker.Client
-}
-
-// isDCRFeatureEnabled checks if the mcp-oauth-dcr feature is enabled
-func (c *FileBasedConfiguration) isDCRFeatureEnabled() bool {
-	return c.McpOAuthDcrEnabled
 }
 
 func (c *FileBasedConfiguration) Read(ctx context.Context) (Configuration, chan Configuration, func() error, error) {
@@ -212,19 +206,6 @@ func (c *FileBasedConfiguration) Read(ctx context.Context) (Configuration, chan 
 		if err := watcher.Add(path); err != nil && !os.IsNotExist(err) {
 			return Configuration{}, nil, nil, err
 		}
-	}
-
-	// Add token event file to watcher only if DCR feature is enabled
-	if c.isDCRFeatureEnabled() {
-		tokenEventPath := filepath.Join(os.Getenv("HOME"), ".docker", "mcp", TokenEventFilename)
-		if err := watcher.Add(tokenEventPath); err != nil && !os.IsNotExist(err) {
-			log(fmt.Sprintf("DCR: Warning - Could not watch token event file %s: %v", tokenEventPath, err))
-			// Don't fail configuration loading if token event file can't be watched
-		} else {
-			log(fmt.Sprintf("DCR: Watching token event file: %s", tokenEventPath))
-		}
-	} else {
-		log("DCR: Token event file watching disabled (mcp-oauth-dcr feature inactive)")
 	}
 
 	return configuration, updates, watcher.Close, nil

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -12,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/telemetry"
 )
 
@@ -111,6 +113,14 @@ func (g *Gateway) mcpServerToolHandler(serverConfig *catalog.ServerConfig, serve
 				attribute.String("mcp.client.name", req.Session.InitializeParams().ClientInfo.Name),
 			),
 		)
+
+		// Check for OAuth 401 errors on DCR servers and trigger refresh
+		if err == nil && result != nil && result.IsError && serverConfig.Spec.OAuth != nil && len(serverConfig.Spec.OAuth.Providers) > 0 {
+			if oauthResult := g.handleOAuth401(ctx, result, serverConfig.Name); oauthResult != nil {
+				span.SetStatus(codes.Ok, "OAuth token refresh triggered")
+				return oauthResult, nil
+			}
+		}
 
 		if err != nil {
 			// Record error in telemetry
@@ -244,4 +254,57 @@ func (g *Gateway) mcpServerResourceHandler(serverConfig *catalog.ServerConfig, s
 		span.SetStatus(codes.Ok, "")
 		return result, nil
 	}
+}
+
+// handleOAuth401 checks if a tool result contains OAuth 401 errors and triggers token refresh
+func (g *Gateway) handleOAuth401(ctx context.Context, result *mcp.CallToolResult, serverName string) *mcp.CallToolResult {
+	// Check each content item for OAuth 401 error message
+	for _, content := range result.Content {
+		textContent, ok := content.(*mcp.TextContent)
+		if !ok {
+			continue
+		}
+
+		if isOAuth401Error(textContent.Text) {
+			// Trigger OAuth refresh
+			authClient := desktop.NewAuthClient()
+			_, err := authClient.GetOAuthApp(ctx, serverName)
+			if err != nil {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{
+						&mcp.TextContent{
+							Text: fmt.Sprintf("OAuth token refresh failed for %s: %v", serverName, err),
+						},
+					},
+					IsError: true,
+				}
+			}
+
+			// Return user-friendly message - the notification system will handle reload
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{
+						Text: fmt.Sprintf("OAuth token expired for %s. Token refresh has been triggered - the server will automatically reload with a fresh token. Please retry your request in a few seconds.", serverName),
+					},
+				},
+			}
+		}
+	}
+
+	return nil // No OAuth 401 detected
+}
+
+// isOAuth401Error checks if a text contains OAuth-related 401 unauthorized error messages
+func isOAuth401Error(text string) bool {
+	// Must contain 401 status code
+	if !strings.Contains(text, "401") {
+		return false
+	}
+
+	// Look for common OAuth 401 error patterns
+	return strings.Contains(text, "Unauthorized") ||
+		strings.Contains(text, "unauthorized") ||
+		strings.Contains(text, "Invalid token") ||
+		strings.Contains(text, "Token expired") ||
+		strings.Contains(text, "Access denied")
 }

--- a/pkg/oauth/credhelper.go
+++ b/pkg/oauth/credhelper.go
@@ -36,6 +36,7 @@ func (h *CredentialHelper) GetOAuthToken(ctx context.Context, serverName string)
 	client := desktop.NewAuthClient()
 	dcrClient, err := client.GetDCRClient(ctx, serverName)
 	if err != nil {
+		logf("! Failed to get DCR client for %s: %v", serverName, err)
 		return "", fmt.Errorf("no DCR client found for %s: %w", serverName, err)
 	}
 
@@ -46,8 +47,10 @@ func (h *CredentialHelper) GetOAuthToken(ctx context.Context, serverName string)
 	_, tokenSecret, err := h.credentialHelper.Get(credentialKey)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
+			logf("- OAuth token not found for key: %s", credentialKey)
 			return "", fmt.Errorf("OAuth token not found for %s (key: %s). Run 'docker mcp oauth authorize %s' to authenticate", serverName, credentialKey, serverName)
 		}
+		logf("! Failed to retrieve token from credential helper: %v", err)
 		return "", fmt.Errorf("failed to retrieve OAuth token for %s: %w", serverName, err)
 	}
 

--- a/pkg/oauth/logs.go
+++ b/pkg/oauth/logs.go
@@ -1,0 +1,18 @@
+package oauth
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func log(a ...any) {
+	_, _ = fmt.Fprintln(os.Stderr, a...)
+}
+
+func logf(format string, a ...any) {
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
+	}
+	_, _ = fmt.Fprintf(os.Stderr, format, a...)
+}

--- a/pkg/oauth/notification_monitor.go
+++ b/pkg/oauth/notification_monitor.go
@@ -1,0 +1,240 @@
+package oauth
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+)
+
+// EventType represents the type of OAuth event from Docker Desktop
+type EventType string
+
+const (
+	EventLoginStart    EventType = "login-start"
+	EventCodeReceived  EventType = "code-received"
+	EventLoginSuccess  EventType = "login-success"
+	EventTokenRefresh  EventType = "token-refresh"
+	EventLogoutSuccess EventType = "logout-success"
+	EventError         EventType = "error"
+)
+
+// Event represents a parsed OAuth notification event
+type Event struct {
+	Type     EventType
+	Provider string
+	Message  string
+	Error    string
+}
+
+// NotificationMonitor subscribes to Docker Desktop's OAuth notification stream
+type NotificationMonitor struct {
+	url          string
+	client       *http.Client
+	OnOAuthEvent func(event Event) // Callback for OAuth events
+}
+
+// NewNotificationMonitor creates a new notification monitor
+func NewNotificationMonitor() *NotificationMonitor {
+	// Create HTTP client that uses Docker Desktop's backend Unix socket
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				// Use the same dialing approach as desktop.ClientBackend
+				dialer := net.Dialer{}
+				return dialer.DialContext(ctx, "unix", desktop.Paths().BackendSocket)
+			},
+		},
+	}
+
+	return &NotificationMonitor{
+		url:    "http://localhost/notify/notifications/channel/external-oauth",
+		client: client,
+	}
+}
+
+// Start begins monitoring OAuth notifications from Docker Desktop
+func (m *NotificationMonitor) Start(ctx context.Context) {
+	go m.monitor(ctx)
+}
+
+// monitor runs the main monitoring loop with automatic reconnection
+func (m *NotificationMonitor) monitor(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			log("- OAuth notification monitor shutting down")
+			return
+		default:
+			m.connect(ctx)
+			// Reconnect after 5 seconds on disconnect
+			select {
+			case <-time.After(5 * time.Second):
+				log("- OAuth notification monitor reconnecting...")
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// connect establishes SSE connection and processes events
+func (m *NotificationMonitor) connect(ctx context.Context) {
+	logf("- Connecting to OAuth notification stream at %s", m.url)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, m.url, nil)
+	if err != nil {
+		logf("! Failed to create OAuth notification request: %v", err)
+		return
+	}
+
+	// Set SSE headers
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		logf("! Failed to connect to OAuth notifications: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logf("! OAuth notification stream unexpected status: %d %s", resp.StatusCode, resp.Status)
+		return
+	}
+
+	log("- OAuth notification stream connected")
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			log("- OAuth notification stream stopping")
+			return
+		default:
+		}
+
+		line := scanner.Text()
+
+		// Skip empty lines and SSE comments
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// Docker Desktop only sends data: fields
+		if jsonData, found := strings.CutPrefix(line, "data: "); found {
+			// Skip empty data
+			if jsonData == "" {
+				continue
+			}
+
+			oauthEvent, err := parseOAuthEvent(jsonData)
+			if err != nil {
+				logf("! Failed to parse OAuth event: %v", err)
+				continue
+			}
+
+			m.processOAuthEvent(oauthEvent)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		logf("! OAuth notification connection error: %v", err)
+	} else {
+		log("- OAuth notification stream closed")
+	}
+}
+
+// parseOAuthEvent parses JSON data from Docker Desktop into an Event
+func parseOAuthEvent(jsonData string) (Event, error) {
+	var rawEvent map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &rawEvent); err != nil {
+		return Event{}, fmt.Errorf("failed to parse JSON: %v", err)
+	}
+
+	// Extract operation field (Docker Desktop uses 'operation', not 'event_type')
+	operation, ok := rawEvent["operation"].(string)
+	if !ok {
+		return Event{}, fmt.Errorf("missing operation field")
+	}
+
+	// Remove mcp-oauth- prefix if present
+	eventTypeStr := strings.TrimPrefix(operation, "mcp-oauth-")
+	eventType := EventType(eventTypeStr)
+
+	// Extract message and provider
+	var message string
+	if msg, ok := rawEvent["message"].(string); ok {
+		message = msg
+	}
+
+	provider := extractProviderFromMessage(message)
+
+	// Extract error field if present
+	var errorMsg string
+	if err, ok := rawEvent["error"].(string); ok {
+		errorMsg = err
+	}
+
+	return Event{
+		Type:     eventType,
+		Provider: provider,
+		Message:  message,
+		Error:    errorMsg,
+	}, nil
+}
+
+// processOAuthEvent calls callback for relevant events and logs errors
+func (m *NotificationMonitor) processOAuthEvent(event Event) {
+	// Only log errors and unknown events - let handleOAuthEvent handle success logs
+	switch event.Type {
+	case EventLoginStart, EventCodeReceived:
+		// These are informational events, no callback needed
+	case EventLoginSuccess, EventTokenRefresh, EventLogoutSuccess:
+		// Trigger callback - handler will log details
+		if m.OnOAuthEvent != nil {
+			m.OnOAuthEvent(event)
+		}
+	case EventError:
+		if event.Error != "" {
+			logf("! OAuth error for %s: %s", event.Provider, event.Error)
+		} else {
+			logf("! OAuth error for %s (no details)", event.Provider)
+		}
+	default:
+		logf("! Unknown OAuth event type: %s for %s", event.Type, event.Provider)
+	}
+}
+
+// extractProviderFromMessage extracts provider name from notification message
+// Examples:
+//
+//	"Login successful for linear-remote" -> "linear-remote"
+//	"Successfully logged out of github" -> "github"
+func extractProviderFromMessage(message string) string {
+	// Handle "... for {provider}"
+	if strings.Contains(message, " for ") {
+		parts := strings.Split(message, " for ")
+		if len(parts) >= 2 {
+			return strings.TrimSpace(parts[len(parts)-1])
+		}
+	}
+
+	// Handle "... of {provider}"
+	if strings.Contains(message, " of ") {
+		parts := strings.Split(message, " of ")
+		if len(parts) >= 2 {
+			return strings.TrimSpace(parts[len(parts)-1])
+		}
+	}
+
+	// If no pattern matches, return empty string
+	return ""
+}


### PR DESCRIPTION
**What I did**
- Replace file-based events with real-time Server-Sent Events (SSE) from Docker Desktop's notification system, providing immediate OAuth state synchronization across all MCP Gateway instances.

**Related issue**
The previous file-based OAuth token event approach had several issues:
- **Race conditions**: `registry.yaml` changes could trigger before tokens were stored in credential helper
- **Polling inefficiency**: Required file system watchers and periodic checks
- **Timing issues**: Static delays (200ms) to handle credential store synchronization

**Changes**
## Events Subscribed

| Event Type | Action Taken | Description |
|------------|--------------|-------------|
| `login-success` | **Full reload** | User completed OAuth authorization |
| `token-refresh` | **Full reload** | Docker Desktop refreshed expired token |
| `logout-success` | **Full reload** | User revoked authorization |
| `error` | **Log only** | OAuth flow error (no action taken) |

**Note**: `login-start` and `code-received` are informational events with no action taken.

### Event Processing Flow

When a relevant event is received:

1. **Invalidate Connections**: Close existing OAuth client connections for the provider
   ```go
   g.clientPool.InvalidateOAuthClients(event.Provider)
   ```

2. **Trigger Reload**: If provider is in enabled servers list
   ```go
   if slices.Contains(g.configuration.ServerNames(), event.Provider) {
       // Full reload - same pattern as registry.yaml changes
       g.reloadConfiguration(ctx, g.configuration, nil, nil)
   }
   ```

3. **Logging**: Track event processing and reload status

This follows the **exact same pattern** as `registry.yaml` configuration changes - full reload when server state changes.

### Connection Management

**Connection**:
- Uses same Unix socket dialing as `desktop.ClientBackend`
- HTTP client with custom transport to backend socket

**Reconnection Strategy**:
- Automatic reconnection on disconnect
- 5-second retry interval
- Graceful shutdown on context cancellation

```go
func (m *NotificationMonitor) monitor(ctx context.Context) {
    for {
        select {
        case <-ctx.Done():
            return
        default:
            m.connect(ctx)
            // Reconnect after 5 seconds on disconnect
            select {
            case <-time.After(5 * time.Second):
                log("- OAuth notification monitor reconnecting...")
            case <-ctx.Done():
                return
            }
        }
    }
}
```

### Feature Flag Control

**Requirement**: Only active when `McpOAuthDcrEnabled` feature flag is enabled

```go
if g.McpOAuthDcrEnabled {
    log("- Starting OAuth notification monitor (mcp-oauth-dcr feature enabled)")
    monitor := oauth.NewNotificationMonitor()
    monitor.OnOAuthEvent = func(event oauth.Event) {
        go g.handleOAuthEvent(ctx, event)
    }
    monitor.Start(ctx)
}
```

## Token Refresh Handling

### Proactive Refresh (Initialization)

**Location**: `pkg/mcp/remote.go` in `Initialize()`

Before connecting OAuth DCR servers, trigger refresh check:
```go
if c.config.Spec.OAuth != nil && len(c.config.Spec.OAuth.Providers) > 0 {
    // Trigger token refresh check before fetching token
    authClient := desktop.NewAuthClient()
    authClient.GetOAuthApp(ctx, c.config.Name)

    token := c.getOAuthToken(ctx)
    // ...
}
```

**Purpose**: Ensure fresh tokens at server startup (handles expired tokens)

### Reactive Refresh (401 Handling)

**Location**: `pkg/gateway/handlers.go` in `mcpServerToolHandler()`

After tool execution, check for OAuth 401 errors:
```go
if err == nil && result != nil && result.IsError &&
   serverConfig.Spec.OAuth != nil && len(serverConfig.Spec.OAuth.Providers) > 0 {
    if oauthResult := g.handleOAuth401(ctx, result, serverConfig.Name); oauthResult != nil {
        return oauthResult, nil
    }
}
```

**401 Detection Patterns**:
- Must contain `"401"` status code
- Plus OAuth-specific indicators: `"Unauthorized"`, `"Invalid token"`, `"Token expired"`, `"Access denied"`

**Refresh Flow**:
1. Detect 401 in tool response
2. Call `GetOAuthApp()` to trigger Docker Desktop token refresh
3. Return user-friendly message about automatic reload
4. Docker Desktop sends `token-refresh` notification
5. Gateway receives notification and reloads server with fresh token

### GetOAuthApp API

**New Method**: `pkg/desktop/auth.go`
```go
func (c *Tools) GetOAuthApp(ctx context.Context, app string) (*OAuthApp, error) {
    var result OAuthApp
    err := c.rawClient.Get(ctx, fmt.Sprintf("/apps/%v", app), &result)
    return &result, err
}
```

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**