### PR TITLE
`docker mcp workingset ls` respect format when no sets

### DIFF
--- a/pkg/workingset/list.go
+++ b/pkg/workingset/list.go
@@ -17,7 +17,7 @@ func List(ctx context.Context, dao db.DAO, format OutputFormat) error {
 		return fmt.Errorf("failed to list working sets: %w", err)
 	}
 
-	if len(dbSets) == 0 {
+	if len(dbSets) == 0 && format == OutputFormatHumanReadable {
 		fmt.Println("No working sets found. Use `docker mcp workingset create --name <name>` to create a working set.")
 		return nil
 	}


### PR DESCRIPTION
**What I did**

Noticed that the command output a string message when I haven't created working sets. As expected. But if I do supply a `--format=json` it didn't respect the format and still output a string message (not valid json). I made sure that message is displayed only when the format is set to the human readable one. Anything else should get returned in a valid supported format.

```
J3Q71GC7M4:mcp-gateway dk$ docker mcp workingset ls
No working sets found. Use `docker mcp workingset create --name <name>` to create a working set.
J3Q71GC7M4:mcp-gateway dk$ docker mcp workingset ls --format=json
[]
J3Q71GC7M4:mcp-gateway dk$ docker mcp workingset ls --format=yaml
[]
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**