### PR TITLE
Skip connecting to OAuth stream in container mode

### DIFF
--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -260,8 +260,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 		return fmt.Errorf("loading configuration: %w", err)
 	}
 
-	// Check if running in container mode (compose, k8s, etc.)
-	// Container mode disables OAuth monitoring and authentication
+	// When running in Container mode, disable OAuth notification monitoring and authentication
 	inContainer := os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1"
 
 	if g.McpOAuthDcrEnabled && !inContainer {


### PR DESCRIPTION
**What I did**
- In container mode,  OAuth stream is not available -> do not attempt to connect

**Related issue**
- https://github.com/docker/mcp-gateway/issues/197

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**