### PR TITLE
Add VS Code global client config

### DIFF
--- a/cmd/docker-mcp/client/config.yml
+++ b/cmd/docker-mcp/client/config.yml
@@ -72,7 +72,7 @@ system:
       set: .mcpServers[$NAME] = $JSON
       del: del(.mcpServers[$NAME])
   vscode:
-    displayName: VSCode
+    displayName: Visual Studio Code
     source: https://code.visualstudio.com/
     icon: https://raw.githubusercontent.com/docker/mcp-gateway/main/img/client/vscode.svg
     installCheckPaths:
@@ -230,7 +230,7 @@ project:
       set: .mcpServers[$NAME] = $JSON
       del: del(.mcpServers[$NAME])
   vscode:
-    displayname: VSCode
+    displayname: Visual Studio Code
     projectfile: .vscode/mcp.json
     icon: https://raw.githubusercontent.com/docker/mcp-gateway/main/img/client/vscode.svg
     yq:
@@ -245,4 +245,3 @@ project:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON+{"type":"stdio"}
       del: del(.mcpServers[$NAME])
-


### PR DESCRIPTION
**What I did**

Add a global VS Code config. VS Code has moved away from specifying servers in the user preferences config to a dedicated user mcp.json file ([Add an MCP server to your user configuration](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server))

Tested on:
- [x] Mac
- [x] Windows
- [x] Linux

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**