### PR TITLE
bugfix for OAuth notification stream messages in examples/client

### DIFF
--- a/examples/client/compose.yaml
+++ b/examples/client/compose.yaml
@@ -3,6 +3,7 @@ services:
     build: .
     environment:
       - MCP_HOST=http://gateway:9011/mcp
+      - MCP_GATEWAY_AUTH_TOKEN=my-secret-token
     depends_on:
       - gateway
 
@@ -13,5 +14,9 @@ services:
       - --servers=duckduckgo
       - --verbose=false
       - --port=9011
+    environment:
+      - DOCKER_CONFIG=/etc/docker
+      - MCP_GATEWAY_AUTH_TOKEN=my-secret-token
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./docker-config.json:/etc/docker/config.json:ro

--- a/examples/client/docker-config.json
+++ b/examples/client/docker-config.json
@@ -1,0 +1,5 @@
+{
+  "features": {
+    "mcp-oauth-dcr": "disabled"
+  }
+}

--- a/examples/client/main.py
+++ b/examples/client/main.py
@@ -4,7 +4,11 @@ from mcp import ClientSession
 
 
 async def main():
-    async with streamablehttp_client(os.getenv("MCP_HOST")) as (
+    # Get authentication token from environment
+    token = os.getenv("MCP_GATEWAY_AUTH_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+    async with streamablehttp_client(os.getenv("MCP_HOST"), headers=headers) as (
         read_stream,
         write_stream,
         _,


### PR DESCRIPTION
**What I did**
- Update example/client with fixes to disable: `mcp-oauth-dcr` and set: `MCP_GATEWAY_AUTH_TOKEN`

**Related issue**
- https://github.com/docker/mcp-gateway/issues/197

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**