### PR TITLE
Fixed JSON Schema validation errors in mcp-config-set, mcp-exec that broke Fireworks AI (Ollama Cloud)

### DIFF
--- a/pkg/gateway/dynamic_mcps.go
+++ b/pkg/gateway/dynamic_mcps.go
@@ -939,6 +939,7 @@ func (g *Gateway) createMcpExecTool() *ToolRegistration {
 					Description: "Name of the tool to execute",
 				},
 				"arguments": {
+					Types:       []string{"string", "number", "boolean", "object", "array", "null"},
 					Description: "Arguments to pass to the tool (can be any valid JSON value)",
 				},
 			},


### PR DESCRIPTION
⏺ What I did

  Fixed JSON Schema validation errors in two dynamic MCP tools (mcp-config-set and mcp-exec) that were causing HTTP 500 errors with Fireworks AI and other strict schema validators.

  Both tools had parameters with only Description fields but no Type specification:
  - mcp-config-set: value parameter (can be string, number, boolean, object, or array)
  - mcp-exec: arguments parameter (can be any valid JSON value)

  Added Types field with []string specifying all allowed JSON types for each parameter.

  Error resolved:
  500 Internal Server Error: fireworks_chat_tp: 400: JSON Schema not supported:
  could not understand the instance `{'description': 'Configuration value to set
  (can be string, number, boolean, object, or array)'}`

  Testing:
  - Verified Claude Code continues to work with both tools
  - Verified Fireworks AI no longer produces 500 errors
  - Tested with multiple value types (string, number, boolean, object)

  Related issue
  N/A - discovered during agent testing with Fireworks AI backend

  (not mandatory) A picture of a cute animal, if possible in relation to what you did
  🦊 (A fox that fixed schemas)

Also: kudos to C. Liu on the Docker MCP team for showing me dynamic mcp services.