### PR TITLE
Add metadata to snapshot 

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -15,25 +15,36 @@ type topLevel struct {
 // MCP Servers
 
 type Server struct {
-	Name           string   `yaml:"name,omitempty" json:"name,omitempty"`
-	Type           string   `yaml:"type" json:"type"`
-	Image          string   `yaml:"image" json:"image"`
-	Description    string   `yaml:"description,omitempty" json:"description,omitempty"`
-	Title          string   `yaml:"title,omitempty" json:"title,omitempty"`
-	LongLived      bool     `yaml:"longLived,omitempty" json:"longLived,omitempty"`
-	Remote         Remote   `yaml:"remote" json:"remote"`
-	SSEEndpoint    string   `yaml:"sseEndpoint,omitempty" json:"sseEndpoint,omitempty"` // Deprecated: Use Remote instead
-	OAuth          *OAuth   `yaml:"oauth,omitempty" json:"oauth,omitempty"`
-	Secrets        []Secret `yaml:"secrets,omitempty" json:"secrets,omitempty"`
-	Env            []Env    `yaml:"env,omitempty" json:"env,omitempty"`
-	Command        []string `yaml:"command,omitempty" json:"command,omitempty"`
-	Volumes        []string `yaml:"volumes,omitempty" json:"volumes,omitempty"`
-	User           string   `yaml:"user,omitempty" json:"user,omitempty"`
-	DisableNetwork bool     `yaml:"disableNetwork,omitempty" json:"disableNetwork,omitempty"`
-	AllowHosts     []string `yaml:"allowHosts,omitempty" json:"allowHosts,omitempty"`
-	Tools          []Tool   `yaml:"tools,omitempty" json:"tools,omitempty"`
-	Config         []any    `yaml:"config,omitempty" json:"config,omitempty"`
-	Prefix         string   `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+	Name           string    `yaml:"name,omitempty" json:"name,omitempty"`
+	Type           string    `yaml:"type" json:"type"`
+	Image          string    `yaml:"image" json:"image"`
+	Description    string    `yaml:"description,omitempty" json:"description,omitempty"`
+	Title          string    `yaml:"title,omitempty" json:"title,omitempty"`
+	LongLived      bool      `yaml:"longLived,omitempty" json:"longLived,omitempty"`
+	Remote         Remote    `yaml:"remote" json:"remote"`
+	SSEEndpoint    string    `yaml:"sseEndpoint,omitempty" json:"sseEndpoint,omitempty"` // Deprecated: Use Remote instead
+	OAuth          *OAuth    `yaml:"oauth,omitempty" json:"oauth,omitempty"`
+	Secrets        []Secret  `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+	Env            []Env     `yaml:"env,omitempty" json:"env,omitempty"`
+	Command        []string  `yaml:"command,omitempty" json:"command,omitempty"`
+	Volumes        []string  `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	User           string    `yaml:"user,omitempty" json:"user,omitempty"`
+	DisableNetwork bool      `yaml:"disableNetwork,omitempty" json:"disableNetwork,omitempty"`
+	AllowHosts     []string  `yaml:"allowHosts,omitempty" json:"allowHosts,omitempty"`
+	Tools          []Tool    `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Config         []any     `yaml:"config,omitempty" json:"config,omitempty"`
+	Prefix         string    `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+	Metadata       *Metadata `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+}
+
+type Metadata struct {
+	Pulls       int      `yaml:"pulls,omitempty" json:"pulls,omitempty"`
+	Stars       int      `yaml:"stars,omitempty" json:"stars,omitempty"`
+	GithubStars int      `yaml:"githubStars,omitempty" json:"githubStars,omitempty"`
+	Category    string   `yaml:"category,omitempty" json:"category,omitempty"`
+	Tags        []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+	License     string   `yaml:"license,omitempty" json:"license,omitempty"`
+	Owner       string   `yaml:"owner,omitempty" json:"owner,omitempty"`
 }
 
 func (s *Server) IsOAuthServer() bool {

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -634,6 +634,47 @@ type: remote`,
 				},
 			},
 		},
+		{
+			name: "image with full metadata including pulls and owner",
+			server: Server{
+				Type:  ServerTypeImage,
+				Image: "testimage:v1.0",
+			},
+			labels: map[string]string{
+				"io.docker.server.metadata": `name: GitHub Server
+type: server
+image: testimage:v1.0
+description: Official GitHub MCP Server
+title: GitHub Official
+metadata:
+  pulls: 42055
+  githubStars: 24479
+  category: devops
+  tags:
+    - github
+    - devops
+  license: MIT License
+  owner: github`,
+			},
+			expectError: false,
+			expected: &ServerSnapshot{
+				Server: catalog.Server{
+					Name:        "GitHub Server",
+					Type:        "server",
+					Image:       "testimage:v1.0",
+					Description: "Official GitHub MCP Server",
+					Title:       "GitHub Official",
+					Metadata: &catalog.Metadata{
+						Pulls:       42055,
+						GithubStars: 24479,
+						Category:    "devops",
+						Tags:        []string{"github", "devops"},
+						License:     "MIT License",
+						Owner:       "github",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -670,6 +711,15 @@ type: remote`,
 				assert.Equal(t, tt.expected.Server.Type, snapshot.Server.Type)
 				if tt.expected.Server.Description != "" {
 					assert.Equal(t, tt.expected.Server.Description, snapshot.Server.Description)
+				}
+				if tt.expected.Server.Metadata != nil {
+					require.NotNil(t, snapshot.Server.Metadata)
+					assert.Equal(t, tt.expected.Server.Metadata.Pulls, snapshot.Server.Metadata.Pulls)
+					assert.Equal(t, tt.expected.Server.Metadata.GithubStars, snapshot.Server.Metadata.GithubStars)
+					assert.Equal(t, tt.expected.Server.Metadata.Category, snapshot.Server.Metadata.Category)
+					assert.Equal(t, tt.expected.Server.Metadata.Tags, snapshot.Server.Metadata.Tags)
+					assert.Equal(t, tt.expected.Server.Metadata.License, snapshot.Server.Metadata.License)
+					assert.Equal(t, tt.expected.Server.Metadata.Owner, snapshot.Server.Metadata.Owner)
 				}
 			}
 		})


### PR DESCRIPTION
**What I did**

Because we are now marshaling data into `Server` and storing that data as `Snapshot` as part of a server's data in a profile or catalog. we need the complete object that was being returned by `docker mcp catalog show` which read from the file to get the metadata. 

I have updated the `Server` struct to include `Metadata` so that we now get data like the following in profiles and catalogs
```
   "metadata": {
        "pulls": 500,
        "category": "finance",
        "tags": [
          "finance",
        ],
        "license": "MIT License",
        "owner": "owner-name"
      }
```

**Testing Instructions**

Verify that you see the metadata for the zerodha-kite MCP server that includes pulls and owner

```
docker mcp catalog-next create docker-mcp-catalog --from-legacy-catalog https://desktop.docker.com/mcp/catalog/v3/catalog.json
docker mcp profile create --name metadata
docker mcp profile server add metadata --catalog docker-mcp-catalog --catalog-server zerodha-kite
docker mcp profile show metadata --format json
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="686" height="480" alt="Screenshot 2025-11-18 at 6 51 56 AM" src="https://github.com/user-attachments/assets/411b8030-9a77-431c-87e9-8b3d8c004a17" />
