### PR TITLE
Fix issue with openai

### DIFF
--- a/pkg/gateway/dynamic_mcps.go
+++ b/pkg/gateway/dynamic_mcps.go
@@ -745,6 +745,7 @@ func (g *Gateway) createMcpConfigSetTool(_ *clientConfig) *ToolRegistration {
 				"value": {
 					Types:       []string{"string", "number", "boolean", "object", "array"},
 					Description: "Configuration value to set (can be string, number, boolean, object, or array)",
+					Items:       &jsonschema.Schema{Type: "object"},
 				},
 			},
 			Required: []string{"server", "key", "value"},


### PR DESCRIPTION
Fixes #264

This schema is rejected by OpenAI because
the value could be an array without items type.

This seems to fix it.

A better solution would maybe be to use anyOf with a union of all five possible types.
