### PR TITLE
feat: Manage tool filters in working sets

### DIFF
--- a/cmd/docker-mcp/commands/workingset.go
+++ b/cmd/docker-mcp/commands/workingset.go
@@ -70,27 +70,37 @@ func configWorkingSetCommand() *cobra.Command {
 }
 
 func toolsWorkingSetCommand() *cobra.Command {
-	var add []string
-	var remove []string
+	var enable []string
+	var disable []string
+	var enableAll []string
+	var disableAll []string
 
 	cmd := &cobra.Command{
-		Use:   "tools <working-set-id> [--add <tool> ...] [--remove <tool> ...]",
+		Use:   "tools <working-set-id> [--enable <tool> ...] [--disable <tool> ...] [--enable-all <server> ...] [--disable-all <server> ...]",
 		Short: "Manage tool allowlist for servers in a working set",
 		Long: `Manage the tool allowlist for servers in a working set.
 Tools are specified using dot notation: <serverName>.<toolName>
 
-Use --add to enable tools for a server (can be specified multiple times).
-Use --remove to disable tools for a server (can be specified multiple times).
+Use --enable to enable specific tools for a server (can be specified multiple times).
+Use --disable to disable specific tools for a server (can be specified multiple times).
+Use --enable-all to enable all tools for a server (can be specified multiple times).
+Use --disable-all to disable all tools for a server (can be specified multiple times).
 
 To view enabled tools, use: docker mcp workingset show <working-set-id>`,
-		Example: `  # Add tools to a server's allowlist
-  docker mcp workingset tools my-set --add github.create_issue --add github.list_repos
+		Example: `  # Enable specific tools for a server
+  docker mcp workingset tools my-set --enable github.create_issue --enable github.list_repos
 
-  # Remove tools from a server's allowlist
-  docker mcp workingset tools my-set --remove github.create_issue --remove github.search_code
+  # Disable specific tools for a server
+  docker mcp workingset tools my-set --disable github.create_issue --disable github.search_code
 
-  # Add and remove in one command
-  docker mcp workingset tools my-set --add github.create_issue --remove github.search_code
+  # Enable and disable in one command
+  docker mcp workingset tools my-set --enable github.create_issue --disable github.search_code
+
+  # Enable all tools for a server
+  docker mcp workingset tools my-set --enable-all github
+
+  # Disable all tools for a server
+  docker mcp workingset tools my-set --disable-all github
 
   # View all enabled tools in the working set
   docker mcp workingset show my-set`,
@@ -100,13 +110,15 @@ To view enabled tools, use: docker mcp workingset show <working-set-id>`,
 			if err != nil {
 				return err
 			}
-			return workingset.UpdateTools(cmd.Context(), dao, args[0], add, remove)
+			return workingset.UpdateTools(cmd.Context(), dao, args[0], enable, disable, enableAll, disableAll)
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&add, "add", []string{}, "Add tools to allowlist: <serverName>.<toolName> (repeatable)")
-	flags.StringArrayVar(&remove, "remove", []string{}, "Remove tools from allowlist: <serverName>.<toolName> (repeatable)")
+	flags.StringArrayVar(&enable, "enable", []string{}, "Enable specific tools: <serverName>.<toolName> (repeatable)")
+	flags.StringArrayVar(&disable, "disable", []string{}, "Disable specific tools: <serverName>.<toolName> (repeatable)")
+	flags.StringArrayVar(&enableAll, "enable-all", []string{}, "Enable all tools for a server: <serverName> (repeatable)")
+	flags.StringArrayVar(&disableAll, "disable-all", []string{}, "Disable all tools for a server: <serverName> (repeatable)")
 
 	return cmd
 }

--- a/pkg/db/workingset.go
+++ b/pkg/db/workingset.go
@@ -34,7 +34,7 @@ type Server struct {
 	Type    string         `json:"type"`
 	Config  map[string]any `json:"config,omitempty"`
 	Secrets string         `json:"secrets,omitempty"`
-	Tools   []string       `json:"tools,omitempty"`
+	Tools   []string       `json:"tools"`
 	Source  string         `json:"source,omitempty"`
 	Image   string         `json:"image,omitempty"`
 

--- a/pkg/workingset/tools_test.go
+++ b/pkg/workingset/tools_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/db"
 )
 
-func TestAddATool(t *testing.T) {
+func TestEnableATool(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
@@ -36,7 +36,7 @@ func TestAddATool(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = UpdateTools(ctx, dao, "test-set", []string{"test-server.create_issue"}, []string{})
+	err = UpdateTools(ctx, dao, "test-set", []string{"test-server.create_issue"}, []string{}, []string{}, []string{})
 	require.NoError(t, err)
 
 	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
@@ -45,7 +45,7 @@ func TestAddATool(t *testing.T) {
 	assert.Len(t, dbSet.Servers[0].Tools, 1)
 }
 
-func TestAddMultipleTools(t *testing.T) {
+func TestEnableMultipleTools(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
@@ -76,7 +76,7 @@ func TestAddMultipleTools(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = UpdateTools(ctx, dao, "test-set", []string{"test-server-1.create_issue", "test-server-2.update_issue"}, []string{})
+	err = UpdateTools(ctx, dao, "test-set", []string{"test-server-1.create_issue", "test-server-2.update_issue"}, []string{}, []string{}, []string{})
 	require.NoError(t, err)
 
 	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
@@ -85,7 +85,7 @@ func TestAddMultipleTools(t *testing.T) {
 	assert.Contains(t, dbSet.Servers[1].Tools, "update_issue")
 }
 
-func TestRemoveATool(t *testing.T) {
+func TestDisableATool(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
@@ -110,15 +110,15 @@ func TestRemoveATool(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{"test-server.create_issue"})
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{"test-server.create_issue"}, []string{}, []string{})
 	require.NoError(t, err)
 
 	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
 	require.NoError(t, err)
-	assert.Nil(t, dbSet.Servers[0].Tools)
+	assert.Empty(t, dbSet.Servers[0].Tools)
 }
 
-func TestRemoveMultipleTools(t *testing.T) {
+func TestDisableMultipleTools(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
@@ -162,7 +162,7 @@ func TestRemoveMultipleTools(t *testing.T) {
 		"test-server-1.tool-2",
 		"test-server-2.tool-1",
 		"test-server-2.tool-2",
-	})
+	}, []string{}, []string{})
 	require.NoError(t, err)
 
 	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
@@ -171,7 +171,7 @@ func TestRemoveMultipleTools(t *testing.T) {
 	assert.Empty(t, dbSet.Servers[1].Tools)
 }
 
-func TestAddAndRemoveMultipleTools(t *testing.T) {
+func TestEnableAndDisableMultipleTools(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
@@ -206,7 +206,7 @@ func TestAddAndRemoveMultipleTools(t *testing.T) {
 		"test-server-1.create_issue", "test-server-2.update_issue",
 	}, []string{
 		"test-server-1.create_issue", "test-server-2.update_issue",
-	})
+	}, []string{}, []string{})
 	require.NoError(t, err)
 
 	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
@@ -246,9 +246,9 @@ func TestErrorNoOperation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{})
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{}, []string{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must provide a flag either --add or --remove")
+	assert.Contains(t, err.Error(), "must provide at least one flag")
 }
 
 func TestErrorWorkingSetNotFound(t *testing.T) {
@@ -284,7 +284,7 @@ func TestErrorWorkingSetNotFound(t *testing.T) {
 
 	setid := "bogus"
 
-	err = UpdateTools(ctx, dao, setid, []string{"test-server-1.tool"}, []string{})
+	err = UpdateTools(ctx, dao, setid, []string{"test-server-1.tool"}, []string{}, []string{}, []string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("working set %s not found", setid))
 }
@@ -320,7 +320,7 @@ func TestErrorInvalidToolFormat(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = UpdateTools(ctx, dao, "test-set", []string{"bogus"}, []string{})
+	err = UpdateTools(ctx, dao, "test-set", []string{"bogus"}, []string{}, []string{}, []string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("invalid tool argument: %s, expected <serverName>.<toolName>", "bogus"))
 }
@@ -356,74 +356,279 @@ func TestErrorServerNotFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = UpdateTools(ctx, dao, "test-set", []string{"bogus.tool"}, []string{})
+	err = UpdateTools(ctx, dao, "test-set", []string{"bogus.tool"}, []string{}, []string{}, []string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("server %s not found in working set for argument %s", "bogus", "bogus.tool"))
+}
+
+func TestEnableAllTools(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := dao.CreateWorkingSet(ctx, db.WorkingSet{
+		ID:   "test-set",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  "image",
+				Image: "myimage:latest",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server",
+					},
+				},
+				Tools: []string{"create_issue", "update_issue"},
+			},
+		},
+		Secrets: db.SecretMap{},
+	})
+	require.NoError(t, err)
+
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{"test-server"}, []string{})
+	require.NoError(t, err)
+
+	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
+	require.NoError(t, err)
+	assert.Nil(t, dbSet.Servers[0].Tools)
+}
+
+func TestEnableAllToolsMultipleServers(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := dao.CreateWorkingSet(ctx, db.WorkingSet{
+		ID:   "test-set",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  "image",
+				Image: "myimage:latest",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server-1",
+					},
+				},
+				Tools: []string{"tool-1"},
+			},
+			{
+				Type:  "image",
+				Image: "anotherimage:v1.0",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server-2",
+					},
+				},
+				Tools: []string{"tool-2"},
+			},
+		},
+		Secrets: db.SecretMap{},
+	})
+	require.NoError(t, err)
+
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{"test-server-1", "test-server-2"}, []string{})
+	require.NoError(t, err)
+
+	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
+	require.NoError(t, err)
+	assert.Nil(t, dbSet.Servers[0].Tools)
+	assert.Nil(t, dbSet.Servers[1].Tools)
+}
+
+func TestEnableAllToolsServerNotFound(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := dao.CreateWorkingSet(ctx, db.WorkingSet{
+		ID:   "test-set",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  "image",
+				Image: "myimage:latest",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server",
+					},
+				},
+				Tools: []string{"tool-1"},
+			},
+		},
+		Secrets: db.SecretMap{},
+	})
+	require.NoError(t, err)
+
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{"bogus"}, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server bogus not found in working set")
+}
+
+func TestDisableAllTools(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := dao.CreateWorkingSet(ctx, db.WorkingSet{
+		ID:   "test-set",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  "image",
+				Image: "myimage:latest",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server",
+					},
+				},
+				Tools: []string{"create_issue", "update_issue"},
+			},
+		},
+		Secrets: db.SecretMap{},
+	})
+	require.NoError(t, err)
+
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{}, []string{"test-server"})
+	require.NoError(t, err)
+
+	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
+	require.NoError(t, err)
+	assert.Empty(t, dbSet.Servers[0].Tools)
+	assert.NotNil(t, dbSet.Servers[0].Tools)
+}
+
+func TestDisableAllToolsMultipleServers(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := dao.CreateWorkingSet(ctx, db.WorkingSet{
+		ID:   "test-set",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  "image",
+				Image: "myimage:latest",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server-1",
+					},
+				},
+				Tools: []string{"tool-1"},
+			},
+			{
+				Type:  "image",
+				Image: "anotherimage:v1.0",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server-2",
+					},
+				},
+				Tools: []string{"tool-2"},
+			},
+		},
+		Secrets: db.SecretMap{},
+	})
+	require.NoError(t, err)
+
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{}, []string{"test-server-1", "test-server-2"})
+	require.NoError(t, err)
+
+	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
+	require.NoError(t, err)
+	assert.Empty(t, dbSet.Servers[0].Tools)
+	assert.NotNil(t, dbSet.Servers[0].Tools)
+	assert.Empty(t, dbSet.Servers[1].Tools)
+	assert.NotNil(t, dbSet.Servers[1].Tools)
+}
+
+func TestDisableAllToolsServerNotFound(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := dao.CreateWorkingSet(ctx, db.WorkingSet{
+		ID:   "test-set",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  "image",
+				Image: "myimage:latest",
+				Snapshot: &db.ServerSnapshot{
+					Server: catalog.Server{
+						Name: "test-server",
+					},
+				},
+				Tools: []string{"tool-1"},
+			},
+		},
+		Secrets: db.SecretMap{},
+	})
+	require.NoError(t, err)
+
+	err = UpdateTools(ctx, dao, "test-set", []string{}, []string{}, []string{}, []string{"bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server bogus not found in working set")
 }
 
 func TestOutputMessages(t *testing.T) {
 	tests := []struct {
 		name           string
 		initialTools   []string
-		addTools       []string
-		removeTools    []string
+		enableTools    []string
+		disableTools   []string
 		expectedOutput string
 	}{
 		{
-			name:           "add tools",
+			name:           "enable tools",
 			initialTools:   []string{},
-			addTools:       []string{"test-server.create_issue", "test-server.update_issue"},
-			removeTools:    []string{},
-			expectedOutput: "Updated working set test-set: 2 tool(s) added, 0 tool(s) removed\n",
+			enableTools:    []string{"test-server.create_issue", "test-server.update_issue"},
+			disableTools:   []string{},
+			expectedOutput: "Updated working set test-set: 2 tool(s) enabled, 0 tool(s) disabled\n",
 		},
 		{
-			name:           "remove tools",
+			name:           "disable tools",
 			initialTools:   []string{"create_issue", "update_issue"},
-			addTools:       []string{},
-			removeTools:    []string{"test-server.create_issue", "test-server.update_issue"},
-			expectedOutput: "Updated working set test-set: 0 tool(s) added, 2 tool(s) removed\n",
+			enableTools:    []string{},
+			disableTools:   []string{"test-server.create_issue", "test-server.update_issue"},
+			expectedOutput: "Updated working set test-set: 0 tool(s) enabled, 2 tool(s) disabled\n",
 		},
 		{
-			name:           "add and remove different tools",
+			name:           "enable and disable different tools",
 			initialTools:   []string{"create_issue"},
-			addTools:       []string{"test-server.update_issue"},
-			removeTools:    []string{"test-server.create_issue"},
-			expectedOutput: "Updated working set test-set: 1 tool(s) added, 1 tool(s) removed\n",
+			enableTools:    []string{"test-server.update_issue"},
+			disableTools:   []string{"test-server.create_issue"},
+			expectedOutput: "Updated working set test-set: 1 tool(s) enabled, 1 tool(s) disabled\n",
 		},
 		{
-			name:           "no changes - add existing tool",
+			name:           "no changes - enable existing tool",
 			initialTools:   []string{"create_issue"},
-			addTools:       []string{"test-server.create_issue"},
-			removeTools:    []string{},
-			expectedOutput: "No tools were added or removed from working set test-set\n",
+			enableTools:    []string{"test-server.create_issue"},
+			disableTools:   []string{},
+			expectedOutput: "No changes made to working set test-set\n",
 		},
 		{
-			name:           "no changes - remove non-existent tool",
+			name:           "no changes - disable non-existent tool",
 			initialTools:   []string{"create_issue"},
-			addTools:       []string{},
-			removeTools:    []string{"test-server.update_issue"},
-			expectedOutput: "No tools were added or removed from working set test-set\n",
+			enableTools:    []string{},
+			disableTools:   []string{"test-server.update_issue"},
+			expectedOutput: "No changes made to working set test-set\n",
 		},
 		{
-			name:           "overlap - add and remove same tool",
+			name:           "overlap - enable and disable same tool",
 			initialTools:   []string{},
-			addTools:       []string{"test-server.create_issue"},
-			removeTools:    []string{"test-server.create_issue"},
-			expectedOutput: "Updated working set test-set: 1 tool(s) added, 1 tool(s) removed\nWarning: The following tool(s) were both added and removed in the same operation: test-server.create_issue\n",
+			enableTools:    []string{"test-server.create_issue"},
+			disableTools:   []string{"test-server.create_issue"},
+			expectedOutput: "Updated working set test-set: 1 tool(s) enabled, 1 tool(s) disabled\nWarning: The following tool(s) were both enabled and disabled in the same operation: test-server.create_issue\n",
 		},
 		{
-			name:           "overlap - add and remove with partial overlap",
+			name:           "overlap - enable and disable with partial overlap",
 			initialTools:   []string{"create_issue"},
-			addTools:       []string{"test-server.update_issue", "test-server.delete_issue"},
-			removeTools:    []string{"test-server.create_issue", "test-server.update_issue"},
-			expectedOutput: "Updated working set test-set: 2 tool(s) added, 2 tool(s) removed\nWarning: The following tool(s) were both added and removed in the same operation: test-server.update_issue\n",
+			enableTools:    []string{"test-server.update_issue", "test-server.delete_issue"},
+			disableTools:   []string{"test-server.create_issue", "test-server.update_issue"},
+			expectedOutput: "Updated working set test-set: 2 tool(s) enabled, 2 tool(s) disabled\nWarning: The following tool(s) were both enabled and disabled in the same operation: test-server.update_issue\n",
 		},
 		{
 			name:           "overlap - multiple overlapping tools",
 			initialTools:   []string{},
-			addTools:       []string{"test-server.create_issue", "test-server.update_issue", "test-server.delete_issue"},
-			removeTools:    []string{"test-server.create_issue", "test-server.update_issue"},
-			expectedOutput: "Updated working set test-set: 3 tool(s) added, 2 tool(s) removed\nWarning: The following tool(s) were both added and removed in the same operation: test-server.create_issue, test-server.update_issue\n",
+			enableTools:    []string{"test-server.create_issue", "test-server.update_issue", "test-server.delete_issue"},
+			disableTools:   []string{"test-server.create_issue", "test-server.update_issue"},
+			expectedOutput: "Updated working set test-set: 3 tool(s) enabled, 2 tool(s) disabled\nWarning: The following tool(s) were both enabled and disabled in the same operation: test-server.create_issue, test-server.update_issue\n",
 		},
 	}
 
@@ -455,7 +660,7 @@ func TestOutputMessages(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
-			err = UpdateTools(ctx, dao, "test-set", tt.addTools, tt.removeTools)
+			err = UpdateTools(ctx, dao, "test-set", tt.enableTools, tt.disableTools, []string{}, []string{})
 			require.NoError(t, err)
 
 			w.Close()


### PR DESCRIPTION
**What I did**

Added commands that allow you to manage tool filters as part of a working set.

**Enable a tool**
`docker mcp workingset tools <working-set-id>  --add <server-name>.<tool-name>`

**Enable multiple tools**
`docker mcp workingset tools <working-set-id>  --add <server-name>.<tool-name> --add <server-name>.<tool-name>`

**Remove tools**
`docker mcp workingset tools <working-set-id>  --remove <server-name>.<tool-name> --remove <server-name>.<tool-name>`

**Add and remove tools**
`docker mcp workingset tools <working-set-id>  --add <server-name>.<tool-name> --remove <server-name>.<tool-name>`

You can see the updated tool list by looking at the workingset with the show command `docker mcp workingset show <working-set-id>`

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="958" height="624" alt="Screenshot 2025-11-09 at 7 26 48 AM" src="https://github.com/user-attachments/assets/0dd6e312-e982-4875-b63a-374829237c49" />
