### PR TITLE
use appropriate type for config attributes

### DIFF
--- a/cmd/docker-mcp/commands/workingset.go
+++ b/cmd/docker-mcp/commands/workingset.go
@@ -63,7 +63,7 @@ func configWorkingSetCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&set, "set", []string{}, "Set configuration values: <key>=<value> (can be specified multiple times)")
+	flags.StringArrayVar(&set, "set", []string{}, "Set configuration values: <key>=<value> (repeatable). Value may be JSON to set typed values (arrays, numbers, booleans, objects).")
 	flags.StringArrayVar(&get, "get", []string{}, "Get configuration values: <key> (can be specified multiple times)")
 	flags.StringArrayVar(&del, "del", []string{}, "Delete configuration values: <key> (can be specified multiple times)")
 	flags.BoolVar(&getAll, "get-all", false, "Get all configuration values")

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -270,6 +270,27 @@ docker mcp profile config my-profile --get-all --format yaml
 - `--get-all`: Retrieves all configuration values from all servers in the profile
 - `--format`: Output format - `human` (default), `json`, or `yaml`
 
+**Typed values via JSON:**
+
+- Values passed to `--set` are parsed as JSON when possible. This allows arrays, numbers, booleans and objects.
+- If the value is not valid JSON, it is stored as a plain string.
+- Examples:
+
+```bash
+# Numbers and booleans
+docker mcp profile config my-profile --set github.timeout=60 --set github.debug=true
+
+# Strings (either raw or JSON-quoted both work)
+docker mcp profile config my-profile --set slack.channel=general
+docker mcp profile config my-profile --set slack.channel='"general"'
+
+# Arrays
+docker mcp profile config my-profile --set filesystem.paths='["/Users/dk/dev","/Users/dk/projects"]'
+
+# Objects
+docker mcp profile config my-profile --set build.options='{"retries":3,"cache":false}'
+```
+
 **Important notes:**
 - The server name must match the name from the server's snapshot (not the image or source URL)
 - Use `docker mcp profile show <profile-id> --format yaml` to see available server names


### PR DESCRIPTION
**What I did** I noticed all of the config attributes were stored as plain strings. Instead of handling the parsing logic on the client side, I believe it's better to do it in the CLI. I've added JSON parsing when setting values and also displaying them in the correct type.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Notice: booleans and numbers not being strings. Also the string array in the second example.
```
docker mcp profile config redis --get-all --format=json
{
  "redis.cluster_mode": false,
  "redis.host": "localhost",
  "redis.port": 6379,
  "redis.ssl": false,
  "redis.ssl_keyfile": "f"
}
docker mcp profile config file --get-all --format=json
{
  "filesystem.paths": [
    "/Users/dk/dev",
    "/Users/dk/tmp"
  ]
}
```

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="741" height="775" alt="image" src="https://github.com/user-attachments/assets/b50be55c-d4c0-4ebe-b5aa-958dc5af4fb7" />
