### PR TITLE
improve catalog show output readability

### DIFF
--- a/cmd/docker-mcp/catalog/show.go
+++ b/cmd/docker-mcp/catalog/show.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
-	"golang.org/x/term"
+	"github.com/moby/term"
 	"gopkg.in/yaml.v3"
 
 	"github.com/docker/mcp-gateway/pkg/yq"
@@ -171,11 +171,12 @@ func isURL(fileOrURL string) bool {
 }
 
 func getTerminalWidth() int {
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	fd, _ := term.GetFdInfo(os.Stdout)
+	ws, err := term.GetWinsize(fd)
 	if err != nil {
 		return 80
 	}
-	return width
+	return int(ws.Width)
 }
 
 func wrapText(text string, width int, indent string) string {


### PR DESCRIPTION
**What I did**
Formatted the output of the `docker mcp catalog show` command to make it more readable.
* Bolden the server name
* Add padding
* Indent the description
* Add an empty line between entries
* Wrap the text appropriately
* Header + footer showing server count

I considered adding pagination, but figured there are already cli tools and pipes for handling the output. WDYT?

Please be extra critical when reviewing the code as it's one of my first times touching go. Best practices, conventions, short-form functions, etc.

**Related issue**
https://docker.atlassian.net/browse/MCPT-105

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

Before:
<img width="1331" height="353" alt="image" src="https://github.com/user-attachments/assets/8c80c285-1878-4e58-8696-22ca7693691a" />


After:
<img width="1331" height="564" alt="image" src="https://github.com/user-attachments/assets/5f8e0b5d-e793-4c0d-8f7a-c680dd2ef440" />
