### PR TITLE
Update tool name prefix separator from colon to double underscore

### DIFF
--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -80,7 +80,7 @@ func prefixToolName(prefix, toolName string) string {
 	if prefix == "" {
 		return toolName
 	}
-	return prefix + ":" + toolName
+	return prefix + "__" + toolName
 }
 
 func (caps *Capabilities) getPromptByName(promptName string) (PromptRegistration, error) {


### PR DESCRIPTION
This is to fix [#228] Tool names with colons violate MCP naming pattern

**What I did**
Update tool name prefix separator from colon `:` to double underscore `__`

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
This fixes #228 
