### PR TITLE
feat: Add ability to add/remove servers

### DIFF
--- a/cmd/docker-mcp/commands/workingset.go
+++ b/cmd/docker-mcp/commands/workingset.go
@@ -325,9 +325,6 @@ func addServerCommand() *cobra.Command {
   docker mcp workingset server add my-working-set --server http://registry.modelcontextprotocol.io/v0/servers/71de5a2a-6cfb-4250-a196-f93080ecc860 --server docker://mcp/github:latest`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(servers) == 0 {
-				return fmt.Errorf("at least one --server flag must be specified")
-			}
 			dao, err := db.New()
 			if err != nil {
 				return err
@@ -345,35 +342,29 @@ func addServerCommand() *cobra.Command {
 }
 
 func removeServerCommand() *cobra.Command {
-	var servers []string
+	var names []string
 
 	cmd := &cobra.Command{
-		Use:   "remove <working-set-id> --server <ref1> --server <ref2> ...",
+		Use:   "remove <working-set-id> --name <name1> --name <name2> ...",
 		Short: "Remove MCP servers from a working set",
-		Long:  "Remove MCP servers from a working set by server reference.",
-		Example: ` # Remove servers with OCI references
-  docker mcp workingset server remove my-working-set --server docker://mcp/github:latest --server docker://mcp/slack:latest
+		Long:  "Remove MCP servers from a working set by server name.",
+		Example: ` # Remove servers by name
+  docker mcp workingset server remove my-working-set --name github --name slack
 
-  # Remove servers with MCP Registry references
-  docker mcp workingset server remove my-working-set --server http://registry.modelcontextprotocol.io/v0/servers/71de5a2a-6cfb-4250-a196-f93080ecc860
-
-  # Mix MCP Registry references and OCI references
-  docker mcp workingset server remove my-working-set --server http://registry.modelcontextprotocol.io/v0/servers/71de5a2a-6cfb-4250-a196-f93080ecc860 --server docker://mcp/github:latest`,
+  # Remove a single server
+  docker mcp workingset server remove my-working-set --name github`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(servers) == 0 {
-				return fmt.Errorf("at least one --server flag must be specified")
-			}
 			dao, err := db.New()
 			if err != nil {
 				return err
 			}
-			return workingset.RemoveServers(cmd.Context(), dao, args[0], servers)
+			return workingset.RemoveServers(cmd.Context(), dao, args[0], names)
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&servers, "server", []string{}, "Server to remove: MCP Registry reference or OCI reference with docker:// prefix (can be specified multiple times)")
+	flags.StringArrayVar(&names, "name", []string{}, "Server name to remove (can be specified multiple times)")
 
 	return cmd
 }

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -150,7 +150,27 @@ func (workingSet WorkingSet) ToDb() db.WorkingSet {
 }
 
 func (workingSet *WorkingSet) Validate() error {
-	return validate.Get().Struct(workingSet)
+	err := validate.Get().Struct(workingSet)
+	if err != nil {
+		return err
+	}
+	return workingSet.validateUniqueServerNames()
+}
+
+func (workingSet *WorkingSet) validateUniqueServerNames() error {
+	seen := make(map[string]bool)
+	for _, server := range workingSet.Servers {
+		// TODO: Update when Snapshot is required
+		if server.Snapshot == nil {
+			continue
+		}
+		name := server.Snapshot.Server.Name
+		if seen[name] {
+			return fmt.Errorf("duplicate server name %s", name)
+		}
+		seen[name] = true
+	}
+	return nil
 }
 
 func (workingSet *WorkingSet) FindServer(serverName string) *Server {

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -251,6 +251,35 @@ func TestWorkingSetValidate(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "duplicate server name",
+			ws: WorkingSet{
+				Version: CurrentWorkingSetVersion,
+				ID:      "test-id",
+				Name:    "Test",
+				Servers: []Server{
+					{
+						Type:  ServerTypeImage,
+						Image: "myimage:latest",
+						Snapshot: &ServerSnapshot{
+							Server: catalog.Server{
+								Name: "mcp.docker.com/test-server",
+							},
+						},
+					},
+					{
+						Type:  ServerTypeImage,
+						Image: "myimage:previous",
+						Snapshot: &ServerSnapshot{
+							Server: catalog.Server{
+								Name: "mcp.docker.com/test-server",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What I did**

Added commands to add and remove servers from a working set.

1. Add a server to an existing working set
`docker mcp workingset server add [working-set-id] --server [ref or uri]`

**Example**
`docker mcp workingset server add test-set --server docker://roberthouse224/mcp-dice:latest --server https://mcp.docker.com/v0/servers/slack`

2. Remove a server from an existing working set
`docker mcp workingset server remove [working-set-id] --server [ref or uri]`

**Example**
`docker mcp workingset server remove test-set --server docker://roberthouse224/mcp-dice:latest --server https://mcp.docker.com/v0/servers/slack/versions/latest`

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(very mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="423" height="432" alt="Screenshot 2025-11-07 at 2 21 10 PM" src="https://github.com/user-attachments/assets/3edc4f6c-9730-4e6a-990e-919dcaae1e39" />
