### PR TITLE
Migrate old versions of catalog

### DIFF
--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -66,6 +66,12 @@ func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDc
 			// If it's an official v2/v3 catalog URL, always use the URL that matches the feature flag
 			isV2URL := strings.Contains(url, "/catalog/v2/catalog.yaml")
 			isV3URL := strings.Contains(url, "/catalog/v3/catalog.yaml")
+			isV1URL := strings.Contains(url, "/catalog/catalog.yaml")
+
+			if isV1URL {
+				url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
+				catalog.URL = url
+			}
 
 			if isV2URL || isV3URL {
 				url = GetDockerCatalogURL(mcpOAuthDcrEnabled)


### PR DESCRIPTION
**What I did**

When an older version of the ~/.docker/mcp/catalog.json file was present:

```
{
  "catalogs": {
    "docker-mcp": {
      "displayName": "Docker MCP Catalog",
      "url": "https://desktop.docker.com/mcp/catalog/catalog.yaml",
      "lastUpdate": "2025-10-08T10:33:44-04:00"
    }
  }
}
```

It was matching neither the v2 or the v3 pattern so we were just leaving it alone. This has caused a problem now that Docker Desktop >4.47 requires either v2 or v3.

The fix is to detect old versions of the catalog and to treat the catalog as if it was not there, thus replacing it with either a v2 or v3 catalog and updating the docker-mcp entry with the new value.

I tested this by unzipping an old version of the catalog into ~/.docker/mcp and seeing that the catalog disappears in 4.48.  I think run `docker mcp catalog update` with this bug fix and see that the catalog repairs itself.

Docker desktop uses `docker mcp catalog update` to update the docker-mcp catalog so publishing this as a module update should fix the issue.

