### PR TITLE
Make mcp-oauth-dcr feature default true

### DIFF
--- a/cmd/docker-mcp/commands/feature.go
+++ b/cmd/docker-mcp/commands/feature.go
@@ -190,12 +190,12 @@ func isFeatureEnabledFromCli(dockerCli command.Cli, feature string) bool {
 // isFeatureEnabledFromConfig checks if a feature is enabled from a config file
 func isFeatureEnabledFromConfig(configFile *configfile.ConfigFile, feature string) bool {
 	if configFile.Features == nil {
-		return false
+		return feature == "mcp-oauth-dcr" // mcp-oauth-dcr is enabled by default
 	}
 
 	value, exists := configFile.Features[feature]
 	if !exists {
-		return false
+		return feature == "mcp-oauth-dcr" // mcp-oauth-dcr is enabled by default
 	}
 
 	// Handle both boolean string values and "enabled"/"disabled" strings

--- a/cmd/docker-mcp/commands/feature_test.go
+++ b/cmd/docker-mcp/commands/feature_test.go
@@ -67,9 +67,48 @@ func TestIsFeatureEnabledDynamicTools(t *testing.T) {
 	})
 }
 
+func TestIsFeatureEnabledMcpOAuthDcr(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: map[string]string{
+				"mcp-oauth-dcr": "enabled",
+			},
+		}
+		enabled := isFeatureEnabledFromConfig(configFile, "mcp-oauth-dcr")
+		assert.True(t, enabled)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: map[string]string{
+				"mcp-oauth-dcr": "disabled",
+			},
+		}
+		enabled := isFeatureEnabledFromConfig(configFile, "mcp-oauth-dcr")
+		assert.False(t, enabled)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: make(map[string]string),
+		}
+		enabled := isFeatureEnabledFromConfig(configFile, "mcp-oauth-dcr")
+		assert.True(t, enabled, "mcp-oauth-dcr should default to enabled when missing")
+	})
+
+	t.Run("nil features map", func(t *testing.T) {
+		configFile := &configfile.ConfigFile{
+			Features: nil,
+		}
+		enabled := isFeatureEnabledFromConfig(configFile, "mcp-oauth-dcr")
+		assert.True(t, enabled, "mcp-oauth-dcr should default to enabled when Features is nil")
+	})
+}
+
 func TestIsKnownFeature(t *testing.T) {
 	// Test valid features
 	assert.True(t, isKnownFeature("oauth-interceptor"))
+	assert.True(t, isKnownFeature("mcp-oauth-dcr"))
 	assert.True(t, isKnownFeature("dynamic-tools"))
 
 	// Test invalid features

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -278,12 +278,12 @@ func isOAuthInterceptorFeatureEnabled(dockerCli command.Cli) bool {
 func isMcpOAuthDcrFeatureEnabled(dockerCli command.Cli) bool {
 	configFile := dockerCli.ConfigFile()
 	if configFile == nil || configFile.Features == nil {
-		return false
+		return true // Default enabled when no config exists
 	}
 
 	value, exists := configFile.Features["mcp-oauth-dcr"]
 	if !exists {
-		return false
+		return true // Default enabled when not in config
 	}
 
 	return value == "enabled"


### PR DESCRIPTION
**What I did**
- In preparation for MCP OAuth roll-out make `mcp-oauth-dcr` default true

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
