### PR TITLE
fix: forward original tool name to remote MCP servers

### DIFF
--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -159,7 +159,7 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 						capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 							ServerName: serverConfig.Name,
 							Tool:       &prefixedTool,
-							Handler:    g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations),
+							Handler:    g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations, tool.Name),
 						})
 					}
 				}

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -57,7 +57,7 @@ func (g *Gateway) mcpToolHandler(tool catalog.Tool) mcp.ToolHandler {
 	}
 }
 
-func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, annotations *mcp.ToolAnnotations) mcp.ToolHandler {
+func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, annotations *mcp.ToolAnnotations, originalToolName string) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		// Look up server configuration
 		serverConfig, _, ok := g.configuration.Find(serverName)
@@ -128,7 +128,7 @@ func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, an
 		}
 		params := &mcp.CallToolParams{
 			Meta:      req.Params.Meta,
-			Name:      req.Params.Name,
+			Name:      originalToolName,
 			Arguments: args,
 		}
 


### PR DESCRIPTION
## Problem

When `tool-name-prefix` is enabled (or when using explicit `prefix` in server config), the gateway correctly prefixes tool names for the client (e.g., `new_page` → `server__new_page`).

However, when forwarding the `tools/call` request to the remote MCP server, the **prefixed name** was being sent instead of the original name. The remote server doesn't know about gateway prefixes and fails with "tool not found".

## Root Cause

In `handlers.go`, the `mcpServerToolHandler` was using `req.Params.Name` (the prefixed name from the client request) when calling `client.Session().CallTool()`:

```go
params := &mcp.CallToolParams{
    Name: req.Params.Name,  // Bug: sends "server__new_page" to server that only knows "new_page"
    ...
}
```

## Solution

Pass the original tool name (without prefix) to the handler and use it when forwarding to the remote server:

1. Add `originalToolName` parameter to `mcpServerToolHandler`
2. Pass `tool.Name` (original name) when creating the handler in `listCapabilities`
3. Use `originalToolName` instead of `req.Params.Name` when calling the remote server

## Testing

Tested with Chrome DevTools MCP server using custom `prefix` configuration:
- **Before fix:** `chromedev__new_page` → "Tool new_page not found"
- **After fix:** `chromedev__new_page` → works correctly

## Related

This fix is complementary to #263 which changes the prefix separator from `:` to `__`. Without this fix, the `tool-name-prefix` feature doesn't work regardless of which separator is used.