### PR TITLE
docs: add DOCKER_MCP_IN_CONTAINER bypass information

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ docker mcp --help
 
 ## Usage
 
+> [!NOTE]
+> **Running without Docker Desktop Feature Flags**
+>
+> If you encounter "Docker Desktop is not running" errors when the Docker daemon is active, you can bypass Desktop feature checks by setting:
+> ```bash
+> export DOCKER_MCP_IN_CONTAINER=1
+> ```
+> This is useful when running in WSL2, containerized environments, or Docker CE where Desktop backend sockets are unavailable.
+
 ### Catalog Management
 
 Manage the catalogs available to the MCP gateway. The [default catalog](https://hub.docker.com/mcp) is available with the name 'docker-mcp'.


### PR DESCRIPTION
  ## Summary
  - Add documentation for `DOCKER_MCP_IN_CONTAINER=1` environment variable bypass
  - Helps users running in WSL2, containerized environments, or Docker CE
  - Addresses "Docker Desktop is not running" error when Desktop backend sockets are unavailable

  ## Changes
  - Added GitHub-style NOTE infobox in Usage section of README.md
  - Documented environment variable and its use cases

  ## Context
  Users running Docker Desktop in WSL2 or containerized environments may encounter
  "Docker Desktop is not running" errors even when the Docker daemon is active. This
  occurs because the Desktop backend API sockets (`~/.docker/desktop/backend.sock`)
  are not available in these environments.

  The `DOCKER_MCP_IN_CONTAINER=1` environment variable allows users to bypass the
  Desktop feature flag checks (see `cmd/docker-mcp/commands/root.go:48`), enabling
  the MCP Gateway to work in these scenarios.