### PR TITLE
Use v3 catalog URL when mcp-oauth-dcr feature is enabled

### DIFF
--- a/cmd/docker-mcp/catalog/catalog.go
+++ b/cmd/docker-mcp/catalog/catalog.go
@@ -9,9 +9,11 @@ import (
 )
 
 const (
-	DockerCatalogName     = "docker-mcp"
-	DockerCatalogURL      = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
-	DockerCatalogFilename = "docker-mcp.yaml"
+	DockerCatalogName       = "docker-mcp"
+	DockerCatalogURLV2      = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
+	DockerCatalogURLV3      = "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml"
+	DockerCatalogURL        = DockerCatalogURLV2 // Default to v2
+	DockerCatalogFilename   = "docker-mcp.yaml"
 
 	// Docker server names for bootstrap command
 	DockerHubServerName = "dockerhub"
@@ -20,6 +22,14 @@ const (
 
 var aliasToURL = map[string]string{
 	DockerCatalogName: DockerCatalogURL,
+}
+
+// GetDockerCatalogURL returns the appropriate Docker catalog URL based on the mcp-oauth-dcr flag
+func GetDockerCatalogURL(mcpOAuthDcrEnabled bool) string {
+	if mcpOAuthDcrEnabled {
+		return DockerCatalogURLV3
+	}
+	return DockerCatalogURLV2
 }
 
 type MetaData struct {

--- a/cmd/docker-mcp/catalog/catalog.go
+++ b/cmd/docker-mcp/catalog/catalog.go
@@ -9,11 +9,10 @@ import (
 )
 
 const (
-	DockerCatalogName       = "docker-mcp"
-	DockerCatalogURLV2      = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
-	DockerCatalogURLV3      = "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml"
-	DockerCatalogURL        = DockerCatalogURLV2 // Default to v2
-	DockerCatalogFilename   = "docker-mcp.yaml"
+	DockerCatalogName     = "docker-mcp"
+	DockerCatalogURLV2    = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
+	DockerCatalogURLV3    = "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml"
+	DockerCatalogFilename = "docker-mcp.yaml"
 
 	// Docker server names for bootstrap command
 	DockerHubServerName = "dockerhub"
@@ -21,7 +20,7 @@ const (
 )
 
 var aliasToURL = map[string]string{
-	DockerCatalogName: DockerCatalogURL,
+	DockerCatalogName: DockerCatalogURLV2, // Default to v2 for backwards compatibility
 }
 
 // GetDockerCatalogURL returns the appropriate Docker catalog URL based on the mcp-oauth-dcr flag

--- a/cmd/docker-mcp/catalog/show.go
+++ b/cmd/docker-mcp/catalog/show.go
@@ -52,7 +52,7 @@ func SupportedFormats() string {
 	return strings.Join(quoted, ", ")
 }
 
-func Show(ctx context.Context, name string, format Format) error {
+func Show(ctx context.Context, name string, format Format, mcpOAuthDcrEnabled bool) error {
 	cfg, err := ReadConfigWithDefaultCatalog(ctx)
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func Show(ctx context.Context, name string, format Format) error {
 		}
 	}
 	if needsUpdate {
-		if err := updateCatalog(ctx, name, catalog); err != nil {
+		if err := updateCatalog(ctx, name, catalog, mcpOAuthDcrEnabled); err != nil {
 			return err
 		}
 	}

--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -66,11 +66,9 @@ func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDc
 			isV2URL := strings.Contains(url, "/catalog/v2/catalog.yaml")
 			isV3URL := strings.Contains(url, "/catalog/v3/catalog.yaml")
 
-			// Only override if it's an official catalog URL with the wrong version
-			needsV3 := mcpOAuthDcrEnabled && isV2URL
-			needsV2 := !mcpOAuthDcrEnabled && isV3URL
-
-			if needsV3 || needsV2 {
+			// Override if it's an official catalog URL with the wrong version for the feature flag
+			wrongVersion := (mcpOAuthDcrEnabled && isV2URL) || (!mcpOAuthDcrEnabled && isV3URL)
+			if wrongVersion {
 				url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
 			}
 		}

--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -56,11 +56,11 @@ func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDc
 		err            error
 	)
 	// For the docker catalog, override URL to match the feature flag state if:
-	// 1. No URL is set, OR
+	// 1. No URL is set or invalid, OR
 	// 2. The URL is an official v2/v3 catalog URL (prod or staging) that doesn't match the feature flag
 	// This preserves truly custom URLs while ensuring official catalogs switch between v2/v3.
 	if name == DockerCatalogName {
-		if url == "" {
+		if url == "" || !isValidURL(url) {
 			url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
 		} else {
 			isV2URL := strings.Contains(url, "/catalog/v2/catalog.yaml")

--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -55,6 +55,7 @@ func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDc
 		err            error
 	)
 	// For the docker catalog, always use the appropriate URL based on feature flag
+	// to ensure it matches the current state regardless of what's stored in config
 	if name == DockerCatalogName {
 		url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
 	}

--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -63,12 +63,11 @@ func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDc
 		if url == "" || !isValidURL(url) {
 			url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
 		} else {
+			// If it's an official v2/v3 catalog URL, always use the URL that matches the feature flag
 			isV2URL := strings.Contains(url, "/catalog/v2/catalog.yaml")
 			isV3URL := strings.Contains(url, "/catalog/v3/catalog.yaml")
 
-			// Override if it's an official catalog URL with the wrong version for the feature flag
-			wrongVersion := (mcpOAuthDcrEnabled && isV2URL) || (!mcpOAuthDcrEnabled && isV3URL)
-			if wrongVersion {
+			if isV2URL || isV3URL {
 				url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
 			}
 		}

--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func Update(ctx context.Context, args []string) error {
+func Update(ctx context.Context, args []string, mcpOAuthDcrEnabled bool) error {
 	cfg, err := ReadConfig()
 	if err != nil {
 		return err
@@ -30,7 +30,7 @@ func Update(ctx context.Context, args []string) error {
 		if !ok {
 			continue
 		}
-		if err := updateCatalog(ctx, name, catalog); err != nil {
+		if err := updateCatalog(ctx, name, catalog, mcpOAuthDcrEnabled); err != nil {
 			errs = append(errs, err)
 		}
 		fmt.Println("updated:", name)
@@ -47,16 +47,16 @@ func getAllCatalogNames(cfg Config) []string {
 	return names
 }
 
-func updateCatalog(ctx context.Context, name string, catalog Catalog) error {
+func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDcrEnabled bool) error {
 	url := catalog.URL
 
 	var (
 		catalogContent []byte
 		err            error
 	)
-	// For the docker catalog, use the default URL if none is set
-	if name == DockerCatalogName && (url == "" || !isValidURL(url)) {
-		url = DockerCatalogURL
+	// For the docker catalog, always use the appropriate URL based on feature flag
+	if name == DockerCatalogName {
+		url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
 	}
 
 	if isValidURL(url) {

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -104,7 +104,7 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 
 			// Only add configured catalogs if defaultPaths is not a single Docker catalog entry
 			var configuredPaths []string
-			if len(defaultPaths) == 1 && (defaultPaths[0] == catalog.DockerCatalogURL || defaultPaths[0] == catalog.DockerCatalogURLV2 || defaultPaths[0] == catalog.DockerCatalogURLV3 || defaultPaths[0] == catalog.DockerCatalogFilename) {
+			if len(defaultPaths) == 1 && (defaultPaths[0] == catalog.DockerCatalogURLV2 || defaultPaths[0] == catalog.DockerCatalogURLV3 || defaultPaths[0] == catalog.DockerCatalogFilename) {
 				configuredPaths = getConfiguredCatalogPaths()
 			}
 			catalogPaths := buildUniqueCatalogPaths(defaultPaths, configuredPaths, additionalCatalogs)

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -227,13 +227,22 @@ func TestBuildUniqueCatalogPaths(t *testing.T) {
 }
 
 func TestConditionalConfiguredCatalogPaths(t *testing.T) {
-	t.Run("excludes configured catalogs when single Docker catalog URL", func(t *testing.T) {
-		// Test the logic for when defaultPaths contains only DockerCatalogURL
+	t.Run("excludes configured catalogs when single Docker catalog URL v2", func(t *testing.T) {
+		// Test the logic for when defaultPaths contains only DockerCatalogURLV2
 		defaultPaths := []string{"https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"}
 
 		// This should match the condition and return empty configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
-		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog URL")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog URL v2")
+	})
+
+	t.Run("excludes configured catalogs when single Docker catalog URL v3", func(t *testing.T) {
+		// Test the logic for when defaultPaths contains only DockerCatalogURLV3
+		defaultPaths := []string{"https://desktop.docker.com/mcp/catalog/v3/catalog.yaml"}
+
+		// This should match the condition and return empty configuredPaths
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog URL v3")
 	})
 
 	t.Run("excludes configured catalogs when single Docker catalog filename", func(t *testing.T) {
@@ -241,7 +250,7 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		defaultPaths := []string{"docker-mcp.yaml"}
 
 		// This should match the condition and return empty configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
 		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog filename")
 	})
 
@@ -250,7 +259,7 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		defaultPaths := []string{"docker-mcp.yaml", "other-catalog.yaml"}
 
 		// This should NOT match the condition and allow configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
 		assert.False(t, shouldExclude, "should include configured catalogs when multiple paths")
 	})
 
@@ -259,7 +268,7 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		defaultPaths := []string{"custom-catalog.yaml"}
 
 		// This should NOT match the condition and allow configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
 		assert.False(t, shouldExclude, "should include configured catalogs when single non-Docker catalog")
 	})
 }

--- a/cmd/docker-mcp/commands/root.go
+++ b/cmd/docker-mcp/commands/root.go
@@ -70,7 +70,7 @@ func Root(ctx context.Context, cwd string, dockerCli command.Cli) *cobra.Command
 
 	dockerClient := docker.NewClient(dockerCli)
 
-	cmd.AddCommand(catalogCommand())
+	cmd.AddCommand(catalogCommand(dockerCli))
 	cmd.AddCommand(clientCommand(cwd))
 	cmd.AddCommand(configCommand(dockerClient))
 	cmd.AddCommand(featureCommand(dockerCli))

--- a/docs/generator/reference/docker_mcp_catalog_show.yaml
+++ b/docs/generator/reference/docker_mcp_catalog_show.yaml
@@ -16,7 +16,12 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-examples: "  # Show Docker's official catalog\n  docker mcp catalog show\n  \n  # Show a specific catalog in JSON format\n  docker mcp catalog show my-catalog --format=json"
+examples: |4-
+      # Show Docker's official catalog
+      docker mcp catalog show
+
+      # Show a specific catalog in JSON format
+      docker mcp catalog show my-catalog --format=json
 deprecated: false
 hidden: false
 experimental: false

--- a/docs/generator/reference/docker_mcp_catalog_update.yaml
+++ b/docs/generator/reference/docker_mcp_catalog_update.yaml
@@ -6,7 +6,12 @@ long: |-
 usage: docker mcp catalog update [name]
 pname: docker mcp catalog
 plink: docker_mcp_catalog.yaml
-examples: "  # Update all catalogs\n  docker mcp catalog update\n  \n  # Update specific catalog\n  docker mcp catalog update team-servers"
+examples: |4-
+      # Update all catalogs
+      docker mcp catalog update
+
+      # Update specific catalog
+      docker mcp catalog update team-servers
 deprecated: false
 hidden: false
 experimental: false

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -65,7 +65,7 @@ services:
 + Starts an MCP Gateway for other services to use. Think AI Agents.
 + Work independently from Docker Desktop's MCP Toolkit. It can run anywhere there's a Docker engine.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 
 ### How to run
 

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -65,7 +65,7 @@ services:
 + Starts an MCP Gateway for other services to use. Think AI Agents.
 + Work independently from Docker Desktop's MCP Toolkit. It can run anywhere there's a Docker engine.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
 
 ### How to run
 

--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -4,7 +4,7 @@ This example shows how to call the MCP Gateway from a python client:
 
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 + Uses the latest http streaming transport.
 
 ## How to run

--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -4,7 +4,7 @@ This example shows how to call the MCP Gateway from a python client:
 
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
 + Uses the latest http streaming transport.
 
 ## How to run

--- a/examples/interceptors/README.md
+++ b/examples/interceptors/README.md
@@ -4,7 +4,7 @@ This example shows how to call the MCP Gateway from a python client:
 
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 + Uses the latest http streaming transport.
 
 ## How to run

--- a/examples/interceptors/README.md
+++ b/examples/interceptors/README.md
@@ -4,7 +4,7 @@ This example shows how to call the MCP Gateway from a python client:
 
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
 + Uses the latest http streaming transport.
 
 ## How to run

--- a/examples/minimal-compose/README.md
+++ b/examples/minimal-compose/README.md
@@ -5,7 +5,7 @@ This is a very minimalist example of running the MCP Gateway with Docker Compose
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
 + Doesn't define any secret.
-+ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 
 ## How to run
 

--- a/examples/minimal-compose/README.md
+++ b/examples/minimal-compose/README.md
@@ -5,7 +5,7 @@ This is a very minimalist example of running the MCP Gateway with Docker Compose
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
 + Doesn't define any secret.
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
 
 ## How to run
 

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -5,7 +5,7 @@ This is a simple example of running the MCP Gateway with Docker Compose:
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
 + Defines secrets in an `.env` file.
-+ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 
 ## How to run
 

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -5,7 +5,7 @@ This is a simple example of running the MCP Gateway with Docker Compose:
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
 + Defines secrets in an `.env` file.
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog hosted at http://desktop.docker.com/mcp/catalog (v2 by default, v3 when `mcp-oauth-dcr` feature is enabled).
 
 ## How to run
 

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -146,7 +146,7 @@ func TestIntegrationDryRunEmpty(t *testing.T) {
 
 func TestIntegrationDryRunFetch(t *testing.T) {
 	thisIsAnIntegrationTest(t)
-	out := runDockerMCP(t, "gateway", "run", "--dry-run", "--servers=fetch", "--catalog="+catalog.DockerCatalogURL)
+	out := runDockerMCP(t, "gateway", "run", "--dry-run", "--servers=fetch", "--catalog="+catalog.DockerCatalogURLV2)
 	assert.Contains(t, out, "fetch: (1 tools)")
 	assert.Contains(t, out, "Initialized in")
 }
@@ -178,7 +178,7 @@ func TestIntegrationCallToolDuckDuckDb(t *testing.T) {
 	thisIsAnIntegrationTest(t)
 	gatewayArgs := []string{
 		"--servers=duckduckgo",
-		"--catalog=" + catalog.DockerCatalogURL,
+		"--catalog=" + catalog.DockerCatalogURLV2,
 	}
 
 	out := runDockerMCP(t, "tools", "call", "--gateway-arg="+strings.Join(gatewayArgs, ","), "search", "query=Docker")


### PR DESCRIPTION
## Summary

This PR implements dynamic catalog URL selection based on the `mcp-oauth-dcr` feature flag, allowing the gateway to automatically switch between v2 and v3 catalog URLs.

## Test

`make docker-mcp`
`docker mcp feature enable mcp-oauth-dcr`
`docker mcp catalog update`
You should see 280 servers in the catalog
<img width="1339" height="788" alt="Screenshot 2025-10-02 at 12 54 29 PM" src="https://github.com/user-attachments/assets/35bfd0bd-4c6d-4c67-ac1c-e3fff49c0341" />

`docker mcp feature disable mcp-oauth-dcr`
`docker mcp catalog update`
You should see 224 servers in the catalog
<img width="1383" height="832" alt="Screenshot 2025-10-02 at 12 54 45 PM" src="https://github.com/user-attachments/assets/3fee2428-49e6-4e5c-89dc-bc09891689f9" />
