### PR TITLE
"default" profile support for connected clients.

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -196,20 +196,27 @@ func FindClientsByProfile(ctx context.Context, profileID string) map[string]any 
 			continue
 		}
 		clientCfg := processor.ParseConfig()
-		if clientCfg.WorkingSet == profileID {
+		if matchesProfile(clientCfg, profileID) {
 			clients[vendor] = clientCfg
 		}
 	}
 
 	gordonCfg := GetGordonSetup(ctx)
-	if gordonCfg.WorkingSet == profileID {
+	if matchesProfile(gordonCfg, profileID) {
 		clients[VendorGordon] = gordonCfg
 	}
 
 	codexCfg := GetCodexSetup(ctx)
-	if codexCfg.WorkingSet == profileID {
+	if matchesProfile(codexCfg, profileID) {
 		clients[VendorCodex] = codexCfg
 	}
 
 	return clients
+}
+
+func matchesProfile(cfg MCPClientCfg, profileID string) bool {
+	if cfg.IsMCPCatalogConnected && profileID == "default" && cfg.WorkingSet == "" {
+		return true
+	}
+	return cfg.WorkingSet == profileID
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -319,6 +319,18 @@ func TestFindClientsByProfile(t *testing.T) {
 			expectedVendors: []string{},
 		},
 		{
+			name:      "find clients with default profile",
+			profileID: "default",
+			mockConfigs: map[string][]byte{
+				vendorCursor:        readTestData(t, "find-profiles/cursor-with-profile.json"),
+				vendorClaudeDesktop: readTestData(t, "find-profiles/claude-desktop-with-profile.json"),
+				vendorZed:           readTestData(t, "find-profiles/zed-without-profile.json"),
+				vendorKiro:          readTestData(t, "find-profiles/kiro-without-profile.json"),
+				vendorContinueDev:   readTestData(t, "find-profiles/continue-without-profile.yml"),
+			},
+			expectedVendors: []string{vendorZed, vendorKiro, vendorContinueDev},
+		},
+		{
 			name:      "finds clients without profile when searching for empty string",
 			profileID: "",
 			mockConfigs: map[string][]byte{
@@ -376,6 +388,10 @@ func TestFindClientsByProfile(t *testing.T) {
 					IsOsSupported: true,
 				}
 				clientCfg.setParseResult(lists, nil)
+
+				if matchesProfile(clientCfg, tc.profileID) {
+					clientCfg.WorkingSet = tc.profileID // Overwrite if matching
+				}
 
 				shouldMatch := expectedMap[vendor]
 


### PR DESCRIPTION
**What I did**

When a user has a `default` profile, `docker mcp profile show <profile> --clients` should also return any clients that are expected to run the profile as the default. This adds that.

Default profile running is implemented [here](https://github.com/docker/mcp-gateway/pull/276).

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**