### PR TITLE
update to go sdk 1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.3
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-containerregistry v0.20.6
-	github.com/google/jsonschema-go v0.2.0
+	github.com/google/jsonschema-go v0.3.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mikefarah/yq/v4 v4.45.4
-	github.com/modelcontextprotocol/go-sdk v0.2.0
+	github.com/modelcontextprotocol/go-sdk v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
@@ -171,5 +171,3 @@ require (
 	gotest.tools/v3 v3.5.2 // indirect
 	k8s.io/client-go v0.33.1 // indirect
 )
-
-replace github.com/modelcontextprotocol/go-sdk => github.com/slimslenderslacks/go-sdk v0.0.0-20250822220738-3d404486ee12

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.2.0 h1:Uh19091iHC56//WOsAd1oRg6yy1P9BpSvpjOL6RcjLQ=
-github.com/google/jsonschema-go v0.2.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
@@ -502,6 +502,8 @@ github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7z
 github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.0.0 h1:Z4MSjLi38bTgLrd/LjSmofqRqyBiVKRyQSJgw8q8V74=
+github.com/modelcontextprotocol/go-sdk v1.0.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -646,8 +648,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
-github.com/slimslenderslacks/go-sdk v0.0.0-20250822220738-3d404486ee12 h1:8TzpeZgdQM8jeeKragiJIIQ/kutnyoz9Wu+cSdn0EXE=
-github.com/slimslenderslacks/go-sdk v0.0.0-20250822220738-3d404486ee12/go.mod h1:AFug448GknnlU68RVJpdQG3RDvmJrrZdrEVR5j1zfPo=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -159,20 +159,23 @@ func (g *Gateway) listCapabilities(ctx context.Context, configuration Configurat
 					continue
 				}
 
-				mcpTool := mcp.Tool{
-					Name:        tool.Name,
-					Description: tool.Description,
-					InputSchema: &jsonschema.Schema{},
-				}
+				// Create schema with proper type
+				schema := &jsonschema.Schema{}
 				// TODO: Properly convert tool.Parameters to jsonschema.Schema
 				// For now, we'll create a simple schema structure
 				if len(tool.Parameters.Properties) == 0 {
-					mcpTool.InputSchema.Type = "object"
+					schema.Type = "object"
 				} else {
-					mcpTool.InputSchema.Type = tool.Parameters.Type
+					schema.Type = tool.Parameters.Type
 					// Note: tool.Parameters.Properties.ToMap() returns map[string]any
 					// but we need map[string]*jsonschema.Schema
 					// This is a complex conversion that needs proper implementation
+				}
+
+				mcpTool := mcp.Tool{
+					Name:        tool.Name,
+					Description: tool.Description,
+					InputSchema: schema,
 				}
 
 				capabilities.Tools = append(capabilities.Tools, ToolRegistration{

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -23,21 +23,25 @@ type Capabilities struct {
 }
 
 type ToolRegistration struct {
-	Tool    *mcp.Tool
-	Handler mcp.ToolHandler
+	ServerName string
+	Tool       *mcp.Tool
+	Handler    mcp.ToolHandler
 }
 
 type PromptRegistration struct {
-	Prompt  *mcp.Prompt
-	Handler mcp.PromptHandler
+	ServerName string
+	Prompt     *mcp.Prompt
+	Handler    mcp.PromptHandler
 }
 
 type ResourceRegistration struct {
-	Resource *mcp.Resource
-	Handler  mcp.ResourceHandler
+	ServerName string
+	Resource   *mcp.Resource
+	Handler    mcp.ResourceHandler
 }
 
 type ResourceTemplateRegistration struct {
+	ServerName       string
 	ResourceTemplate mcp.ResourceTemplate
 	Handler          mcp.ResourceHandler
 }
@@ -81,8 +85,9 @@ func (g *Gateway) listCapabilities(ctx context.Context, configuration Configurat
 							continue
 						}
 						capabilities.Tools = append(capabilities.Tools, ToolRegistration{
-							Tool:    tool,
-							Handler: g.mcpServerToolHandler(serverConfig, g.mcpServer, tool.Annotations),
+							ServerName: serverConfig.Name,
+							Tool:       tool,
+							Handler:    g.mcpServerToolHandler(serverConfig, g.mcpServer, tool.Annotations),
 						})
 					}
 				}
@@ -94,8 +99,9 @@ func (g *Gateway) listCapabilities(ctx context.Context, configuration Configurat
 
 					for _, prompt := range prompts.Prompts {
 						capabilities.Prompts = append(capabilities.Prompts, PromptRegistration{
-							Prompt:  prompt,
-							Handler: g.mcpServerPromptHandler(serverConfig, g.mcpServer),
+							ServerName: serverConfig.Name,
+							Prompt:     prompt,
+							Handler:    g.mcpServerPromptHandler(serverConfig, g.mcpServer),
 						})
 					}
 				}
@@ -107,8 +113,9 @@ func (g *Gateway) listCapabilities(ctx context.Context, configuration Configurat
 
 					for _, resource := range resources.Resources {
 						capabilities.Resources = append(capabilities.Resources, ResourceRegistration{
-							Resource: resource,
-							Handler:  g.mcpServerResourceHandler(serverConfig, g.mcpServer),
+							ServerName: serverConfig.Name,
+							Resource:   resource,
+							Handler:    g.mcpServerResourceHandler(serverConfig, g.mcpServer),
 						})
 					}
 				}
@@ -120,6 +127,7 @@ func (g *Gateway) listCapabilities(ctx context.Context, configuration Configurat
 
 					for _, resourceTemplate := range resourceTemplates.ResourceTemplates {
 						capabilities.ResourceTemplates = append(capabilities.ResourceTemplates, ResourceTemplateRegistration{
+							ServerName:       serverConfig.Name,
 							ResourceTemplate: *resourceTemplate,
 							Handler:          g.mcpServerResourceHandler(serverConfig, g.mcpServer),
 						})

--- a/pkg/gateway/transport.go
+++ b/pkg/gateway/transport.go
@@ -24,7 +24,7 @@ func (g *Gateway) startSseServer(ctx context.Context, ln net.Listener) error {
 	mux.Handle("/", redirectHandler("/sse"))
 	sseHandler := mcp.NewSSEHandler(func(_ *http.Request) *mcp.Server {
 		return g.mcpServer
-	})
+	}, nil)
 	mux.Handle("/sse", sseHandler)
 	httpServer := &http.Server{
 		Handler: mux,

--- a/pkg/mcp/mcp_client.go
+++ b/pkg/mcp/mcp_client.go
@@ -17,10 +17,10 @@ type Client interface {
 
 // CapabilityRefresher interface allows the notification handlers to refresh server capabilities
 type CapabilityRefresher interface {
-	RefreshCapabilities(ctx context.Context, server *mcp.Server, serverSession *mcp.ServerSession) error
+	RefreshCapabilities(ctx context.Context, server *mcp.Server, serverSession *mcp.ServerSession, serverName string) error
 }
 
-func notifications(serverSession *mcp.ServerSession, server *mcp.Server, refresher CapabilityRefresher) *mcp.ClientOptions {
+func notifications(serverName string, serverSession *mcp.ServerSession, server *mcp.Server, refresher CapabilityRefresher) *mcp.ClientOptions {
 	return &mcp.ClientOptions{
 		ResourceUpdatedHandler: func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
 			if server != nil {
@@ -33,17 +33,17 @@ func notifications(serverSession *mcp.ServerSession, server *mcp.Server, refresh
 		},
 		ToolListChangedHandler: func(ctx context.Context, _ *mcp.ToolListChangedRequest) {
 			if refresher != nil && server != nil && serverSession != nil {
-				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
+				_ = refresher.RefreshCapabilities(ctx, server, serverSession, serverName)
 			}
 		},
 		ResourceListChangedHandler: func(ctx context.Context, _ *mcp.ResourceListChangedRequest) {
 			if refresher != nil && server != nil && serverSession != nil {
-				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
+				_ = refresher.RefreshCapabilities(ctx, server, serverSession, serverName)
 			}
 		},
 		PromptListChangedHandler: func(ctx context.Context, _ *mcp.PromptListChangedRequest) {
 			if refresher != nil && server != nil && serverSession != nil {
-				_ = refresher.RefreshCapabilities(ctx, server, serverSession)
+				_ = refresher.RefreshCapabilities(ctx, server, serverSession, serverName)
 			}
 		},
 		ProgressNotificationHandler: func(ctx context.Context, req *mcp.ProgressNotificationClientRequest) {

--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -48,7 +48,7 @@ func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParams
 	c.client = mcp.NewClient(&mcp.Implementation{
 		Name:    "docker-mcp-gateway",
 		Version: "1.0.0",
-	}, notifications(ss, server, refresher))
+	}, notifications(c.name, ss, server, refresher))
 
 	c.client.AddRoots(c.roots...)
 

--- a/test/servers/elicit/server.go
+++ b/test/servers/elicit/server.go
@@ -64,14 +64,15 @@ func server() {
 			log.Printf("Received arguments: %T = %+v", req.Params.Arguments, req.Params.Arguments)
 
 			var args map[string]any
-			switch v := req.Params.Arguments.(type) {
-			case map[string]any:
-				args = v
-			case json.RawMessage:
-				if err := json.Unmarshal(v, &args); err != nil {
+			if len(req.Params.Arguments) > 0 {
+				if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
 					return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("failed to unmarshal arguments: %v", err)}}}, nil
 				}
-			default:
+			} else {
+				args = make(map[string]any)
+			}
+
+			if args == nil {
 				return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("arguments must be an object, got %T: %+v", req.Params.Arguments, req.Params.Arguments)}}}, nil
 			}
 

--- a/vendor/github.com/google/jsonschema-go/LICENSE
+++ b/vendor/github.com/google/jsonschema-go/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Go MCP SDK Authors
+Copyright (c) 2025 JSON Schema Go Project Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/github.com/google/jsonschema-go/jsonschema/annotations.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/annotations.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/google/jsonschema-go/jsonschema/doc.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/google/jsonschema-go/jsonschema/infer.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/infer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-// ForOptions are options for the [For] function.
+// ForOptions are options for the [For] and [ForType] functions.
 type ForOptions struct {
 	// If IgnoreInvalidTypes is true, fields that can't be represented as a JSON
 	// Schema are ignored instead of causing an error.
@@ -26,12 +26,12 @@ type ForOptions struct {
 	IgnoreInvalidTypes bool
 
 	// TypeSchemas maps types to their schemas.
-	// If [For] encounters a type equal to a type of a key in this map, the
+	// If [For] encounters a type that is a key in this map, the
 	// corresponding value is used as the resulting schema (after cloning to
 	// ensure uniqueness).
 	// Types in this map override the default translations, as described
 	// in [For]'s documentation.
-	TypeSchemas map[any]*Schema
+	TypeSchemas map[reflect.Type]*Schema
 }
 
 // For constructs a JSON schema object for the given type argument.
@@ -78,9 +78,7 @@ func For[T any](opts *ForOptions) (*Schema, error) {
 	}
 	schemas := maps.Clone(initialSchemaMap)
 	// Add types from the options. They override the default ones.
-	for v, s := range opts.TypeSchemas {
-		schemas[reflect.TypeOf(v)] = s
-	}
+	maps.Copy(schemas, opts.TypeSchemas)
 	s, err := forType(reflect.TypeFor[T](), map[reflect.Type]bool{}, opts.IgnoreInvalidTypes, schemas)
 	if err != nil {
 		var z T
@@ -93,9 +91,7 @@ func For[T any](opts *ForOptions) (*Schema, error) {
 func ForType(t reflect.Type, opts *ForOptions) (*Schema, error) {
 	schemas := maps.Clone(initialSchemaMap)
 	// Add types from the options. They override the default ones.
-	for v, s := range opts.TypeSchemas {
-		schemas[reflect.TypeOf(v)] = s
-	}
+	maps.Copy(schemas, opts.TypeSchemas)
 	s, err := forType(t, map[reflect.Type]bool{}, opts.IgnoreInvalidTypes, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("ForType(%s): %w", t, err)
@@ -187,9 +183,11 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		s.Type = "object"
 		// no additional properties are allowed
 		s.AdditionalProperties = falseSchema()
+		for _, field := range reflect.VisibleFields(t) {
+			if field.Anonymous {
+				continue
+			}
 
-		for i := range t.NumField() {
-			field := t.Field(i)
 			info := fieldJSONInfo(field)
 			if info.omit {
 				continue
@@ -231,7 +229,6 @@ func forType(t reflect.Type, seen map[reflect.Type]bool, ignore bool, schemas ma
 		s.Types = []string{"null", s.Type}
 		s.Type = ""
 	}
-	schemas[t] = s
 	return s, nil
 }
 

--- a/vendor/github.com/google/jsonschema-go/jsonschema/json_pointer.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/json_pointer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/google/jsonschema-go/jsonschema/resolve.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/resolve.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
@@ -114,8 +114,8 @@ type ResolveOptions struct {
 	Loader Loader
 	// ValidateDefaults determines whether to validate values of "default" keywords
 	// against their schemas.
-	// The [JSON Schema specification] does not require this, but it is
-	// recommended if defaults will be used.
+	// The [JSON Schema specification] does not require this, but it is recommended
+	// if defaults will be used.
 	//
 	// [JSON Schema specification]: https://json-schema.org/understanding-json-schema/reference/annotations
 	ValidateDefaults bool

--- a/vendor/github.com/google/jsonschema-go/jsonschema/schema.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
@@ -20,8 +20,8 @@ import (
 // A Schema is a JSON schema object.
 // It corresponds to the 2020-12 draft, as described in https://json-schema.org/draft/2020-12,
 // specifically:
-// - https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01
-// - https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01
+//   - https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01
+//   - https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01
 //
 // A Schema value may have non-zero values for more than one field:
 // all relevant non-zero fields are used for validation.
@@ -152,7 +152,7 @@ func (s *Schema) String() string {
 
 // CloneSchemas returns a copy of s.
 // The copy is shallow except for sub-schemas, which are themelves copied with CloneSchemas.
-// This allows both s and s.CloneSchemas() to appear as sub-schemas in the same parent.
+// This allows both s and s.CloneSchemas() to appear as sub-schemas of the same parent.
 func (s *Schema) CloneSchemas() *Schema {
 	if s == nil {
 		return nil

--- a/vendor/github.com/google/jsonschema-go/jsonschema/util.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/util.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/google/jsonschema-go/jsonschema/validate.go
+++ b/vendor/github.com/google/jsonschema-go/jsonschema/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Copyright 2025 The JSON Schema Go Project Authors. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
@@ -6,6 +6,7 @@ package jsonschema
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/maphash"
 	"iter"
@@ -399,11 +400,13 @@ func (st *state) validate(instance reflect.Value, schema *Schema, callerAnns *an
 
 	// objects
 	// https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2
-	if instance.Kind() == reflect.Map || instance.Kind() == reflect.Struct {
-		if instance.Kind() == reflect.Map {
-			if kt := instance.Type().Key(); kt.Kind() != reflect.String {
-				return fmt.Errorf("map key type %s is not a string", kt)
-			}
+	// Validating structs is problematic. See https://github.com/google/jsonschema-go/issues/23.
+	if instance.Kind() == reflect.Struct {
+		return errors.New("cannot validate against a struct; see https://github.com/google/jsonschema-go/issues/23 for details")
+	}
+	if instance.Kind() == reflect.Map {
+		if kt := instance.Type().Key(); kt.Kind() != reflect.String {
+			return fmt.Errorf("map key type %s is not a string", kt)
 		}
 		// Track the evaluated properties for just this schema, to support additionalProperties.
 		// If we used anns here, then we'd be including properties evaluated in subschemas
@@ -440,13 +443,35 @@ func (st *state) validate(instance reflect.Value, schema *Schema, callerAnns *an
 			}
 		}
 		if schema.AdditionalProperties != nil {
-			// Apply to all properties not handled above.
-			for prop, val := range properties(instance) {
-				if !evalProps[prop] {
-					if err := st.validate(val, schema.AdditionalProperties, nil); err != nil {
-						return err
+			// Special case for a better error message when additional properties is
+			// 'falsy'
+			//
+			// If additionalProperties is {"not":{}} (which is how we
+			// unmarshal "false"), we can produce a better error message that
+			// summarizes all the extra properties. Otherwise, we fall back to the
+			// default validation.
+			//
+			// Note: this is much faster than comparing with falseSchema using Equal.
+			isFalsy := schema.AdditionalProperties.Not != nil && reflect.ValueOf(*schema.AdditionalProperties.Not).IsZero()
+			if isFalsy {
+				var disallowed []string
+				for prop := range properties(instance) {
+					if !evalProps[prop] {
+						disallowed = append(disallowed, prop)
 					}
-					evalProps[prop] = true
+				}
+				if len(disallowed) > 0 {
+					return fmt.Errorf("unexpected additional properties %q", disallowed)
+				}
+			} else {
+				// Apply to all properties not handled above.
+				for prop, val := range properties(instance) {
+					if !evalProps[prop] {
+						if err := st.validate(val, schema.AdditionalProperties, nil); err != nil {
+							return err
+						}
+						evalProps[prop] = true
+					}
 				}
 			}
 		}
@@ -599,11 +624,10 @@ func (st *state) resolveDynamicRef(schema *Schema) (*Schema, error) {
 //
 // It is recommended to first call Resolve with a ValidateDefaults option of true,
 // then call this method, and lastly call Validate.
-//
-// TODO(jba): consider what defaults on top-level or array instances might mean.
-// TODO(jba): follow $ref and $dynamicRef
-// TODO(jba): apply defaults on sub-schemas to corresponding sub-instances.
 func (rs *Resolved) ApplyDefaults(instancep any) error {
+	// TODO(jba): consider what defaults on top-level or array instances might mean.
+	// TODO(jba): follow $ref and $dynamicRef
+	// TODO(jba): apply defaults on sub-schemas to corresponding sub-instances.
 	st := &state{rs: rs}
 	return st.applyDefaults(reflect.ValueOf(instancep), rs.root)
 }
@@ -615,6 +639,10 @@ func (st *state) applyDefaults(instancep reflect.Value, schema *Schema) (err err
 
 	schemaInfo := st.rs.resolvedInfos[schema]
 	instance := instancep.Elem()
+	if instance.Kind() == reflect.Interface && instance.IsValid() {
+		// If we unmarshalled into 'any', the default object unmarshalling will be map[string]any.
+		instance = instance.Elem()
+	}
 	if instance.Kind() == reflect.Map || instance.Kind() == reflect.Struct {
 		if instance.Kind() == reflect.Map {
 			if kt := instance.Type().Key(); kt.Kind() != reflect.String {
@@ -748,6 +776,9 @@ func structPropertiesOf(t reflect.Type) propertyMap {
 	}
 	props := map[string]reflect.StructField{}
 	for _, sf := range reflect.VisibleFields(t) {
+		if sf.Anonymous {
+			continue
+		}
 		info := fieldJSONInfo(sf)
 		if !info.omit {
 			props[info.name] = sf

--- a/vendor/github.com/modelcontextprotocol/go-sdk/auth/auth.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/auth/auth.go
@@ -24,9 +24,13 @@ type TokenInfo struct {
 // The error that a TokenVerifier should return if the token cannot be verified.
 var ErrInvalidToken = errors.New("invalid token")
 
+// The error that a TokenVerifier should return for OAuth-specific protocol errors.
+var ErrOAuth = errors.New("oauth error")
+
 // A TokenVerifier checks the validity of a bearer token, and extracts information
 // from it. If verification fails, it should return an error that unwraps to ErrInvalidToken.
-type TokenVerifier func(ctx context.Context, token string) (*TokenInfo, error)
+// The HTTP request is provided in case verifying the token involves checking it.
+type TokenVerifier func(ctx context.Context, token string, req *http.Request) (*TokenInfo, error)
 
 // RequireBearerTokenOptions are options for [RequireBearerToken].
 type RequireBearerTokenOptions struct {
@@ -59,7 +63,7 @@ func RequireBearerToken(verifier TokenVerifier, opts *RequireBearerTokenOptions)
 
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			tokenInfo, errmsg, code := verify(r.Context(), verifier, opts, r.Header.Get("Authorization"))
+			tokenInfo, errmsg, code := verify(r, verifier, opts)
 			if code != 0 {
 				if code == http.StatusUnauthorized || code == http.StatusForbidden {
 					if opts != nil && opts.ResourceMetadataURL != "" {
@@ -75,22 +79,23 @@ func RequireBearerToken(verifier TokenVerifier, opts *RequireBearerTokenOptions)
 	}
 }
 
-func verify(ctx context.Context, verifier TokenVerifier, opts *RequireBearerTokenOptions, authHeader string) (_ *TokenInfo, errmsg string, code int) {
+func verify(req *http.Request, verifier TokenVerifier, opts *RequireBearerTokenOptions) (_ *TokenInfo, errmsg string, code int) {
 	// Extract bearer token.
+	authHeader := req.Header.Get("Authorization")
 	fields := strings.Fields(authHeader)
 	if len(fields) != 2 || strings.ToLower(fields[0]) != "bearer" {
 		return nil, "no bearer token", http.StatusUnauthorized
 	}
 
 	// Verify the token and get information from it.
-	tokenInfo, err := verifier(ctx, fields[1])
+	tokenInfo, err := verifier(req.Context(), fields[1], req)
 	if err != nil {
 		if errors.Is(err, ErrInvalidToken) {
 			return nil, err.Error(), http.StatusUnauthorized
 		}
-		// TODO: the TS SDK distinguishes another error, OAuthError, and returns a 400.
-		// Investigate how that works.
-		// See typescript-sdk/src/server/auth/middleware/bearerAuth.ts.
+		if errors.Is(err, ErrOAuth) {
+			return nil, err.Error(), http.StatusBadRequest
+		}
 		return nil, err.Error(), http.StatusInternalServerError
 	}
 

--- a/vendor/github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2/messages.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2/messages.go
@@ -16,8 +16,8 @@ type ID struct {
 	value any
 }
 
-// MakeID coerces the given Go value to an ID. The value is assumed to be the
-// default JSON marshaling of a Request identifier -- nil, float64, or string.
+// MakeID coerces the given Go value to an ID. The value should be the
+// default JSON marshaling of a Request identifier: nil, float64, or string.
 //
 // Returns an error if the value type was not a valid Request ID type.
 //

--- a/vendor/github.com/modelcontextprotocol/go-sdk/jsonrpc/jsonrpc.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/jsonrpc/jsonrpc.go
@@ -19,8 +19,8 @@ type (
 	Response = jsonrpc2.Response
 )
 
-// MakeID coerces the given Go value to an ID. The value is assumed to be the
-// default JSON marshaling of a Request identifier -- nil, float64, or string.
+// MakeID coerces the given Go value to an ID. The value should be the
+// default JSON marshaling of a Request identifier: nil, float64, or string.
 //
 // Returns an error if the value type was not a valid Request ID type.
 func MakeID(v any) (ID, error) {

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/client.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/client.go
@@ -55,11 +55,15 @@ func NewClient(impl *Implementation, opts *ClientOptions) *Client {
 
 // ClientOptions configures the behavior of the client.
 type ClientOptions struct {
-	// Handler for sampling.
-	// Called when a server calls CreateMessage.
+	// CreateMessageHandler handles incoming requests for sampling/createMessage.
+	//
+	// Setting CreateMessageHandler to a non-nil value causes the client to
+	// advertise the sampling capability.
 	CreateMessageHandler func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error)
-	// Handler for elicitation.
-	// Called when a server requests user input via Elicit.
+	// ElicitationHandler handles incoming requests for elicitation/create.
+	//
+	// Setting ElicitationHandler to a non-nil value causes the client to
+	// advertise the elicitation capability.
 	ElicitationHandler func(context.Context, *ElicitRequest) (*ElicitResult, error)
 	// Handlers for notifications from the server.
 	ToolListChangedHandler      func(context.Context, *ToolListChangedRequest)
@@ -123,7 +127,7 @@ func (c *Client) capabilities() *ClientCapabilities {
 }
 
 // Connect begins an MCP session by connecting to a server over the given
-// transport, and initializing the session.
+// transport. The resulting session is initialized, and ready to use.
 //
 // Typically, it is the responsibility of the client to close the connection
 // when it is no longer needed. However, if the connection is closed by the
@@ -154,7 +158,7 @@ func (c *Client) Connect(ctx context.Context, t Transport, _ *ClientSessionOptio
 		hc.sessionUpdated(cs.state)
 	}
 	req2 := &initializedClientRequest{Session: cs, Params: &InitializedParams{}}
-	if err := HandleNotify(ctx, notificationInitialized, req2); err != nil {
+	if err := handleNotify(ctx, notificationInitialized, req2); err != nil {
 		_ = cs.Close()
 		return nil, err
 	}
@@ -279,7 +283,7 @@ func (c *Client) listRoots(_ context.Context, req *ListRootsRequest) (*ListRoots
 func (c *Client) createMessage(ctx context.Context, req *CreateMessageRequest) (*CreateMessageResult, error) {
 	if c.opts.CreateMessageHandler == nil {
 		// TODO: wrap or annotate this error? Pick a standard code?
-		return nil, jsonrpc2.NewError(CodeUnsupportedMethod, "client does not support CreateMessage")
+		return nil, jsonrpc2.NewError(codeUnsupportedMethod, "client does not support CreateMessage")
 	}
 	return c.opts.CreateMessageHandler(ctx, req)
 }
@@ -287,12 +291,13 @@ func (c *Client) createMessage(ctx context.Context, req *CreateMessageRequest) (
 func (c *Client) elicit(ctx context.Context, req *ElicitRequest) (*ElicitResult, error) {
 	if c.opts.ElicitationHandler == nil {
 		// TODO: wrap or annotate this error? Pick a standard code?
-		return nil, jsonrpc2.NewError(CodeUnsupportedMethod, "client does not support elicitation")
+		return nil, jsonrpc2.NewError(codeUnsupportedMethod, "client does not support elicitation")
 	}
 
 	// Validate that the requested schema only contains top-level properties without nesting
-	if err := validateElicitSchema(req.Params.RequestedSchema); err != nil {
-		return nil, jsonrpc2.NewError(CodeInvalidParams, err.Error())
+	schema, err := validateElicitSchema(req.Params.RequestedSchema)
+	if err != nil {
+		return nil, jsonrpc2.NewError(codeInvalidParams, err.Error())
 	}
 
 	res, err := c.opts.ElicitationHandler(ctx, req)
@@ -301,14 +306,17 @@ func (c *Client) elicit(ctx context.Context, req *ElicitRequest) (*ElicitResult,
 	}
 
 	// Validate elicitation result content against requested schema
-	if req.Params.RequestedSchema != nil && res.Content != nil {
-		resolved, err := req.Params.RequestedSchema.Resolve(nil)
+	if schema != nil && res.Content != nil {
+		// TODO: is this the correct behavior if validation fails?
+		// It isn't the *server's* params that are invalid, so why would we return
+		// this code to the server?
+		resolved, err := schema.Resolve(nil)
 		if err != nil {
-			return nil, jsonrpc2.NewError(CodeInvalidParams, fmt.Sprintf("failed to resolve requested schema: %v", err))
+			return nil, jsonrpc2.NewError(codeInvalidParams, fmt.Sprintf("failed to resolve requested schema: %v", err))
 		}
 
 		if err := resolved.Validate(res.Content); err != nil {
-			return nil, jsonrpc2.NewError(CodeInvalidParams, fmt.Sprintf("elicitation result content does not match requested schema: %v", err))
+			return nil, jsonrpc2.NewError(codeInvalidParams, fmt.Sprintf("elicitation result content does not match requested schema: %v", err))
 		}
 	}
 
@@ -317,14 +325,19 @@ func (c *Client) elicit(ctx context.Context, req *ElicitRequest) (*ElicitResult,
 
 // validateElicitSchema validates that the schema conforms to MCP elicitation schema requirements.
 // Per the MCP specification, elicitation schemas are limited to flat objects with primitive properties only.
-func validateElicitSchema(schema *jsonschema.Schema) error {
-	if schema == nil {
-		return nil // nil schema is allowed
+func validateElicitSchema(wireSchema any) (*jsonschema.Schema, error) {
+	if wireSchema == nil {
+		return nil, nil // nil schema is allowed
+	}
+
+	var schema *jsonschema.Schema
+	if err := remarshal(wireSchema, &schema); err != nil {
+		return nil, err
 	}
 
 	// The root schema must be of type "object" if specified
 	if schema.Type != "" && schema.Type != "object" {
-		return fmt.Errorf("elicit schema must be of type 'object', got %q", schema.Type)
+		return nil, fmt.Errorf("elicit schema must be of type 'object', got %q", schema.Type)
 	}
 
 	// Check if the schema has properties
@@ -335,12 +348,12 @@ func validateElicitSchema(schema *jsonschema.Schema) error {
 			}
 
 			if err := validateElicitProperty(propName, propSchema); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
-	return nil
+	return schema, nil
 }
 
 // validateElicitProperty validates a single property in an elicitation schema.
@@ -376,7 +389,7 @@ func validateElicitStringProperty(propName string, propSchema *jsonschema.Schema
 		if propSchema.Extra != nil {
 			if enumNamesRaw, exists := propSchema.Extra["enumNames"]; exists {
 				// Type check enumNames - should be a slice
-				if enumNamesSlice, ok := enumNamesRaw.([]interface{}); ok {
+				if enumNamesSlice, ok := enumNamesRaw.([]any); ok {
 					if len(enumNamesSlice) != len(propSchema.Enum) {
 						return fmt.Errorf("elicit schema property %q has %d enum values but %d enumNames, they must match", propName, len(propSchema.Enum), len(enumNamesSlice))
 					}
@@ -564,8 +577,9 @@ func (cs *ClientSession) ListTools(ctx context.Context, params *ListToolsParams)
 	return handleSend[*ListToolsResult](ctx, methodListTools, newClientRequest(cs, orZero[Params](params)))
 }
 
-// CallTool calls the tool with the given name and arguments.
-// The arguments can be any value that marshals into a JSON object.
+// CallTool calls the tool with the given parameters.
+//
+// The params.Arguments can be any value that marshals into a JSON object.
 func (cs *ClientSession) CallTool(ctx context.Context, params *CallToolParams) (*CallToolResult, error) {
 	if params == nil {
 		params = new(CallToolParams)
@@ -660,9 +674,9 @@ func (cs *ClientSession) callProgressNotificationHandler(ctx context.Context, pa
 // NotifyProgress sends a progress notification from the client to the server
 // associated with this session.
 // This can be used if the client is performing a long-running task that was
-// initiated by the server
+// initiated by the server.
 func (cs *ClientSession) NotifyProgress(ctx context.Context, params *ProgressNotificationParams) error {
-	return HandleNotify(ctx, notificationProgress, newClientRequest(cs, orZero[Params](params)))
+	return handleNotify(ctx, notificationProgress, newClientRequest(cs, orZero[Params](params)))
 }
 
 // Tools provides an iterator for all tools available on the server,
@@ -693,7 +707,7 @@ func (cs *ClientSession) Resources(ctx context.Context, params *ListResourcesPar
 
 // ResourceTemplates provides an iterator for all resource templates available on the server,
 // automatically fetching pages and managing cursors.
-// The `params` argument can set the initial cursor.
+// The params argument can set the initial cursor.
 // Iteration stops at the first encountered error, which will be yielded.
 func (cs *ClientSession) ResourceTemplates(ctx context.Context, params *ListResourceTemplatesParams) iter.Seq2[*ResourceTemplate, error] {
 	if params == nil {

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/content.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/content.go
@@ -189,7 +189,7 @@ type ResourceContents struct {
 	Meta     Meta   `json:"_meta,omitempty"`
 }
 
-func (r ResourceContents) MarshalJSON() ([]byte, error) {
+func (r *ResourceContents) MarshalJSON() ([]byte, error) {
 	// If we could assume Go 1.24, we could use omitzero for Blob and avoid this method.
 	if r.URI == "" {
 		return nil, errors.New("ResourceContents missing URI")
@@ -197,7 +197,7 @@ func (r ResourceContents) MarshalJSON() ([]byte, error) {
 	if r.Blob == nil {
 		// Text. Marshal normally.
 		type wireResourceContents ResourceContents // (lacks MarshalJSON method)
-		return json.Marshal((wireResourceContents)(r))
+		return json.Marshal((wireResourceContents)(*r))
 	}
 	// Blob.
 	if r.Text != "" {

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/logging.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/logging.go
@@ -70,6 +70,7 @@ type LoggingHandlerOptions struct {
 	// The value for the "logger" field of logging notifications.
 	LoggerName string
 	// Limits the rate at which log messages are sent.
+	// Excess messages are dropped.
 	// If zero, there is no rate limiting.
 	MinInterval time.Duration
 }

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/mcp.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/mcp.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../internal/readme/build.sh
-
 // The mcp package provides an SDK for writing model context protocol clients
 // and servers.
 //
@@ -82,9 +80,9 @@
 // validated. As a special case, if the output type is 'any', no output schema
 // is generated.
 //
-//	func double(_ context.Context, _ *mcp.CallToolRequest, in In) (*mcp.CallToolResponse, Out, error) {
+//	func double(_ context.Context, _ *mcp.CallToolRequest, in In) (*mcp.CallToolResult, Out, error) {
 //		return nil, Out{Answer: 2*in.Number}, nil
 //	}
 //	...
-//	mcp.AddTool(&mcp.Tool{Name: "double", Description: "double a number"}, double)
+//	mcp.AddTool(server, &mcp.Tool{Name: "double"}, double)
 package mcp

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/protocol.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/protocol.go
@@ -13,12 +13,10 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // Optional annotations for the client. The client can use annotations to inform
-// how objects are used or displayed
+// how objects are used or displayed.
 type Annotations struct {
 	// Describes who the intended customer of this object or data is.
 	//
@@ -40,54 +38,96 @@ type Annotations struct {
 	Priority float64 `json:"priority,omitempty"`
 }
 
+// CallToolParams is used by clients to call a tool.
 type CallToolParams struct {
+	// Meta is reserved by the protocol to allow clients and servers to
+	// attach additional metadata to their responses.
+	Meta `json:"_meta,omitempty"`
+	// Name is the name of the tool to call.
+	Name string `json:"name"`
+	// Arguments holds the tool arguments. It can hold any value that can be
+	// marshaled to JSON.
+	Arguments any `json:"arguments,omitempty"`
+}
+
+// CallToolParamsRaw is passed to tool handlers on the server. Its arguments
+// are not yet unmarshaled (hence "raw"), so that the handlers can perform
+// unmarshaling themselves.
+type CallToolParamsRaw struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
-	Meta      `json:"_meta,omitempty"`
-	Name      string `json:"name"`
-	Arguments any    `json:"arguments,omitempty"`
+	Meta `json:"_meta,omitempty"`
+	// Name is the name of the tool being called.
+	Name string `json:"name"`
+	// Arguments is the raw arguments received over the wire from the client. It
+	// is the responsibility of the tool handler to unmarshal and validate the
+	// Arguments (see [AddTool]).
+	Arguments json.RawMessage `json:"arguments,omitempty"`
 }
 
-// When unmarshalling CallToolParams on the server side, we need to delay unmarshaling of the arguments.
-func (c *CallToolParams) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Meta         `json:"_meta,omitempty"`
-		Name         string          `json:"name"`
-		RawArguments json.RawMessage `json:"arguments,omitempty"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	c.Meta = raw.Meta
-	c.Name = raw.Name
-	c.Arguments = raw.RawArguments
-	return nil
-}
-
-// The server's response to a tool call.
+// A CallToolResult is the server's response to a tool call.
+//
+// The [ToolHandler] and [ToolHandlerFor] handler functions return this result,
+// though [ToolHandlerFor] populates much of it automatically as documented at
+// each field.
 type CallToolResult struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
 	Meta `json:"_meta,omitempty"`
+
 	// A list of content objects that represent the unstructured result of the tool
 	// call.
+	//
+	// When using a [ToolHandlerFor] with structured output, if Content is unset
+	// it will be populated with JSON text content corresponding to the
+	// structured output value.
 	Content []Content `json:"content"`
-	// An optional JSON object that represents the structured result of the tool
-	// call.
+
+	// StructuredContent is an optional value that represents the structured
+	// result of the tool call. It must marshal to a JSON object.
+	//
+	// When using a [ToolHandlerFor] with structured output, you should not
+	// populate this field. It will be automatically populated with the typed Out
+	// value.
 	StructuredContent any `json:"structuredContent,omitempty"`
-	// Whether the tool call ended in an error.
+
+	// IsError reports whether the tool call ended in an error.
 	//
 	// If not set, this is assumed to be false (the call was successful).
 	//
-	// Any errors that originate from the tool should be reported inside the result
-	// object, with isError set to true, not as an MCP protocol-level error
-	// response. Otherwise, the LLM would not be able to see that an error occurred
-	// and self-correct.
+	// Any errors that originate from the tool should be reported inside the
+	// Content field, with IsError set to true, not as an MCP protocol-level
+	// error response. Otherwise, the LLM would not be able to see that an error
+	// occurred and self-correct.
 	//
 	// However, any errors in finding the tool, an error indicating that the
 	// server does not support tool calls, or any other exceptional conditions,
 	// should be reported as an MCP error response.
+	//
+	// When using a [ToolHandlerFor], this field is automatically set when the
+	// tool handler returns an error, and the error string is included as text in
+	// the Content field.
 	IsError bool `json:"isError,omitempty"`
+
+	// The error passed to setError, if any.
+	// It is not marshaled, and therefore it is only visible on the server.
+	// Its only use is in server sending middleware, where it can be accessed
+	// with getError.
+	err error
+}
+
+// TODO(#64): consider exposing setError (and getError), by adding an error
+// field on CallToolResult.
+func (r *CallToolResult) setError(err error) {
+	r.Content = []Content{&TextContent{Text: err.Error()}}
+	r.IsError = true
+	r.err = err
+}
+
+// getError returns the error set with setError, or nil if none.
+// This function always returns nil on clients.
+func (r *CallToolResult) getError() error {
+	return r.err
 }
 
 func (*CallToolResult) isResult() {}
@@ -114,6 +154,10 @@ func (x *CallToolResult) UnmarshalJSON(data []byte) error {
 func (x *CallToolParams) isParams()              {}
 func (x *CallToolParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *CallToolParams) SetProgressToken(t any) { setProgressToken(x, t) }
+
+func (x *CallToolParamsRaw) isParams()              {}
+func (x *CallToolParamsRaw) GetProgressToken() any  { return getProgressToken(x) }
+func (x *CallToolParamsRaw) SetProgressToken(t any) { setProgressToken(x, t) }
 
 type CancelledParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
@@ -599,15 +643,16 @@ type ProgressNotificationParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
 	Meta `json:"_meta,omitempty"`
+	// The progress token which was given in the initial request, used to associate
+	// this notification with the request that is proceeding.
+	ProgressToken any `json:"progressToken"`
 	// An optional message describing the current progress.
 	Message string `json:"message,omitempty"`
 	// The progress thus far. This should increase every time progress is made, even
 	// if the total is unknown.
 	Progress float64 `json:"progress"`
-	// The progress token which was given in the initial request, used to associate
-	// this notification with the request that is proceeding.
-	ProgressToken any `json:"progressToken"`
 	// Total number of items to process (or total progress required), if known.
+	// Zero means unknown.
 	Total float64 `json:"total,omitempty"`
 }
 
@@ -866,14 +911,38 @@ type Tool struct {
 	// This can be used by clients to improve the LLM's understanding of available
 	// tools. It can be thought of like a "hint" to the model.
 	Description string `json:"description,omitempty"`
-	// A JSON Schema object defining the expected parameters for the tool.
-	InputSchema *jsonschema.Schema `json:"inputSchema"`
+	// InputSchema holds a JSON Schema object defining the expected parameters
+	// for the tool.
+	//
+	// From the server, this field may be set to any value that JSON-marshals to
+	// valid JSON schema (including json.RawMessage). However, for tools added
+	// using [AddTool], which automatically validates inputs and outputs, the
+	// schema must be in a draft the SDK understands. Currently, the SDK uses
+	// github.com/google/jsonschema-go for inference and validation, which only
+	// supports the 2020-12 draft of JSON schema. To do your own validation, use
+	// [Server.AddTool].
+	//
+	// From the client, this field will hold the default JSON marshaling of the
+	// server's input schema (a map[string]any).
+	InputSchema any `json:"inputSchema"`
 	// Intended for programmatic or logical use, but used as a display name in past
 	// specs or fallback (if title isn't present).
 	Name string `json:"name"`
-	// An optional JSON Schema object defining the structure of the tool's output
-	// returned in the structuredContent field of a CallToolResult.
-	OutputSchema *jsonschema.Schema `json:"outputSchema,omitempty"`
+	// OutputSchema holds an optional JSON Schema object defining the structure
+	// of the tool's output returned in the StructuredContent field of a
+	// CallToolResult.
+	//
+	// From the server, this field may be set to any value that JSON-marshals to
+	// valid JSON schema (including json.RawMessage). However, for tools added
+	// using [AddTool], which automatically validates inputs and outputs, the
+	// schema must be in a draft the SDK understands. Currently, the SDK uses
+	// github.com/google/jsonschema-go for inference and validation, which only
+	// supports the 2020-12 draft of JSON schema. To do your own validation, use
+	// [Server.AddTool].
+	//
+	// From the client, this field will hold the default JSON marshaling of the
+	// server's output schema (a map[string]any).
+	OutputSchema any `json:"outputSchema,omitempty"`
 	// Intended for UI and end-user contexts — optimized to be human-readable and
 	// easily understood, even by those unfamiliar with domain-specific terminology.
 	// If not provided, Annotations.Title should be used for display if present,
@@ -975,9 +1044,18 @@ type ElicitParams struct {
 	Meta `json:"_meta,omitempty"`
 	// The message to present to the user.
 	Message string `json:"message"`
-	// A restricted subset of JSON Schema.
+	// A JSON schema object defining the requested elicitation schema.
+	//
+	// From the server, this field may be set to any value that can JSON-marshal
+	// to valid JSON schema (including json.RawMessage for raw schema values).
+	// Internally, the SDK uses github.com/google/jsonschema-go for validation,
+	// which only supports the 2020-12 draft of the JSON schema spec.
+	//
+	// From the client, this field will use the default JSON marshaling (a
+	// map[string]any).
+	//
 	// Only top-level properties are allowed, without nesting.
-	RequestedSchema *jsonschema.Schema `json:"requestedSchema"`
+	RequestedSchema any `json:"requestedSchema"`
 }
 
 func (x *ElicitParams) isParams() {}

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/requests.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/requests.go
@@ -7,7 +7,7 @@
 package mcp
 
 type (
-	CallToolRequest                   = ServerRequest[*CallToolParams]
+	CallToolRequest                   = ServerRequest[*CallToolParamsRaw]
 	CompleteRequest                   = ServerRequest[*CompleteParams]
 	GetPromptRequest                  = ServerRequest[*GetPromptParams]
 	InitializedRequest                = ServerRequest[*InitializedParams]

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/resource.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/resource.go
@@ -41,7 +41,7 @@ type ResourceHandler func(context.Context, *ReadResourceRequest) (*ReadResourceR
 // not be found.
 func ResourceNotFoundError(uri string) error {
 	return &jsonrpc2.WireError{
-		Code:    CodeResourceNotFound,
+		Code:    codeResourceNotFound,
 		Message: "Resource not found",
 		Data:    json.RawMessage(fmt.Sprintf(`{"uri":%q}`, uri)),
 	}

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/root.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/root.go
@@ -1,5 +1,0 @@
-// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file.
-
-package mcp

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/server.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/server.go
@@ -14,7 +14,6 @@ import (
 	"iter"
 	"maps"
 	"net/url"
-	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -28,6 +27,7 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
+// DefaultPageSize is the default for [ServerOptions.PageSize].
 const DefaultPageSize = 1000
 
 // A Server is an instance of an MCP server.
@@ -84,6 +84,16 @@ type ServerOptions struct {
 	// If true, advertises the tools capability during initialization,
 	// even if no tools have been registered.
 	HasTools bool
+
+	// GetSessionID provides the next session ID to use for an incoming request.
+	// If nil, a default randomly generated ID will be used.
+	//
+	// Session IDs should be globally unique across the scope of the server,
+	// which may span multiple processes in the case of distributed servers.
+	//
+	// As a special case, if GetSessionID returns the empty string, the
+	// Mcp-Session-Id header will not be set.
+	GetSessionID func() string
 }
 
 // NewServer creates a new MCP server. The resulting server has no features:
@@ -115,6 +125,11 @@ func NewServer(impl *Implementation, options *ServerOptions) *Server {
 	if opts.UnsubscribeHandler != nil && opts.SubscribeHandler == nil {
 		panic("UnsubscribeHandler requires SubscribeHandler")
 	}
+
+	if opts.GetSessionID == nil {
+		opts.GetSessionID = randText
+	}
+
 	return &Server{
 		impl:                    impl,
 		opts:                    opts,
@@ -150,15 +165,23 @@ func (s *Server) RemovePrompts(names ...string) {
 //
 // The tool's input schema must be non-nil and have the type "object". For a tool
 // that takes no input, or one where any input is valid, set [Tool.InputSchema] to
-// &jsonschema.Schema{Type: "object"}.
+// `{"type": "object"}`, using your preferred library or `json.RawMessage`.
 //
-// If present, the output schema must also have type "object".
+// If present, [Tool.OutputSchema] must also have type "object".
 //
 // When the handler is invoked as part of a CallTool request, req.Params.Arguments
-// will be a json.RawMessage. Unmarshaling the arguments and validating them against the
-// input schema are the handler author's responsibility.
+// will be a json.RawMessage.
 //
-// Most users should use the top-level function [AddTool].
+// Unmarshaling the arguments and validating them against the input schema are the
+// caller's responsibility.
+//
+// Validating the result against the output schema, if any, is the caller's responsibility.
+//
+// Setting the result's Content, StructuredContent and IsError fields are the caller's
+// responsibility.
+//
+// Most users should use the top-level function [AddTool], which handles all these
+// responsibilities.
 func (s *Server) AddTool(t *Tool, h ToolHandler) {
 	if t.InputSchema == nil {
 		// This prevents the tool author from forgetting to write a schema where
@@ -167,11 +190,29 @@ func (s *Server) AddTool(t *Tool, h ToolHandler) {
 		// discovered until runtime, when the LLM sent bad data.
 		panic(fmt.Errorf("AddTool %q: missing input schema", t.Name))
 	}
-	if t.InputSchema.Type != "object" {
+	if s, ok := t.InputSchema.(*jsonschema.Schema); ok && s.Type != "object" {
 		panic(fmt.Errorf(`AddTool %q: input schema must have type "object"`, t.Name))
+	} else {
+		var m map[string]any
+		if err := remarshal(t.InputSchema, &m); err != nil {
+			panic(fmt.Errorf("AddTool %q: can't marshal input schema to a JSON object: %v", t.Name, err))
+		}
+		if typ := m["type"]; typ != "object" {
+			panic(fmt.Errorf(`AddTool %q: input schema must have type "object" (got %v)`, t.Name, typ))
+		}
 	}
-	if t.OutputSchema != nil && t.OutputSchema.Type != "object" {
-		panic(fmt.Errorf(`AddTool %q: output schema must have type "object"`, t.Name))
+	if t.OutputSchema != nil {
+		if s, ok := t.OutputSchema.(*jsonschema.Schema); ok && s.Type != "object" {
+			panic(fmt.Errorf(`AddTool %q: output schema must have type "object"`, t.Name))
+		} else {
+			var m map[string]any
+			if err := remarshal(t.OutputSchema, &m); err != nil {
+				panic(fmt.Errorf("AddTool %q: can't marshal output schema to a JSON object: %v", t.Name, err))
+			}
+			if typ := m["type"]; typ != "object" {
+				panic(fmt.Errorf(`AddTool %q: output schema must have type "object" (got %v)`, t.Name, typ))
+			}
+		}
 	}
 	st := &serverTool{tool: t, handler: h}
 	// Assume there was a change, since add replaces existing tools.
@@ -182,27 +223,6 @@ func (s *Server) AddTool(t *Tool, h ToolHandler) {
 		func() bool { s.tools.add(st); return true })
 }
 
-// ToolFor returns a shallow copy of t and a [ToolHandler] that wraps h.
-//
-// If the tool's input schema is nil, it is set to the schema inferred from the In
-// type parameter, using [jsonschema.For]. The In type parameter must be a map
-// or a struct, so that its inferred JSON Schema has type "object".
-//
-// For tools that don't return structured output, Out should be 'any'.
-// Otherwise, if the tool's output schema is nil the output schema is set to
-// the schema inferred from Out, which must be a map or a struct.
-//
-// Most users will call [AddTool]. Use [ToolFor] if you wish to modify the
-// tool's schemas or wrap the ToolHandler before calling [Server.AddTool].
-func ToolFor[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHandler) {
-	tt, hh, err := toolForErr(t, h)
-	if err != nil {
-		panic(fmt.Sprintf("ToolFor: tool %q: %v", t.Name, err))
-	}
-	return tt, hh
-}
-
-// TODO(v0.3.0): test
 func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHandler, error) {
 	tt := *t
 
@@ -225,7 +245,7 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 		elemZero       any // only non-nil if Out is a pointer type
 		outputResolved *jsonschema.Resolved
 	)
-	if reflect.TypeFor[Out]() != reflect.TypeFor[any]() {
+	if t.OutputSchema != nil || reflect.TypeFor[Out]() != reflect.TypeFor[any]() {
 		var err error
 		elemZero, err = setSchema[Out](&tt.OutputSchema, &outputResolved)
 		if err != nil {
@@ -234,12 +254,23 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 	}
 
 	th := func(ctx context.Context, req *CallToolRequest) (*CallToolResult, error) {
+		var input json.RawMessage
+		if req.Params.Arguments != nil {
+			input = req.Params.Arguments
+		}
+		// Validate input and apply defaults.
+		var err error
+		input, err = applySchema(input, inputResolved)
+		if err != nil {
+			// TODO(#450): should this be considered a tool error? (and similar below)
+			return nil, fmt.Errorf("%w: validating \"arguments\": %v", jsonrpc2.ErrInvalidParams, err)
+		}
+
 		// Unmarshal and validate args.
-		rawArgs := req.Params.Arguments.(json.RawMessage)
 		var in In
-		if rawArgs != nil {
-			if err := unmarshalSchema(rawArgs, inputResolved, &in); err != nil {
-				return nil, err
+		if input != nil {
+			if err := json.Unmarshal(input, &in); err != nil {
+				return nil, fmt.Errorf("%w: %v", jsonrpc2.ErrInvalidParams, err)
 			}
 		}
 
@@ -255,35 +286,52 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 				return nil, wireErr
 			}
 			// For regular errors, embed them in the tool result as per MCP spec
-			return &CallToolResult{
-				Content: []Content{&TextContent{Text: err.Error()}},
-				IsError: true,
-			}, nil
+			var errRes CallToolResult
+			errRes.setError(err)
+			return &errRes, nil
 		}
 
-		// TODO(v0.3.0): Validate out.
-		_ = outputResolved
-
-		// TODO: return the serialized JSON in a TextContent block, as per spec?
-		// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
-		// But people may use res.Content for other things.
 		if res == nil {
 			res = &CallToolResult{}
 		}
-		if res.Content == nil {
-			res.Content = []Content{} // avoid returning 'null'
-		}
-		res.StructuredContent = out
+
+		// Marshal the output and put the RawMessage in the StructuredContent field.
+		var outval any = out
 		if elemZero != nil {
 			// Avoid typed nil, which will serialize as JSON null.
-			// Instead, use the zero value of the non-zero
+			// Instead, use the zero value of the unpointered type.
 			var z Out
 			if any(out) == any(z) { // zero is only non-nil if Out is a pointer type
-				res.StructuredContent = elemZero
+				outval = elemZero
+			}
+		}
+		if outval != nil {
+			outbytes, err := json.Marshal(outval)
+			if err != nil {
+				return nil, fmt.Errorf("marshaling output: %w", err)
+			}
+			outJSON := json.RawMessage(outbytes)
+			// Validate the output JSON, and apply defaults.
+			//
+			// We validate against the JSON, rather than the output value, as
+			// some types may have custom JSON marshalling (issue #447).
+			outJSON, err = applySchema(outJSON, outputResolved)
+			if err != nil {
+				return nil, fmt.Errorf("validating tool output: %w", err)
+			}
+			res.StructuredContent = outJSON // avoid a second marshal over the wire
+
+			// If the Content field isn't being used, return the serialized JSON in a
+			// TextContent block, as the spec suggests:
+			// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content.
+			if res.Content == nil {
+				res.Content = []Content{&TextContent{
+					Text: string(outJSON),
+				}}
 			}
 		}
 		return res, nil
-	}
+	} // end of handler
 
 	return &tt, th, nil
 }
@@ -302,36 +350,56 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 //
 // TODO(rfindley): we really shouldn't ever return 'null' results. Maybe we
 // should have a jsonschema.Zero(schema) helper?
-func setSchema[T any](sfield **jsonschema.Schema, rfield **jsonschema.Resolved) (zero any, err error) {
-	rt := reflect.TypeFor[T]()
+func setSchema[T any](sfield *any, rfield **jsonschema.Resolved) (zero any, err error) {
+	var internalSchema *jsonschema.Schema
 	if *sfield == nil {
+		rt := reflect.TypeFor[T]()
 		if rt.Kind() == reflect.Pointer {
 			rt = rt.Elem()
 			zero = reflect.Zero(rt).Interface()
 		}
 		// TODO: we should be able to pass nil opts here.
-		*sfield, err = jsonschema.ForType(rt, &jsonschema.ForOptions{})
+		internalSchema, err = jsonschema.ForType(rt, &jsonschema.ForOptions{})
+		if err == nil {
+			*sfield = internalSchema
+		}
+	} else {
+		if err := remarshal(*sfield, &internalSchema); err != nil {
+			return zero, err
+		}
 	}
 	if err != nil {
 		return zero, err
 	}
-	*rfield, err = (*sfield).Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
+	*rfield, err = internalSchema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
 	return zero, err
 }
 
 // AddTool adds a tool and typed tool handler to the server.
 //
 // If the tool's input schema is nil, it is set to the schema inferred from the
-// In type parameter, using [jsonschema.For]. The In type parameter must be a
-// map or a struct, so that its inferred JSON Schema has type "object".
+// In type parameter. Types are inferred from Go types, and property
+// descriptions are read from the 'jsonschema' struct tag. Internally, the SDK
+// uses the github.com/google/jsonschema-go package for inference and
+// validation. The In type argument must be a map or a struct, so that its
+// inferred JSON Schema has type "object", as required by the spec. As a
+// special case, if the In type is 'any', the tool's input schema is set to an
+// empty object schema value.
 //
-// For tools that don't return structured output, Out should be 'any'.
-// Otherwise, if the tool's output schema is nil the output schema is set to
-// the schema inferred from Out, which must be a map or a struct.
+// If the tool's output schema is nil, and the Out type is not 'any', the
+// output schema is set to the schema inferred from the Out type argument,
+// which must also be a map or struct. If the Out type is 'any', the output
+// schema is omitted.
 //
-// It is a convenience for s.AddTool(ToolFor(t, h)).
+// Unlike [Server.AddTool], AddTool does a lot automatically, and forces
+// tools to conform to the MCP spec. See [ToolHandlerFor] for a detailed
+// description of this automatic behavior.
 func AddTool[In, Out any](s *Server, t *Tool, h ToolHandlerFor[In, Out]) {
-	s.AddTool(ToolFor(t, h))
+	tt, hh, err := toolForErr(t, h)
+	if err != nil {
+		panic(fmt.Sprintf("AddTool: tool %q: %v", t.Name, err))
+	}
+	s.AddTool(tt, hh)
 }
 
 // RemoveTools removes the tools with the given names.
@@ -346,15 +414,8 @@ func (s *Server) RemoveTools(names ...string) {
 func (s *Server) AddResource(r *Resource, h ResourceHandler) {
 	s.changeAndNotify(notificationResourceListChanged, &ResourceListChangedParams{},
 		func() bool {
-			u, err := url.Parse(r.URI)
-			if err != nil {
-				//panic(err) // url.Parse includes the URI in the error
-				fmt.Fprintf(os.Stderr, "invalid resource URI %q: %v\n", r.URI, err)
-			} else {
-				if !u.IsAbs() {
-					//panic(fmt.Errorf("URI %s needs a scheme", r.URI))
-					fmt.Fprintf(os.Stderr, "invalid resource URI %q: %v\n", r.URI, err)
-				}
+			if _, err := url.Parse(r.URI); err != nil {
+				panic(err) // url.Parse includes the URI in the error
 			}
 			s.resources.add(&serverResource{r, h})
 			return true
@@ -377,17 +438,6 @@ func (s *Server) AddResourceTemplate(t *ResourceTemplate, h ResourceHandler) {
 			_, err := uritemplate.New(t.URITemplate)
 			if err != nil {
 				panic(fmt.Errorf("URI template %q is invalid: %w", t.URITemplate, err))
-			}
-			// Ensure the URI template has a valid scheme
-			u, err := url.Parse(t.URITemplate)
-			if err != nil {
-				//panic(err) // url.Parse includes the URI in the error
-				fmt.Fprintf(os.Stderr, "invalid resource template uri %q: %v\n", t.URITemplate, err)
-			} else {
-				if !u.IsAbs() {
-					//panic(fmt.Errorf("URI template %q needs a scheme", t.URITemplate))
-					fmt.Fprintf(os.Stderr, "invalid resource template uri %q: %v\n", t.URITemplate, err)
-				}
 			}
 			s.resourceTemplates.add(&serverResourceTemplate{t, h})
 			return true
@@ -426,7 +476,7 @@ func (s *Server) capabilities() *ServerCapabilities {
 	return caps
 }
 
-func (s *Server) complete(ctx context.Context, req *CompleteRequest) (Result, error) {
+func (s *Server) complete(ctx context.Context, req *CompleteRequest) (*CompleteResult, error) {
 	if s.opts.CompletionHandler == nil {
 		return nil, jsonrpc2.ErrMethodNotFound
 	}
@@ -448,6 +498,9 @@ func (s *Server) changeAndNotify(notification string, params Params, change func
 }
 
 // Sessions returns an iterator that yields the current set of server sessions.
+//
+// There is no guarantee that the iterator observes sessions that are added or
+// removed during iteration.
 func (s *Server) Sessions() iter.Seq[*ServerSession] {
 	s.mu.Lock()
 	clients := slices.Clone(s.sessions)
@@ -476,7 +529,7 @@ func (s *Server) getPrompt(ctx context.Context, req *GetPromptRequest) (*GetProm
 	if !ok {
 		// Return a proper JSON-RPC error with the correct error code
 		return nil, &jsonrpc2.WireError{
-			Code:    CodeInvalidParams,
+			Code:    codeInvalidParams,
 			Message: fmt.Sprintf("unknown prompt %q", req.Params.Name),
 		}
 	}
@@ -503,13 +556,17 @@ func (s *Server) callTool(ctx context.Context, req *CallToolRequest) (*CallToolR
 	s.mu.Unlock()
 	if !ok {
 		return nil, &jsonrpc2.WireError{
-			Code:    CodeInvalidParams,
+			Code:    codeInvalidParams,
 			Message: fmt.Sprintf("unknown tool %q", req.Params.Name),
 		}
 	}
-	// TODO: if handler returns nil content, it will serialize as null.
-	// Add a test and fix.
-	return st.handler(ctx, req)
+	res, err := st.handler(ctx, req)
+	if err == nil && res != nil && res.Content == nil {
+		res2 := *res
+		res2.Content = []Content{} // avoid "null"
+		res = &res2
+	}
+	return res, err
 }
 
 func (s *Server) listResources(_ context.Context, req *ListResourcesRequest) (*ListResourcesResult, error) {
@@ -816,7 +873,7 @@ func (ss *ServerSession) callProgressNotificationHandler(ctx context.Context, p 
 // This is typically used to report on the status of a long-running request
 // that was initiated by the client.
 func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNotificationParams) error {
-	return HandleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
+	return handleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
 }
 
 func newServerRequest[P Params](ss *ServerSession, params P) *ServerRequest[P] {
@@ -851,6 +908,33 @@ func (ss *ServerSession) updateState(mut func(*ServerSessionState)) {
 	}
 }
 
+// hasInitialized reports whether the server has received the initialized
+// notification.
+//
+// TODO(findleyr): use this to prevent change notifications.
+func (ss *ServerSession) hasInitialized() bool {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	return ss.state.InitializedParams != nil
+}
+
+// checkInitialized returns a formatted error if the server has not yet
+// received the initialized notification.
+func (ss *ServerSession) checkInitialized(method string) error {
+	if !ss.hasInitialized() {
+		// TODO(rfindley): enable this check.
+		// Right now is is flaky, because server tests don't await the initialized notification.
+		// Perhaps requests should simply block until they have received the initialized notification
+
+		// if strings.HasPrefix(method, "notifications/") {
+		// 	return fmt.Errorf("must not send %q before %q is received", method, notificationInitialized)
+		// } else {
+		// 	return fmt.Errorf("cannot call %q before %q is received", method, notificationInitialized)
+		// }
+	}
+	return nil
+}
+
 func (ss *ServerSession) ID() string {
 	if c, ok := ss.mcpConn.(hasSessionID); ok {
 		return c.SessionID()
@@ -866,11 +950,17 @@ func (ss *ServerSession) Ping(ctx context.Context, params *PingParams) error {
 
 // ListRoots lists the client roots.
 func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
+	if err := ss.checkInitialized(methodListRoots); err != nil {
+		return nil, err
+	}
 	return handleSend[*ListRootsResult](ctx, methodListRoots, newServerRequest(ss, orZero[Params](params)))
 }
 
 // CreateMessage sends a sampling request to the client.
 func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
+	if err := ss.checkInitialized(methodCreateMessage); err != nil {
+		return nil, err
+	}
 	if params == nil {
 		params = &CreateMessageParams{Messages: []*SamplingMessage{}}
 	}
@@ -884,6 +974,9 @@ func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessag
 
 // Elicit sends an elicitation request to the client asking for user input.
 func (ss *ServerSession) Elicit(ctx context.Context, params *ElicitParams) (*ElicitResult, error) {
+	if err := ss.checkInitialized(methodElicit); err != nil {
+		return nil, err
+	}
 	return handleSend[*ElicitResult](ctx, methodElicit, newServerRequest(ss, orZero[Params](params)))
 }
 
@@ -903,7 +996,7 @@ func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) 
 	if compareLevels(params.Level, logLevel) < 0 {
 		return nil
 	}
-	return HandleNotify(ctx, notificationLoggingMessage, newServerRequest(ss, orZero[Params](params)))
+	return handleNotify(ctx, notificationLoggingMessage, newServerRequest(ss, orZero[Params](params)))
 }
 
 // AddSendingMiddleware wraps the current sending method handler using the provided
@@ -985,7 +1078,7 @@ func (ss *ServerSession) getConn() *jsonrpc2.Connection { return ss.conn }
 // handle invokes the method described by the given JSON RPC request.
 func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any, error) {
 	ss.mu.Lock()
-	initialized := ss.state.InitializedParams != nil
+	initialized := ss.state.InitializeParams != nil
 	ss.mu.Unlock()
 
 	// From the spec:

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/shared.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/shared.go
@@ -36,13 +36,13 @@ const (
 	latestProtocolVersion   = protocolVersion20250618
 	protocolVersion20250618 = "2025-06-18"
 	protocolVersion20250326 = "2025-03-26"
-	protocolVersion20251105 = "2024-11-05"
+	protocolVersion20241105 = "2024-11-05"
 )
 
 var supportedProtocolVersions = []string{
 	protocolVersion20250618,
 	protocolVersion20250326,
-	protocolVersion20251105,
+	protocolVersion20241105,
 }
 
 // negotiatedVersion returns the effective protocol version to use, given a
@@ -114,7 +114,7 @@ func orZero[T any, P *U, U any](p P) T {
 	return any(p).(T)
 }
 
-func HandleNotify(ctx context.Context, method string, req Request) error {
+func handleNotify(ctx context.Context, method string, req Request) error {
 	mh := req.GetSession().sendingMethodHandler()
 	_, err := mh(ctx, method, req)
 	return err
@@ -331,13 +331,11 @@ func clientSessionMethod[P Params, R Result](f func(*ClientSession, context.Cont
 
 // Error codes
 const (
-	// TODO: should these be unexported?
-
-	CodeResourceNotFound = -32002
+	codeResourceNotFound = -32002
 	// The error code if the method exists and was called properly, but the peer does not support it.
-	CodeUnsupportedMethod = -31001
+	codeUnsupportedMethod = -31001
 	// The error code for invalid parameters
-	CodeInvalidParams = -32602
+	codeInvalidParams = -32602
 )
 
 // notifySessions calls Notify on all the sessions.
@@ -346,12 +344,15 @@ func notifySessions[S Session, P Params](sessions []S, method string, params P) 
 	if sessions == nil {
 		return
 	}
-	// TODO: make this timeout configurable, or call Notify asynchronously.
+	// TODO: make this timeout configurable, or call handleNotify asynchronously.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// TODO: there's a potential spec violation here, when the feature list
+	// changes before the session (client or server) is initialized.
 	for _, s := range sessions {
 		req := newRequest(s, params)
-		if err := HandleNotify(ctx, method, req); err != nil {
+		if err := handleNotify(ctx, method, req); err != nil {
 			// TODO(jba): surface this error better
 			log.Printf("calling %s: %v", method, err)
 		}
@@ -450,13 +451,13 @@ func clientRequestFor[P Params](s *ClientSession, p P) *ClientRequest[P] {
 
 // Params is a parameter (input) type for an MCP call or notification.
 type Params interface {
-	// isParams discourages implementation of Params outside of this package.
-	isParams()
-
 	// GetMeta returns metadata from a value.
 	GetMeta() map[string]any
 	// SetMeta sets the metadata on a value.
 	SetMeta(map[string]any)
+
+	// isParams discourages implementation of Params outside of this package.
+	isParams()
 }
 
 // RequestParams is a parameter (input) type for an MCP request.

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/streamable.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/streamable.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log/slog"
 	"math"
 	"math/rand/v2"
 	"net/http"
@@ -50,16 +51,6 @@ type StreamableHTTPHandler struct {
 
 // StreamableHTTPOptions configures the StreamableHTTPHandler.
 type StreamableHTTPOptions struct {
-	// GetSessionID provides the next session ID to use for an incoming request.
-	// If nil, a default randomly generated ID will be used.
-	//
-	// Session IDs should be globally unique across the scope of the server,
-	// which may span multiple processes in the case of distributed servers.
-	//
-	// As a special case, if GetSessionID returns the empty string, the
-	// Mcp-Session-Id header will not be set.
-	GetSessionID func() string
-
 	// Stateless controls whether the session is 'stateless'.
 	//
 	// A stateless server does not validate the Mcp-Session-Id header, and uses a
@@ -70,10 +61,13 @@ type StreamableHTTPOptions struct {
 	// documentation for [StreamableServerTransport].
 	Stateless bool
 
-	// TODO: support session retention (?)
+	// TODO(#148): support session retention (?)
 
-	// jsonResponse is forwarded to StreamableServerTransport.jsonResponse.
-	jsonResponse bool
+	// JSONResponse causes streamable responses to return application/json rather
+	// than text/event-stream ([§2.1.5] of the spec).
+	//
+	// [§2.1.5]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server
+	JSONResponse bool
 }
 
 // NewStreamableHTTPHandler returns a new [StreamableHTTPHandler].
@@ -88,9 +82,6 @@ func NewStreamableHTTPHandler(getServer func(*http.Request) *Server, opts *Strea
 	}
 	if opts != nil {
 		h.opts = *opts
-	}
-	if h.opts.GetSessionID == nil {
-		h.opts.GetSessionID = randText
 	}
 	return h
 }
@@ -133,7 +124,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Accept must contain 'text/event-stream' for GET requests", http.StatusBadRequest)
 			return
 		}
-	} else if !jsonOK || !streamOK {
+	} else if (!jsonOK || !streamOK) && req.Method != http.MethodDelete { // TODO: consolidate with handling of http method below.
 		http.Error(w, "Accept must contain both 'application/json' and 'text/event-stream'", http.StatusBadRequest)
 		return
 	}
@@ -171,7 +162,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 
 	switch req.Method {
 	case http.MethodPost, http.MethodGet:
-		if req.Method == http.MethodGet && sessionID == "" {
+		if req.Method == http.MethodGet && (h.opts.Stateless || sessionID == "") {
 			http.Error(w, "GET requires an active session", http.StatusMethodNotAllowed)
 			return
 		}
@@ -181,7 +172,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	// Section 2.7 of the spec (2025-06-18) states:
+	// [§2.7] of the spec (2025-06-18) states:
 	//
 	// "If using HTTP, the client MUST include the MCP-Protocol-Version:
 	// <protocol-version> HTTP header on all subsequent requests to the MCP
@@ -209,6 +200,8 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	//     assume 2025-03-26 if the client doesn't say anything).
 	//
 	// This logic matches the typescript SDK.
+	//
+	// [§2.7]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header
 	protocolVersion := req.Header.Get(protocolVersionHeader)
 	if protocolVersion == "" {
 		protocolVersion = protocolVersion20250326
@@ -228,12 +221,12 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 		if sessionID == "" {
 			// In stateless mode, sessionID may be nonempty even if there's no
 			// existing transport.
-			sessionID = h.opts.GetSessionID()
+			sessionID = server.opts.GetSessionID()
 		}
 		transport = &StreamableServerTransport{
 			SessionID:    sessionID,
 			Stateless:    h.opts.Stateless,
-			jsonResponse: h.opts.jsonResponse,
+			jsonResponse: h.opts.JSONResponse,
 		}
 
 		// To support stateless mode, we initialize the session with a default
@@ -282,6 +275,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 			if !hasInitialized {
 				state.InitializedParams = new(InitializedParams)
 			}
+			state.LogLevel = "info"
 			connectOpts = &ServerSessionOptions{
 				State: state,
 			}
@@ -320,15 +314,6 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	}
 
 	transport.ServeHTTP(w, req)
-}
-
-// StreamableServerTransportOptions configures the stramable server transport.
-//
-// Deprecated: use a StreamableServerTransport literal.
-type StreamableServerTransportOptions struct {
-	// Storage for events, to enable stream resumption.
-	// If nil, a [MemoryEventStore] with the default maximum size will be used.
-	EventStore EventStore
 }
 
 // A StreamableServerTransport implements the server side of the MCP streamable
@@ -378,30 +363,17 @@ type StreamableServerTransport struct {
 	// request contain only a single message. In this case, notifications or
 	// requests made within the context of a server request will be sent to the
 	// hanging GET request, if any.
+	//
+	// TODO(rfindley): jsonResponse should be exported, since
+	// StreamableHTTPOptions.JSONResponse is exported.
 	jsonResponse bool
 
 	// connection is non-nil if and only if the transport has been connected.
 	connection *streamableServerConn
 }
 
-// NewStreamableServerTransport returns a new [StreamableServerTransport] with
-// the given session ID and options.
-//
-// Deprecated: use a StreamableServerTransport literal.
-//
-//go:fix inline.
-func NewStreamableServerTransport(sessionID string, opts *StreamableServerTransportOptions) *StreamableServerTransport {
-	t := &StreamableServerTransport{
-		SessionID: sessionID,
-	}
-	if opts != nil {
-		t.EventStore = opts.EventStore
-	}
-	return t
-}
-
 // Connect implements the [Transport] interface.
-func (t *StreamableServerTransport) Connect(context.Context) (Connection, error) {
+func (t *StreamableServerTransport) Connect(ctx context.Context) (Connection, error) {
 	if t.connection != nil {
 		return nil, fmt.Errorf("transport already connected")
 	}
@@ -412,16 +384,20 @@ func (t *StreamableServerTransport) Connect(context.Context) (Connection, error)
 		jsonResponse:   t.jsonResponse,
 		incoming:       make(chan jsonrpc.Message, 10),
 		done:           make(chan struct{}),
-		streams:        make(map[StreamID]*stream),
-		requestStreams: make(map[jsonrpc.ID]StreamID),
+		streams:        make(map[string]*stream),
+		requestStreams: make(map[jsonrpc.ID]string),
+	}
+	if t.connection.eventStore == nil {
+		t.connection.eventStore = NewMemoryEventStore(nil)
 	}
 	// Stream 0 corresponds to the hanging 'GET'.
 	//
 	// It is always text/event-stream, since it must carry arbitrarily many
 	// messages.
-	t.connection.streams[""] = newStream("", false)
-	if t.connection.eventStore == nil {
-		t.connection.eventStore = NewMemoryEventStore(nil)
+	var err error
+	t.connection.streams[""], err = t.connection.newStream(ctx, "", false, false)
+	if err != nil {
+		return nil, err
 	}
 	return t.connection, nil
 }
@@ -454,14 +430,14 @@ type streamableServerConn struct {
 	// bound. If we deleted a stream when the response is sent, we would lose the ability
 	// to replay if there was a cut just before the response was transmitted.
 	// Perhaps we could have a TTL for streams that starts just after the response.
-	streams map[StreamID]*stream
+	streams map[string]*stream
 
 	// requestStreams maps incoming requests to their logical stream ID.
 	//
 	// Lifecycle: requestStreams persist for the duration of the session.
 	//
 	// TODO: clean up once requests are handled. See the TODO for streams above.
-	requestStreams map[jsonrpc.ID]StreamID
+	requestStreams map[jsonrpc.ID]string
 }
 
 func (c *streamableServerConn) SessionID() string {
@@ -478,19 +454,23 @@ func (c *streamableServerConn) SessionID() string {
 type stream struct {
 	// id is the logical ID for the stream, unique within a session.
 	// an empty string is used for messages that don't correlate with an incoming request.
-	id StreamID
+	id string
+
+	// If isInitialize is set, the stream is in response to an initialize request,
+	// and therefore should include the session ID header.
+	isInitialize bool
 
 	// jsonResponse records whether this stream should respond with application/json
 	// instead of text/event-stream.
 	//
-	// See [StreamableServerTransportOptions.jsonResponse].
+	// See [StreamableServerTransportOptions.JSONResponse].
 	jsonResponse bool
 
 	// signal is a 1-buffered channel, owned by an incoming HTTP request, that signals
 	// that there are messages available to write into the HTTP response.
 	// In addition, the presence of a channel guarantees that at most one HTTP response
 	// can receive messages for a logical stream. After claiming the stream, incoming
-	// requests should read from outgoing, to ensure that no new messages are missed.
+	// requests should read from the event store, to ensure that no new messages are missed.
 	//
 	// To simplify locking, signal is an atomic. We need an atomic.Pointer, because
 	// you can't set an atomic.Value to nil.
@@ -502,32 +482,28 @@ type stream struct {
 	// The following mutable fields are protected by the mutex of the containing
 	// StreamableServerTransport.
 
-	// outgoing is the list of outgoing messages, enqueued by server methods that
-	// write notifications and responses, and dequeued by streamResponse.
-	outgoing [][]byte
-
 	// streamRequests is the set of unanswered incoming RPCs for the stream.
 	//
-	// Requests persist until their response data has been added to outgoing.
+	// Requests persist until their response data has been added to the event store.
 	requests map[jsonrpc.ID]struct{}
 }
 
-func newStream(id StreamID, jsonResponse bool) *stream {
+func (c *streamableServerConn) newStream(ctx context.Context, id string, isInitialize, jsonResponse bool) (*stream, error) {
+	if err := c.eventStore.Open(ctx, c.sessionID, id); err != nil {
+		return nil, err
+	}
 	return &stream{
 		id:           id,
+		isInitialize: isInitialize,
 		jsonResponse: jsonResponse,
 		requests:     make(map[jsonrpc.ID]struct{}),
-	}
+	}, nil
 }
 
 func signalChanPtr() *chan struct{} {
 	c := make(chan struct{}, 1)
 	return &c
 }
-
-// A StreamID identifies a stream of SSE events. It is globally unique.
-// [ServerSession].
-type StreamID string
 
 // We track the incoming request ID inside the handler context using
 // idContextValue, so that notifications and server->client calls that occur in
@@ -577,7 +553,7 @@ func (t *StreamableServerTransport) ServeHTTP(w http.ResponseWriter, req *http.R
 // It returns an HTTP status code and error message.
 func (c *streamableServerConn) serveGET(w http.ResponseWriter, req *http.Request) {
 	// connID 0 corresponds to the default GET request.
-	id := StreamID("")
+	id := ""
 	// By default, we haven't seen a last index. Since indices start at 0, we represent
 	// that by -1. This is incremented just before each event is written, in streamResponse
 	// around L407.
@@ -630,19 +606,25 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 		http.Error(w, "POST requires a non-empty body", http.StatusBadRequest)
 		return
 	}
-	// TODO(#21): if the negotiated protocol version is 2025-06-18 or later,
-	// we should not allow batching here.
-	//
-	// This also requires access to the negotiated version, which would either be
-	// set by the MCP-Protocol-Version header, or would require peeking into the
-	// session.
-	incoming, _, err := readBatch(body)
+	incoming, isBatch, err := readBatch(body)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("malformed payload: %v", err), http.StatusBadRequest)
 		return
 	}
+
+	protocolVersion := req.Header.Get(protocolVersionHeader)
+	if protocolVersion == "" {
+		protocolVersion = protocolVersion20250326
+	}
+
+	if isBatch && protocolVersion >= protocolVersion20250618 {
+		http.Error(w, fmt.Sprintf("JSON-RPC batching is not supported in %s and later (request version: %s)", protocolVersion20250618, protocolVersion), http.StatusBadRequest)
+		return
+	}
+
 	requests := make(map[jsonrpc.ID]struct{})
 	tokenInfo := auth.TokenInfoFromContext(req.Context())
+	isInitialize := false
 	for _, msg := range incoming {
 		if jreq, ok := msg.(*jsonrpc.Request); ok {
 			// Preemptively check that this is a valid request, so that we can fail
@@ -651,6 +633,9 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 			if _, err := checkRequest(jreq, serverMethodInfos); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
+			}
+			if jreq.Method == methodInitialize {
+				isInitialize = true
 			}
 			jreq.Extra = &RequestExtra{
 				TokenInfo: tokenInfo,
@@ -668,7 +653,11 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 	// notifications or server->client requests made in the course of handling.
 	// Update accounting for this incoming payload.
 	if len(requests) > 0 {
-		stream = newStream(StreamID(randText()), c.jsonResponse)
+		stream, err = c.newStream(req.Context(), randText(), isInitialize, c.jsonResponse)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("storing stream: %v", err), http.StatusInternalServerError)
+			return
+		}
 		c.mu.Lock()
 		c.streams[stream.id] = stream
 		stream.requests = requests
@@ -700,19 +689,19 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 func (c *streamableServerConn) respondJSON(stream *stream, w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache, no-transform")
 	w.Header().Set("Content-Type", "application/json")
-	if c.sessionID != "" {
+	if c.sessionID != "" && stream.isInitialize {
 		w.Header().Set(sessionIDHeader, c.sessionID)
 	}
 
 	var msgs []json.RawMessage
 	ctx := req.Context()
-	for msg, ok := range c.messages(ctx, stream, false) {
-		if !ok {
+	for msg, err := range c.messages(ctx, stream, false, -1) {
+		if err != nil {
 			if ctx.Err() != nil {
 				w.WriteHeader(http.StatusNoContent)
 				return
 			} else {
-				http.Error(w, http.StatusText(http.StatusGone), http.StatusGone)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
 		}
@@ -735,17 +724,28 @@ func (c *streamableServerConn) respondJSON(stream *stream, w http.ResponseWriter
 
 // lastIndex is the index of the last seen event if resuming, else -1.
 func (c *streamableServerConn) respondSSE(stream *stream, w http.ResponseWriter, req *http.Request, lastIndex int, persistent bool) {
-	writes := 0
-
-	// Accept checked in [StreamableHTTPHandler]
+	// Accept was checked in [StreamableHTTPHandler]
 	w.Header().Set("Cache-Control", "no-cache, no-transform")
 	w.Header().Set("Content-Type", "text/event-stream") // Accept checked in [StreamableHTTPHandler]
 	w.Header().Set("Connection", "keep-alive")
-	if c.sessionID != "" {
+	if c.sessionID != "" && stream.isInitialize {
 		w.Header().Set(sessionIDHeader, c.sessionID)
+	}
+	if persistent {
+		// Issue #410: the hanging GET is likely not to receive messages for a long
+		// time. Ensure that headers are flushed.
+		//
+		// For non-persistent requests, delay the writing of the header in case we
+		// may want to set an error status.
+		// (see the TODO: this probably isn't worth it).
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
 	}
 
 	// write one event containing data.
+	writes := 0
 	write := func(data []byte) bool {
 		lastIndex++
 		e := Event{
@@ -762,50 +762,20 @@ func (c *streamableServerConn) respondSSE(stream *stream, w http.ResponseWriter,
 		return true
 	}
 
-	errorf := func(code int, format string, args ...any) {
-		if writes == 0 {
-			http.Error(w, fmt.Sprintf(format, args...), code)
-		} else {
-			// TODO(#170): log when we add server-side logging
-		}
-	}
-
-	if lastIndex >= 0 {
-		// Resume.
-		for data, err := range c.eventStore.After(req.Context(), c.SessionID(), stream.id, lastIndex) {
-			if err != nil {
-				// TODO: reevaluate these status codes.
-				// Maybe distinguish between storage errors, which are 500s, and missing
-				// session or stream ID--can these arise from bad input?
-				status := http.StatusInternalServerError
-				if errors.Is(err, ErrEventsPurged) {
-					status = http.StatusInsufficientStorage
-				}
-				errorf(status, "failed to read events: %v", err)
-				return
-			}
-			// The iterator yields events beginning just after lastIndex, or it would have
-			// yielded an error.
-			if !write(data) {
-				return
-			}
-		}
-	}
-
 	// Repeatedly collect pending outgoing events and send them.
 	ctx := req.Context()
-	for msg, ok := range c.messages(ctx, stream, persistent) {
-		if !ok {
-			if ctx.Err() != nil && writes == 0 {
-				// This probably doesn't matter, but respond with NoContent if the client disconnected.
-				w.WriteHeader(http.StatusNoContent)
+	for msg, err := range c.messages(ctx, stream, persistent, lastIndex) {
+		if err != nil {
+			if ctx.Err() == nil && writes == 0 && !persistent {
+				// If we haven't yet written the header, we have an opportunity to
+				// promote an error to an HTTP error.
+				//
+				// TODO: This may not matter in practice, in which case we should
+				// simplify.
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			} else {
-				errorf(http.StatusGone, "stream terminated")
+				// TODO(#170): log when we add server-side logging
 			}
-			return
-		}
-		if err := c.eventStore.Append(req.Context(), c.SessionID(), stream.id, msg); err != nil {
-			errorf(http.StatusInternalServerError, "storing event: %v", err.Error())
 			return
 		}
 		if !write(msg) {
@@ -816,27 +786,33 @@ func (c *streamableServerConn) respondSSE(stream *stream, w http.ResponseWriter,
 
 // messages iterates over messages sent to the current stream.
 //
+// persistent indicates if it is the main GET listener, which should never be
+// terminated.
+// lastIndex is the index of the last seen event, iteration begins at lastIndex+1.
+//
 // The first iterated value is the received JSON message. The second iterated
-// value is an OK value indicating whether the stream terminated normally.
+// value is an error value indicating whether the stream terminated normally.
+// Iteration ends at the first non-nil error.
 //
 // If the stream did not terminate normally, it is either because ctx was
 // cancelled, or the connection is closed: check the ctx.Err() to differentiate
 // these cases.
-func (c *streamableServerConn) messages(ctx context.Context, stream *stream, persistent bool) iter.Seq2[json.RawMessage, bool] {
-	return func(yield func(json.RawMessage, bool) bool) {
+func (c *streamableServerConn) messages(ctx context.Context, stream *stream, persistent bool, lastIndex int) iter.Seq2[json.RawMessage, error] {
+	return func(yield func(json.RawMessage, error) bool) {
 		for {
 			c.mu.Lock()
-			outgoing := stream.outgoing
-			stream.outgoing = nil
 			nOutstanding := len(stream.requests)
 			c.mu.Unlock()
-
-			for _, data := range outgoing {
-				if !yield(data, true) {
+			for data, err := range c.eventStore.After(ctx, c.SessionID(), stream.id, lastIndex) {
+				if err != nil {
+					yield(nil, err)
 					return
 				}
+				if !yield(data, nil) {
+					return
+				}
+				lastIndex++
 			}
-
 			// If all requests have been handled and replied to, we should terminate this connection.
 			// "After the JSON-RPC response has been sent, the server SHOULD close the SSE stream."
 			// §6.4, https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server
@@ -850,13 +826,14 @@ func (c *streamableServerConn) messages(ctx context.Context, stream *stream, per
 			case <-*stream.signal.Load(): // there are new outgoing messages
 				// return to top of loop
 			case <-c.done: // session is closed
-				yield(nil, false)
+				yield(nil, errors.New("session is closed"))
 				return
 			case <-ctx.Done():
-				yield(nil, false)
+				yield(nil, ctx.Err())
 				return
 			}
 		}
+
 	}
 }
 
@@ -867,7 +844,7 @@ func (c *streamableServerConn) messages(ctx context.Context, stream *stream, per
 // streamID and message index idx.
 //
 // See also [parseEventID].
-func formatEventID(sid StreamID, idx int) string {
+func formatEventID(sid string, idx int) string {
 	return fmt.Sprintf("%s_%d", sid, idx)
 }
 
@@ -875,17 +852,17 @@ func formatEventID(sid StreamID, idx int) string {
 // index.
 //
 // See also [formatEventID].
-func parseEventID(eventID string) (sid StreamID, idx int, ok bool) {
+func parseEventID(eventID string) (streamID string, idx int, ok bool) {
 	parts := strings.Split(eventID, "_")
 	if len(parts) != 2 {
 		return "", 0, false
 	}
-	stream := StreamID(parts[0])
+	streamID = parts[0]
 	idx, err := strconv.Atoi(parts[1])
 	if err != nil || idx < 0 {
 		return "", 0, false
 	}
-	return StreamID(stream), idx, true
+	return streamID, idx, true
 }
 
 // Read implements the [Connection] interface.
@@ -929,7 +906,7 @@ func (c *streamableServerConn) Write(ctx context.Context, msg jsonrpc.Message) e
 	//
 	// For messages sent outside of a request context, this is the default
 	// connection "".
-	var forStream StreamID
+	var forStream string
 	if forRequest.IsValid() {
 		c.mu.Lock()
 		forStream = c.requestStreams[forRequest]
@@ -963,9 +940,9 @@ func (c *streamableServerConn) Write(ctx context.Context, msg jsonrpc.Message) e
 		stream = c.streams[""]
 	}
 
-	// TODO: if there is nothing to send these messages to (as would happen, for example, if forConn == ""
-	// and the client never did a GET), then memory will grow without bound. Consider a mitigation.
-	stream.outgoing = append(stream.outgoing, data)
+	if err := c.eventStore.Append(ctx, c.SessionID(), stream.id, data); err != nil {
+		return fmt.Errorf("error storing event: %w", err)
+	}
 	if isResponse {
 		// Once we've put the reply on the queue, it's no longer outstanding.
 		delete(stream.requests, forRequest)
@@ -1005,6 +982,14 @@ type StreamableClientTransport struct {
 	// MaxRetries is the maximum number of times to attempt a reconnect before giving up.
 	// It defaults to 5. To disable retries, use a negative number.
 	MaxRetries int
+
+	// TODO(rfindley): propose exporting these.
+	// If strict is set, the transport is in 'strict mode', where any violation
+	// of the MCP spec causes a failure.
+	strict bool
+	// If logger is set, it is used to log aspects of the transport, such as spec
+	// violations that were ignored.
+	logger *slog.Logger
 }
 
 // These settings are not (yet) exposed to the user in
@@ -1019,34 +1004,6 @@ const (
 	// reconnectMaxDelay caps the backoff delay, preventing it from growing indefinitely.
 	reconnectMaxDelay = 30 * time.Second
 )
-
-// StreamableClientTransportOptions provides options for the
-// [NewStreamableClientTransport] constructor.
-//
-// Deprecated: use a StremableClientTransport literal.
-type StreamableClientTransportOptions struct {
-	// HTTPClient is the client to use for making HTTP requests. If nil,
-	// http.DefaultClient is used.
-	HTTPClient *http.Client
-	// MaxRetries is the maximum number of times to attempt a reconnect before giving up.
-	// It defaults to 5. To disable retries, use a negative number.
-	MaxRetries int
-}
-
-// NewStreamableClientTransport returns a new client transport that connects to
-// the streamable HTTP server at the provided URL.
-//
-// Deprecated: use a StreamableClientTransport literal.
-//
-//go:fix inline
-func NewStreamableClientTransport(url string, opts *StreamableClientTransportOptions) *StreamableClientTransport {
-	t := &StreamableClientTransport{Endpoint: url}
-	if opts != nil {
-		t.HTTPClient = opts.HTTPClient
-		t.MaxRetries = opts.MaxRetries
-	}
-	return t
-}
 
 // Connect implements the [Transport] interface.
 //
@@ -1070,13 +1027,15 @@ func (t *StreamableClientTransport) Connect(ctx context.Context) (Connection, er
 	// Create a new cancellable context that will manage the connection's lifecycle.
 	// This is crucial for cleanly shutting down the background SSE listener by
 	// cancelling its blocking network operations, which prevents hangs on exit.
-	connCtx, cancel := context.WithCancel(context.Background())
+	connCtx, cancel := context.WithCancel(ctx)
 	conn := &streamableClientConn{
 		url:        t.Endpoint,
 		client:     client,
 		incoming:   make(chan jsonrpc.Message, 10),
 		done:       make(chan struct{}),
 		maxRetries: maxRetries,
+		strict:     t.strict,
+		logger:     t.logger,
 		ctx:        connCtx,
 		cancel:     cancel,
 		failed:     make(chan struct{}),
@@ -1091,6 +1050,8 @@ type streamableClientConn struct {
 	cancel     context.CancelFunc
 	incoming   chan jsonrpc.Message
 	maxRetries int
+	strict     bool         // from [StreamableClientTransport.strict]
+	logger     *slog.Logger // from [StreamableClientTransport.logger]
 
 	// Guard calls to Close, as it may be called multiple times.
 	closeOnce sync.Once
@@ -1114,6 +1075,17 @@ type streamableClientConn struct {
 	sessionID         string
 }
 
+// errSessionMissing distinguishes if the session is known to not be present on
+// the server (see [streamableClientConn.fail]).
+//
+// TODO(rfindley): should we expose this error value (and its corresponding
+// API) to the user?
+//
+// The spec says that if the server returns 404, clients should reestablish
+// a session. For now, we delegate that to the user, but do they need a way to
+// differentiate a 'NotFound' error from other errors?
+var errSessionMissing = errors.New("session not found")
+
 var _ clientConnection = (*streamableClientConn)(nil)
 
 func (c *streamableClientConn) sessionUpdated(state clientSessionState) {
@@ -1134,13 +1106,17 @@ func (c *streamableClientConn) sessionUpdated(state clientSessionState) {
 	// § 2.5: A server using the Streamable HTTP transport MAY assign a session
 	// ID at initialization time, by including it in an Mcp-Session-Id header
 	// on the HTTP response containing the InitializeResult.
-	go c.handleSSE(nil, true, nil)
+	go c.handleSSE("hanging GET", nil, true, nil)
 }
 
 // fail handles an asynchronous error while reading.
 //
 // If err is non-nil, it is terminal, and subsequent (or pending) Reads will
 // fail.
+//
+// If err wraps errSessionMissing, the failure indicates that the session is no
+// longer present on the server, and no final DELETE will be performed when
+// closing the connection.
 func (c *streamableClientConn) fail(err error) {
 	if err != nil {
 		c.failOnce.Do(func() {
@@ -1188,9 +1164,21 @@ func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) e
 		return err
 	}
 
+	var requestSummary string
+	var isCall bool
+	switch msg := msg.(type) {
+	case *jsonrpc.Request:
+		requestSummary = fmt.Sprintf("sending %q", msg.Method)
+		isCall = msg.IsCall()
+	case *jsonrpc.Response:
+		requestSummary = fmt.Sprintf("sending jsonrpc response #%d", msg.ID)
+	default:
+		panic("unreachable")
+	}
+
 	data, err := jsonrpc.EncodeMessage(msg)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %v", requestSummary, err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(data))
@@ -1203,9 +1191,21 @@ func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) e
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %v", requestSummary, err)
 	}
 
+	// §2.5.3: "The server MAY terminate the session at any time, after
+	// which it MUST respond to requests containing that session ID with HTTP
+	// 404 Not Found."
+	if resp.StatusCode == http.StatusNotFound {
+		// Fail the session immediately, rather than relying on jsonrpc2 to fail
+		// (and close) it, because we want the call to Close to know that this
+		// session is missing (and therefore not send the DELETE).
+		err := fmt.Errorf("%s: failed to send: %w", requestSummary, errSessionMissing)
+		c.fail(err)
+		resp.Body.Close()
+		return err
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		resp.Body.Close()
 		return fmt.Errorf("broken session: %v", resp.Status)
@@ -1224,28 +1224,41 @@ func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) e
 		}
 	}
 	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusAccepted {
+		// [§2.1.4]: "If the input is a JSON-RPC response or notification:
+		// If the server accepts the input, the server MUST return HTTP status code 202 Accepted with no body."
+		//
+		// [§2.1.4]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server
+		resp.Body.Close()
+		return nil
+	} else if !isCall && !c.strict {
+		// Some servers return 200, even with an empty json body.
+		// Ignore this response in non-strict mode.
+		if c.logger != nil {
+			c.logger.Warn(fmt.Sprintf("unexpected status code %d from non-call", resp.StatusCode))
+		}
 		resp.Body.Close()
 		return nil
 	}
 
-	switch ct := resp.Header.Get("Content-Type"); ct {
+	contentType := strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0])
+	switch contentType {
 	case "application/json":
-		go c.handleJSON(resp)
+		go c.handleJSON(requestSummary, resp)
 
 	case "text/event-stream":
 		jsonReq, _ := msg.(*jsonrpc.Request)
-		go c.handleSSE(resp, false, jsonReq)
+		go c.handleSSE(requestSummary, resp, false, jsonReq)
 
 	default:
 		resp.Body.Close()
-		return fmt.Errorf("unsupported content type %q", ct)
+		return fmt.Errorf("%s: unsupported content type %q", requestSummary, contentType)
 	}
 	return nil
 }
 
 // testAuth controls whether a fake Authorization header is added to outgoing requests.
 // TODO: replace with a better mechanism when client-side auth is in place.
-var testAuth = false
+var testAuth atomic.Bool
 
 func (c *streamableClientConn) setMCPHeaders(req *http.Request) {
 	c.mu.Lock()
@@ -1257,21 +1270,21 @@ func (c *streamableClientConn) setMCPHeaders(req *http.Request) {
 	if c.sessionID != "" {
 		req.Header.Set(sessionIDHeader, c.sessionID)
 	}
-	if testAuth {
+	if testAuth.Load() {
 		req.Header.Set("Authorization", "Bearer foo")
 	}
 }
 
-func (c *streamableClientConn) handleJSON(resp *http.Response) {
+func (c *streamableClientConn) handleJSON(requestSummary string, resp *http.Response) {
 	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		c.fail(err)
+		c.fail(fmt.Errorf("%s: failed to read body: %v", requestSummary, err))
 		return
 	}
 	msg, err := jsonrpc.DecodeMessage(body)
 	if err != nil {
-		c.fail(fmt.Errorf("failed to decode response: %v", err))
+		c.fail(fmt.Errorf("%s: failed to decode response: %v", requestSummary, err))
 		return
 	}
 	select {
@@ -1286,12 +1299,12 @@ func (c *streamableClientConn) handleJSON(resp *http.Response) {
 //
 // If forReq is set, it is the request that initiated the stream, and the
 // stream is complete when we receive its response.
-func (c *streamableClientConn) handleSSE(initialResp *http.Response, persistent bool, forReq *jsonrpc2.Request) {
+func (c *streamableClientConn) handleSSE(requestSummary string, initialResp *http.Response, persistent bool, forReq *jsonrpc2.Request) {
 	resp := initialResp
 	var lastEventID string
 	for {
 		if resp != nil {
-			eventID, clientClosed := c.processStream(resp, forReq)
+			eventID, clientClosed := c.processStream(requestSummary, resp, forReq)
 			lastEventID = eventID
 
 			// If the connection was closed by the client, we're done.
@@ -1309,18 +1322,41 @@ func (c *streamableClientConn) handleSSE(initialResp *http.Response, persistent 
 		newResp, err := c.reconnect(lastEventID)
 		if err != nil {
 			// All reconnection attempts failed: fail the connection.
-			c.fail(err)
+			c.fail(fmt.Errorf("%s: failed to reconnect (session ID: %v): %v", requestSummary, c.sessionID, err))
 			return
 		}
 		resp = newResp
 		if resp.StatusCode == http.StatusMethodNotAllowed && persistent {
+			// [§2.2.3]: "The server MUST either return Content-Type:
+			// text/event-stream in response to this HTTP GET, or else return HTTP
+			// 405 Method Not Allowed, indicating that the server does not offer an
+			// SSE stream at this endpoint."
+			//
+			// [§2.2.3]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server
+
 			// The server doesn't support the hanging GET.
 			resp.Body.Close()
 			return
 		}
+		if resp.StatusCode == http.StatusNotFound && persistent && !c.strict {
+			// modelcontextprotocol/gosdk#393: some servers return NotFound instead
+			// of MethodNotAllowed for the persistent GET.
+			//
+			// Treat this like MethodNotAllowed in non-strict mode.
+			if c.logger != nil {
+				c.logger.Warn("got 404 instead of 405 for hanging GET")
+			}
+			resp.Body.Close()
+			return
+		}
+		// (see equivalent handling in [streamableClientConn.Write]).
+		if resp.StatusCode == http.StatusNotFound {
+			c.fail(fmt.Errorf("%s: failed to reconnect (session ID: %v): %w", requestSummary, c.sessionID, errSessionMissing))
+			return
+		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			resp.Body.Close()
-			c.fail(fmt.Errorf("failed to reconnect: %v", http.StatusText(resp.StatusCode)))
+			c.fail(fmt.Errorf("%s: failed to reconnect: %v", requestSummary, http.StatusText(resp.StatusCode)))
 			return
 		}
 		// Reconnection was successful. Continue the loop with the new response.
@@ -1331,7 +1367,7 @@ func (c *streamableClientConn) handleSSE(initialResp *http.Response, persistent 
 // incoming channel. It returns the ID of the last processed event and a flag
 // indicating if the connection was closed by the client. If resp is nil, it
 // returns "", false.
-func (c *streamableClientConn) processStream(resp *http.Response, forReq *jsonrpc.Request) (lastEventID string, clientClosed bool) {
+func (c *streamableClientConn) processStream(requestSummary string, resp *http.Response, forReq *jsonrpc.Request) (lastEventID string, clientClosed bool) {
 	defer resp.Body.Close()
 	for evt, err := range scanEvents(resp.Body) {
 		if err != nil {
@@ -1344,7 +1380,7 @@ func (c *streamableClientConn) processStream(resp *http.Response, forReq *jsonrp
 
 		msg, err := jsonrpc.DecodeMessage(evt.Data)
 		if err != nil {
-			c.fail(fmt.Errorf("failed to decode event: %v", err))
+			c.fail(fmt.Errorf("%s: failed to decode event: %v", requestSummary, err))
 			return "", true
 		}
 
@@ -1404,19 +1440,23 @@ func (c *streamableClientConn) reconnect(lastEventID string) (*http.Response, er
 // Close implements the [Connection] interface.
 func (c *streamableClientConn) Close() error {
 	c.closeOnce.Do(func() {
-		// Cancel any hanging network requests.
-		c.cancel()
-		close(c.done)
-
-		req, err := http.NewRequest(http.MethodDelete, c.url, nil)
-		if err != nil {
-			c.closeErr = err
+		if errors.Is(c.failure(), errSessionMissing) {
+			// If the session is missing, no need to delete it.
 		} else {
-			c.setMCPHeaders(req)
-			if _, err := c.client.Do(req); err != nil {
+			req, err := http.NewRequestWithContext(c.ctx, http.MethodDelete, c.url, nil)
+			if err != nil {
 				c.closeErr = err
+			} else {
+				c.setMCPHeaders(req)
+				if _, err := c.client.Do(req); err != nil {
+					c.closeErr = err
+				}
 			}
 		}
+
+		// Cancel any hanging network requests after cleanup.
+		c.cancel()
+		close(c.done)
 	})
 	return c.closeErr
 }

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/tool.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/tool.go
@@ -5,7 +5,6 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,12 +13,46 @@ import (
 )
 
 // A ToolHandler handles a call to tools/call.
-// [CallToolParams.Arguments] will contain a map[string]any that has been validated
-// against the input schema.
+//
+// This is a low-level API, for use with [Server.AddTool]. It does not do any
+// pre- or post-processing of the request or result: the params contain raw
+// arguments, no input validation is performed, and the result is returned to
+// the user as-is, without any validation of the output.
+//
+// Most users will write a [ToolHandlerFor] and install it with the generic
+// [AddTool] function.
+//
+// If ToolHandler returns an error, it is treated as a protocol error. By
+// contrast, [ToolHandlerFor] automatically populates [CallToolResult.IsError]
+// and [CallToolResult.Content] accordingly.
 type ToolHandler func(context.Context, *CallToolRequest) (*CallToolResult, error)
 
 // A ToolHandlerFor handles a call to tools/call with typed arguments and results.
-type ToolHandlerFor[In, Out any] func(context.Context, *CallToolRequest, In) (*CallToolResult, Out, error)
+//
+// Use [AddTool] to add a ToolHandlerFor to a server.
+//
+// Unlike [ToolHandler], [ToolHandlerFor] provides significant functionality
+// out of the box, and enforces that the tool conforms to the MCP spec:
+//   - The In type provides a default input schema for the tool, though it may
+//     be overridden in [AddTool].
+//   - The input value is automatically unmarshaled from req.Params.Arguments.
+//   - The input value is automatically validated against its input schema.
+//     Invalid input is rejected before getting to the handler.
+//   - If the Out type is not the empty interface [any], it provides the
+//     default output schema for the tool (which again may be overridden in
+//     [AddTool]).
+//   - The Out value is used to populate result.StructuredOutput.
+//   - If [CallToolResult.Content] is unset, it is populated with the JSON
+//     content of the output.
+//   - An error result is treated as a tool error, rather than a protocol
+//     error, and is therefore packed into CallToolResult.Content, with
+//     [IsError] set.
+//
+// For these reasons, most users can ignore the [CallToolRequest] argument and
+// [CallToolResult] return values entirely. In fact, it is permissible to
+// return a nil CallToolResult, if you only care about returning a output value
+// or error. The effective result will be populated as described above.
+type ToolHandlerFor[In, Out any] func(_ context.Context, request *CallToolRequest, input In) (result *CallToolResult, output Out, _ error)
 
 // A serverTool is a tool definition that is bound to a tool handler.
 type serverTool struct {
@@ -27,38 +60,44 @@ type serverTool struct {
 	handler ToolHandler
 }
 
-// unmarshalSchema unmarshals data into v and validates the result according to
-// the given resolved schema.
-func unmarshalSchema(data json.RawMessage, resolved *jsonschema.Resolved, v any) error {
+// applySchema validates whether data is valid JSON according to the provided
+// schema, after applying schema defaults.
+//
+// Returns the JSON value augmented with defaults.
+func applySchema(data json.RawMessage, resolved *jsonschema.Resolved) (json.RawMessage, error) {
 	// TODO: use reflection to create the struct type to unmarshal into.
 	// Separate validation from assignment.
 
-	// Disallow unknown fields.
-	// Otherwise, if the tool was built with a struct, the client could send extra
-	// fields and json.Unmarshal would ignore them, so the schema would never get
-	// a chance to declare the extra args invalid.
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(v); err != nil {
-		return fmt.Errorf("unmarshaling: %w", err)
-	}
-	// TODO: test with nil args.
+	// Use default JSON marshalling for validation.
+	//
+	// This avoids inconsistent representation due to custom marshallers, such as
+	// time.Time (issue #449).
+	//
+	// Additionally, unmarshalling into a map ensures that the resulting JSON is
+	// at least {}, even if data is empty. For example, arguments is technically
+	// an optional property of callToolParams, and we still want to apply the
+	// defaults in this case.
+	//
+	// TODO(rfindley): in which cases can resolved be nil?
 	if resolved != nil {
-		if err := resolved.ApplyDefaults(v); err != nil {
-			return fmt.Errorf("applying defaults from \n\t%s\nto\n\t%s:\n%w", schemaJSON(resolved.Schema()), data, err)
+		v := make(map[string]any)
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &v); err != nil {
+				return nil, fmt.Errorf("unmarshaling arguments: %w", err)
+			}
 		}
-		if err := resolved.Validate(v); err != nil {
-			return fmt.Errorf("validating\n\t%s\nagainst\n\t %s:\n %w", data, schemaJSON(resolved.Schema()), err)
+		if err := resolved.ApplyDefaults(&v); err != nil {
+			return nil, fmt.Errorf("applying schema defaults:\n%w", err)
+		}
+		if err := resolved.Validate(&v); err != nil {
+			return nil, err
+		}
+		// We must re-marshal with the default values applied.
+		var err error
+		data, err = json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling with defaults: %v", err)
 		}
 	}
-	return nil
-}
-
-// schemaJSON returns the JSON value for s as a string, or a string indicating an error.
-func schemaJSON(s *jsonschema.Schema) string {
-	m, err := json.Marshal(s)
-	if err != nil {
-		return fmt.Sprintf("<!%s>", err)
-	}
-	return string(m)
+	return data, nil
 }

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/transport.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/transport.go
@@ -93,16 +93,6 @@ func (*StdioTransport) Connect(context.Context) (Connection, error) {
 	return newIOConn(rwc{os.Stdin, os.Stdout}), nil
 }
 
-// NewStdioTransport constructs a transport that communicates over
-// stdin/stdout.
-//
-// Deprecated: use a StdioTransport literal.
-//
-//go:fix inline
-func NewStdioTransport() *StdioTransport {
-	return &StdioTransport{}
-}
-
 // An InMemoryTransport is a [Transport] that communicates over an in-memory
 // network connection, using newline-delimited JSON.
 type InMemoryTransport struct {
@@ -114,8 +104,12 @@ func (t *InMemoryTransport) Connect(context.Context) (Connection, error) {
 	return newIOConn(t.rwc), nil
 }
 
-// NewInMemoryTransports returns two [InMemoryTransports] that connect to each
-// other.
+// NewInMemoryTransports returns two [InMemoryTransport] objects that connect
+// to each other.
+//
+// The resulting transports are symmetrical: use either to connect to a server,
+// and then the other to connect to a client. Servers must be connected before
+// clients, as the client initializes the MCP session during connection.
 func NewInMemoryTransports() (*InMemoryTransport, *InMemoryTransport) {
 	c1, c2 := net.Pipe()
 	return &InMemoryTransport{c1}, &InMemoryTransport{c2}
@@ -194,7 +188,7 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 	err := call.Await(ctx, result)
 	switch {
 	case errors.Is(err, jsonrpc2.ErrClientClosing), errors.Is(err, jsonrpc2.ErrServerClosing):
-		return fmt.Errorf("calling %q: %w", method, ErrConnectionClosed)
+		return fmt.Errorf("%w: calling %q: %v", ErrConnectionClosed, method, err)
 	case ctx.Err() != nil:
 		// Notify the peer of cancellation.
 		err := conn.Notify(xcontext.Detach(ctx), notificationCancelled, &CancelledParams{
@@ -215,16 +209,6 @@ type LoggingTransport struct {
 	Writer    io.Writer
 }
 
-// NewLoggingTransport creates a new LoggingTransport that delegates to the
-// provided transport, writing RPC logs to the provided io.Writer.
-//
-// Deprecated: use a LoggingTransport literal.
-//
-//go:fix inline
-func NewLoggingTransport(delegate Transport, w io.Writer) *LoggingTransport {
-	return &LoggingTransport{Transport: delegate, Writer: w}
-}
-
 // Connect connects the underlying transport, returning a [Connection] that writes
 // logs to the configured destination.
 func (t *LoggingTransport) Connect(ctx context.Context) (Connection, error) {
@@ -232,12 +216,14 @@ func (t *LoggingTransport) Connect(ctx context.Context) (Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &loggingConn{delegate, t.Writer}, nil
+	return &loggingConn{delegate: delegate, w: t.Writer}, nil
 }
 
 type loggingConn struct {
 	delegate Connection
-	w        io.Writer
+
+	mu sync.Mutex
+	w  io.Writer
 }
 
 func (c *loggingConn) SessionID() string { return c.delegate.SessionID() }
@@ -245,15 +231,21 @@ func (c *loggingConn) SessionID() string { return c.delegate.SessionID() }
 // Read is a stream middleware that logs incoming messages.
 func (s *loggingConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 	msg, err := s.delegate.Read(ctx)
+
 	if err != nil {
-		fmt.Fprintf(s.w, "read error: %v", err)
+		s.mu.Lock()
+		fmt.Fprintf(s.w, "read error: %v\n", err)
+		s.mu.Unlock()
 	} else {
 		data, err := jsonrpc2.EncodeMessage(msg)
+		s.mu.Lock()
 		if err != nil {
 			fmt.Fprintf(s.w, "LoggingTransport: failed to marshal: %v", err)
 		}
 		fmt.Fprintf(s.w, "read: %s\n", string(data))
+		s.mu.Unlock()
 	}
+
 	return msg, err
 }
 
@@ -261,13 +253,17 @@ func (s *loggingConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 func (s *loggingConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	err := s.delegate.Write(ctx, msg)
 	if err != nil {
-		fmt.Fprintf(s.w, "write error: %v", err)
+		s.mu.Lock()
+		fmt.Fprintf(s.w, "write error: %v\n", err)
+		s.mu.Unlock()
 	} else {
 		data, err := jsonrpc2.EncodeMessage(msg)
+		s.mu.Lock()
 		if err != nil {
 			fmt.Fprintf(s.w, "LoggingTransport: failed to marshal: %v", err)
 		}
 		fmt.Fprintf(s.w, "write: %s\n", string(data))
+		s.mu.Unlock()
 	}
 	return err
 }
@@ -303,6 +299,8 @@ func (r rwc) Close() error {
 //
 // See [msgBatch] for more discussion of message batching.
 type ioConn struct {
+	protocolVersion string // negotiated version, set during session initialization.
+
 	writeMu sync.Mutex         // guards Write, which must be concurrency safe.
 	rwc     io.ReadWriteCloser // the underlying stream
 
@@ -379,6 +377,17 @@ func newIOConn(rwc io.ReadWriteCloser) *ioConn {
 }
 
 func (c *ioConn) SessionID() string { return "" }
+
+func (c *ioConn) sessionUpdated(state ServerSessionState) {
+	protocolVersion := ""
+	if state.InitializeParams != nil {
+		protocolVersion = state.InitializeParams.ProtocolVersion
+	}
+	if protocolVersion == "" {
+		protocolVersion = protocolVersion20250326
+	}
+	c.protocolVersion = negotiatedVersion(protocolVersion)
+}
 
 // addBatch records a msgBatch for an incoming batch payload.
 // It returns an error if batch is malformed, containing previously seen IDs.
@@ -478,6 +487,10 @@ func (t *ioConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 	if err != nil {
 		return nil, err
 	}
+	if batch && t.protocolVersion >= protocolVersion20250618 {
+		return nil, fmt.Errorf("JSON-RPC batching is not supported in %s and later (request version: %s)", protocolVersion20250618, t.protocolVersion)
+	}
+
 	t.queue = msgs[1:]
 
 	if batch {

--- a/vendor/github.com/modelcontextprotocol/go-sdk/mcp/util.go
+++ b/vendor/github.com/modelcontextprotocol/go-sdk/mcp/util.go
@@ -6,6 +6,7 @@ package mcp
 
 import (
 	"crypto/rand"
+	"encoding/json"
 )
 
 func assert(cond bool, msg string) {
@@ -26,4 +27,17 @@ func randText() string {
 		src[i] = base32alphabet[src[i]%32]
 	}
 	return string(src)
+}
+
+// remarshal marshals from to JSON, and then unmarshals into to, which must be
+// a pointer type.
+func remarshal(from, to any) error {
+	data, err := json.Marshal(from)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, to); err != nil {
+		return err
+	}
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -310,7 +310,7 @@ github.com/google/go-containerregistry/pkg/v1/static
 github.com/google/go-containerregistry/pkg/v1/stream
 github.com/google/go-containerregistry/pkg/v1/tarball
 github.com/google/go-containerregistry/pkg/v1/types
-# github.com/google/jsonschema-go v0.2.0
+# github.com/google/jsonschema-go v0.3.0
 ## explicit; go 1.23.0
 github.com/google/jsonschema-go/jsonschema
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -403,7 +403,7 @@ github.com/moby/sys/sequential
 ## explicit; go 1.18
 github.com/moby/term
 github.com/moby/term/windows
-# github.com/modelcontextprotocol/go-sdk v0.2.0 => github.com/slimslenderslacks/go-sdk v0.0.0-20250822220738-3d404486ee12
+# github.com/modelcontextprotocol/go-sdk v1.0.0
 ## explicit; go 1.23.0
 github.com/modelcontextprotocol/go-sdk/auth
 github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2
@@ -966,4 +966,3 @@ gopkg.in/yaml.v3
 ## explicit; go 1.17
 # k8s.io/client-go v0.33.1
 ## explicit; go 1.24.0
-# github.com/modelcontextprotocol/go-sdk => github.com/slimslenderslacks/go-sdk v0.0.0-20250822220738-3d404486ee12


### PR DESCRIPTION
**What I did**

The official MCP golang SDK has had the 1.0.0 release. There have been several breaking changes so there are some refactors here. This gets us off of my fork.

https://github.com/modelcontextprotocol/go-sdk/releases/tag/v1.0.0