### PR TITLE
Ensure db directory exists

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -55,12 +55,13 @@ func New(opts ...Option) (DAO, error) {
 
 	if o.dbFile == "" {
 		dbFile, err := DefaultDatabaseFilename()
-		ensureDirectoryExists(dbFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default database filename: %w", err)
 		}
 		o.dbFile = dbFile
 	}
+
+	ensureDirectoryExists(o.dbFile)
 
 	db, err := sql.Open("sqlite", "file:"+o.dbFile+"?_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)")
 	if err != nil {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCreatesDirectoryWhenNotExists(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create a nested path that doesn't exist yet
+	nonExistentDir := filepath.Join(tempDir, "nested", "directories", "that", "dont", "exist")
+	dbFile := filepath.Join(nonExistentDir, "test.db")
+
+	// Verify the directory doesn't exist before creating the database
+	_, err := os.Stat(nonExistentDir)
+	assert.True(t, os.IsNotExist(err), "Directory should not exist before database creation")
+
+	// Create the database - this should create the directory
+	dao, err := New(WithDatabaseFile(dbFile))
+	require.NoError(t, err)
+	require.NotNil(t, dao)
+
+	// Verify the directory was created
+	stat, err := os.Stat(nonExistentDir)
+	require.NoError(t, err, "Directory should exist after database creation")
+	assert.True(t, stat.IsDir(), "Created path should be a directory")
+}


### PR DESCRIPTION
**What I did**

I ran into issues where I would get an out of memory error (red herring) if the db's directory didn't exist. This fixes that.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**