### PR TITLE
Support profiles with Gordon and add `profile manual-instructions`

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -201,11 +201,10 @@ func FindClientsByProfile(ctx context.Context, profileID string) map[string]any 
 		}
 	}
 
-	// TODO: Add support for Gordon with flags
-	// gordonCfg := GetGordonSetup(ctx)
-	// if gordonCfg.WorkingSet == profileID {
-	// 	clients[VendorGordon] = gordonCfg
-	// }
+	gordonCfg := GetGordonSetup(ctx)
+	if gordonCfg.WorkingSet == profileID {
+		clients[VendorGordon] = gordonCfg
+	}
 
 	codexCfg := GetCodexSetup(ctx)
 	if codexCfg.WorkingSet == profileID {

--- a/pkg/client/connect.go
+++ b/pkg/client/connect.go
@@ -26,11 +26,7 @@ func Connect(ctx context.Context, dao db.DAO, cwd string, config Config, vendor 
 			return err
 		}
 	} else if vendor == VendorGordon && global {
-		if workingSet != "" {
-			// Gordon doesn't support profiles yet
-			return fmt.Errorf("gordon cannot be connected to a profile")
-		}
-		if err := ConnectGordon(ctx); err != nil {
+		if err := ConnectGordon(ctx, workingSet); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/client/profiles.go
+++ b/pkg/client/profiles.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/mcp-gateway/pkg/user"
+)
+
+type FileConfig struct {
+	Profile string `json:"profile"`
+}
+
+// Currently only used for Gordon.
+type ProfilesFile = map[string]FileConfig
+
+func writeGordonProfile(workingSet string) error {
+	profilePath, err := getProfilePath()
+	if err != nil {
+		return err
+	}
+
+	profiles, err := readProfile(profilePath)
+	if err != nil {
+		return err
+	}
+	profiles[VendorGordon] = FileConfig{Profile: workingSet}
+	return writeProfile(profilePath, profiles)
+}
+
+func ReadGordonProfile() (string, error) {
+	profilePath, err := getProfilePath()
+	if err != nil {
+		return "", err
+	}
+	profiles, err := readProfile(profilePath)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := profiles[VendorGordon]; ok {
+		return profiles[VendorGordon].Profile, nil
+	}
+	return "", nil
+}
+
+func getProfilePath() (string, error) {
+	homeDir, err := user.HomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".docker", "mcp", "profiles.json"), nil
+}
+
+func readProfile(path string) (ProfilesFile, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return make(ProfilesFile), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read profile file: %w", err)
+	}
+	var profiles ProfilesFile
+	if err := json.Unmarshal(data, &profiles); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal profile file: %w", err)
+	}
+	return profiles, nil
+}
+
+func writeProfile(path string, profiles ProfilesFile) error {
+	data, err := json.MarshalIndent(profiles, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal profiles: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create profile directory: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/pkg/workingset/create.go
+++ b/pkg/workingset/create.go
@@ -87,9 +87,6 @@ func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, 
 
 func verifySupportedClients(cfg client.Config, clients []string) error {
 	for _, c := range clients {
-		if c == client.VendorGordon {
-			return fmt.Errorf("gordon cannot be connected to a profile")
-		}
 		if !client.IsSupportedMCPClient(cfg, c, true) {
 			return fmt.Errorf("client %s is not supported. Supported clients: %s", c, strings.Join(client.GetSupportedMCPClients(cfg), ", "))
 		}

--- a/pkg/workingset/manual_instructions.go
+++ b/pkg/workingset/manual_instructions.go
@@ -1,0 +1,36 @@
+package workingset
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func WriteManualInstructions(profileID string, format OutputFormat, output io.Writer) error {
+	if profileID == "" {
+		return fmt.Errorf("profile ID is required")
+	}
+
+	command := []string{"docker", "mcp", "gateway", "run", "--profile", profileID}
+
+	switch format {
+	case OutputFormatHumanReadable:
+		fmt.Fprint(output, strings.Join(command, " "))
+	case OutputFormatJSON:
+		buf, err := json.Marshal(command)
+		if err != nil {
+			return err
+		}
+		_, _ = output.Write(buf)
+	case OutputFormatYAML:
+		buf, err := yaml.Marshal(command)
+		if err != nil {
+			return err
+		}
+		_, _ = output.Write(buf)
+	}
+	return nil
+}

--- a/pkg/workingset/manual_instructions_test.go
+++ b/pkg/workingset/manual_instructions_test.go
@@ -1,0 +1,52 @@
+package workingset
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteManualInstructions_HumanReadable(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := WriteManualInstructions("my-profile", OutputFormatHumanReadable, &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, "docker mcp gateway run --profile my-profile", buf.String())
+}
+
+func TestWriteManualInstructions_JSON(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := WriteManualInstructions("my-profile", OutputFormatJSON, &buf)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `["docker","mcp","gateway","run","--profile","my-profile"]`, buf.String())
+}
+
+func TestWriteManualInstructions_YAML(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := WriteManualInstructions("my-profile", OutputFormatYAML, &buf)
+
+	require.NoError(t, err)
+	expected := `- docker
+- mcp
+- gateway
+- run
+- --profile
+- my-profile
+`
+	assert.Equal(t, expected, buf.String())
+}
+
+func TestWriteManualInstructions_EmptyProfileID(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := WriteManualInstructions("", OutputFormatHumanReadable, &buf)
+
+	require.Error(t, err)
+	assert.Equal(t, "profile ID is required", err.Error())
+}


### PR DESCRIPTION
**What I did**

This PR adds support for using Gordon with profiles. It also adds a hidden `docker mcp profile manual-instructions <profile-id>` that we can use to display instructions in DD.

In order to support profiles with Gordon, we write a profile to `~/.docker/mcp/profiles.json`. Then when Gordon runs the hidden command `docker mcp client manual-instructions --json` it will use the Gordon profile written to that file to produce the mcp gateway run command. The file `profiles.json` has no other use than that at the present time. (In the future we can consider refactoring configuration to be session-based rather than global to enable session-loaded profiles.)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/2eb068cc-1d16-430f-9fd7-c37440580e44" />
