### PR TITLE
bugfix: remove provider check for restricting stdin

### DIFF
--- a/cmd/docker-mcp/commands/secret.go
+++ b/cmd/docker-mcp/commands/secret.go
@@ -108,8 +108,8 @@ func setSecretCommand() *cobra.Command {
 	return cmd
 }
 
-func isNotImplicitReadFromStdinSyntax(args []string, opts secret.SetOpts) bool {
-	return strings.Contains(args[0], "=") || len(args) > 1 || opts.Provider != ""
+func isNotImplicitReadFromStdinSyntax(args []string, _ secret.SetOpts) bool {
+	return strings.Contains(args[0], "=") || len(args) > 1
 }
 
 func exportSecretCommand(docker docker.Client) *cobra.Command {


### PR DESCRIPTION
**What I did**
- Removed check which prevented using `stdin` when specifying secrets with `provider`

**Related issue**
- Secrets management
