### PR TITLE
Disallow session flag with profile flag.

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -72,10 +72,11 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 					len(options.CatalogPath) > 0 || len(options.RegistryPath) > 0 || len(options.ConfigPath) > 0 || len(options.ToolsPath) > 0 ||
 					len(additionalCatalogs) > 0 || len(additionalRegistries) > 0 || len(additionalConfigs) > 0 || len(additionalToolsConfig) > 0 ||
 					len(mcpRegistryUrls) > 0 || len(options.OciRef) > 0 ||
+					len(options.SessionName) > 0 ||
 					(options.SecretsPath != "docker-desktop" && !strings.HasPrefix(options.SecretsPath, "docker-desktop:")) {
 					// We're in legacy mode, so we can't use the working set feature
 					if options.WorkingSet != "" {
-						return fmt.Errorf("cannot use --profile with --servers, --enable-all-servers, --catalog, --additional-catalog, --registry, --additional-registry, --config, --additional-config, --tools-config, --additional-tools-config, --secrets, --oci-ref, --mcp-registry flags")
+						return fmt.Errorf("cannot use --profile with --servers, --enable-all-servers, --catalog, --additional-catalog, --registry, --additional-registry, --config, --additional-config, --tools-config, --additional-tools-config, --secrets, --oci-ref, --mcp-registry, --session flags")
 					}
 					// Make sure to default the options in legacy mode
 					setLegacyDefaults(&options)


### PR DESCRIPTION
**What I did**

Codex caught a conflict here: https://github.com/docker/mcp-gateway/pull/276#discussion_r2586180994

This just disables using `--session` with `--profile`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**