### PR TITLE
Address CI Issues

### DIFF
--- a/cmd/docker-mcp/catalog/reset_test.go
+++ b/cmd/docker-mcp/catalog/reset_test.go
@@ -1,7 +1,6 @@
 package catalog
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"

--- a/pkg/gateway/auth_test.go
+++ b/pkg/gateway/auth_test.go
@@ -228,32 +228,3 @@ func TestFormatBearerToken(t *testing.T) {
 		t.Errorf("expected result to start with 'Authorization: Bearer ', got %q", result)
 	}
 }
-
-func TestAuthenticationMiddleware_ContainerMode(t *testing.T) {
-	// Set container environment variable
-	os.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
-	defer os.Unsetenv("DOCKER_MCP_IN_CONTAINER")
-
-	authToken := "test-token-123"
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("success"))
-	})
-
-	secured := authenticationMiddleware(authToken, handler)
-
-	// Should allow request without auth token when in container mode
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-	// No Authorization header
-
-	rr := httptest.NewRecorder()
-	secured.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Errorf("Expected 200 in container mode, got %d", rr.Code)
-	}
-
-	if rr.Body.String() != "success" {
-		t.Errorf("Expected 'success', got %q", rr.Body.String())
-	}
-}


### PR DESCRIPTION
**What I did**
- This [commit](https://github.com/docker/mcp-gateway/commit/6b076b2479d8d1345c50c112119c62978d46858e) was merged from a private fork. The private fork was based on an old branch of `main` when we had logic in: `authenticationMiddleware` which was verifying the existence of: `DOCKER_MCP_IN_CONTAINER`. Since this logic is now in run.go [here](https://github.com/docker/mcp-gateway/blob/main/pkg/gateway/run.go#L334-L343) this test: `TestAuthenticationMiddleware_ContainerMode` is no longer relevant.
- Resolves lint issue on `main` branch

**Related issue**
- Fixes main CI issues

