### PR TITLE
feat: Add support for custom configuration directory via CLAUDE_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,26 @@ The MCP CLI uses several configuration files:
 Configuration files are typically stored in `~/.docker/mcp/`. This is in this directory that Docker Desktop's
 MCP Toolkit with store its configuration.
 
+### Environment Variables
+
+The MCP CLI respects the following environment variables for client configuration:
+
+- **`CLAUDE_CONFIG_DIR`**: Override the default Claude Code configuration directory (`~/.claude`). When set, Claude Code will use `$CLAUDE_CONFIG_DIR/.claude.json` instead of `~/.claude.json` for its MCP server configuration. This is useful for:
+  - Maintaining separate Claude Code installations for work and personal use
+  - Testing configuration changes in isolation
+  - Managing multiple Claude Code profiles
+
+Example usage:
+```bash
+# Set custom Claude Code configuration directory
+export CLAUDE_CONFIG_DIR=/path/to/custom/config
+
+# Connect MCP Gateway to Claude Code
+docker mcp client connect claude-code --global
+
+# Claude Code will now use /path/to/custom/config/.claude.json
+```
+
 ## Architecture
 
 The Docker MCP CLI implements a gateway pattern:

--- a/cmd/docker-mcp/client/config.yml
+++ b/cmd/docker-mcp/client/config.yml
@@ -24,12 +24,16 @@ system:
     installCheckPaths:
       - $HOME/.claude
       - $USERPROFILE\.claude
+      - $CLAUDE_CONFIG_DIR
     paths:
       linux:
+        - $CLAUDE_CONFIG_DIR/.claude.json
         - $HOME/.claude.json
       darwin:
+        - $CLAUDE_CONFIG_DIR/.claude.json
         - $HOME/.claude.json
       windows:
+        - $CLAUDE_CONFIG_DIR\.claude.json
         - $USERPROFILE\.claude.json
     yq:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'


### PR DESCRIPTION
  ## Summary

  Fixes support for the `CLAUDE_CONFIG_DIR` environment variable when configuring Claude Code clients.

  ## Problem

The Docker MCP Gateway's Claude Code client configuration did not respect the `CLAUDE_CONFIG_DIR` environment variable, always defaulting to `~/.claude.json` regardless of whether users had set a custom configuration directory. This broke multi-profile workflows where users maintain separate Claude Code installations for different contexts (e.g., work vs. personal). When users clicked the 'Connect' button in the MCP Toolkit UI with `CLAUDE_CONFIG_DIR` set, the gateway would configure the wrong Claude Code installation, causing the MCP servers to be unavailable in the intended profile and potentially exposing them in an unintended one.

  ## Changes

  - **Updated `cmd/docker-mcp/client/config.yml`**: Modified the `claude-code` client configuration to prioritize `$CLAUDE_CONFIG_DIR/.claude.json` before
  falling back to `$HOME/.claude.json`
  - **Enhanced `cmd/docker-mcp/client/global.go`**: Added `isPathValid()` function to validate environment variables in paths and updated `Update()` to filter
  out paths with undefined or empty environment variables
  - **Added comprehensive tests in `cmd/docker-mcp/client/global_test.go`**: Tests for path validation, environment variable priority, and fallback behavior
  - **Updated `README.md`**: Added documentation for the `CLAUDE_CONFIG_DIR` environment variable with usage examples

  ## Behavior

  - **When `CLAUDE_CONFIG_DIR` is set and non-empty**: Configuration is written to `$CLAUDE_CONFIG_DIR/.claude.json`
  - **When `CLAUDE_CONFIG_DIR` is unset or empty**: Configuration falls back to `$HOME/.claude.json`
  - **Priority**: Existing files in `CLAUDE_CONFIG_DIR` location are used first if they exist

  ## Testing

  All existing tests pass, plus new tests added:
  - `TestIsPathValid`: Validates path checking logic for defined, undefined, and empty environment variables
  - `TestGlobalCfgProcessor_Update_WithEnvVarPaths`: Verifies configuration uses custom directory when `CLAUDE_CONFIG_DIR` is set
  - `TestGlobalCfgProcessor_Update_FallbackWhenEnvVarUndefined`: Verifies fallback to default location when variable is not set
  - `TestGlobalCfgProcessor_Update_AllPathsInvalid`: Verifies proper error handling

This PR fixes #225