### PR TITLE
fix: remove explicit exclusion of 'claude' clients from tool activation logic.

### DIFF
--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -209,9 +209,9 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 		}
 		clientNameLower := strings.ToLower(clientName)
 
-		// Only activate tools if activate is true AND client name doesn't contain "claude"
-		// (Claude clients auto-refresh their tool list, so they don't need explicit activation)
-		shouldActivate := params.Activate && !strings.Contains(clientNameLower, "claude")
+		// Activate tools if requested - all clients need explicit activation
+		// (Removed incorrect assumption that Claude auto-refreshes tool list)
+		shouldActivate := params.Activate // Claude clients also need explicit activation
 
 		if shouldActivate {
 			// Now update g.mcpServer with the new capabilities


### PR DESCRIPTION
## Summary

The `mcp-add` command was incorrectly skipping tool activation for clients with "claude" in their name, based on the assumption that these clients auto-refresh their tool list. This assumption is incorrect.

## Problem

When `mcp-add` is called with `activate=true` from affected clients:

1. Tools are added to `g.toolRegistrations` (accessible via `mcp-exec`)
2. But `updateServerCapabilities()` is never called due to a client name check
3. Therefore `g.mcpServer.AddTool()` is never executed
4. Direct MCP tool calls fail with "unknown tool" error

**Reproduction:**
```
mcp-add chromedev (activate=true)     → success (26 tools registered)
mcp-exec chromedev:list_pages         → works ✓
direct call to chromedev:list_pages   → "unknown tool" error ✗
```

## Root Cause

In `pkg/gateway/mcpadd.go` line 234:
```go
shouldActivate := params.Activate && \!strings.Contains(clientNameLower, "claude")
```

This check prevents tool activation for any client with "claude" in its name.

## Fix

Remove the client name exclusion:

```go
shouldActivate := params.Activate // All clients need explicit activation
```

## Testing

Tested with Claude Code:
- Before fix: direct tool calls fail after `mcp-add`
- After fix: direct tool calls work correctly

## Related

Related to #278 (tool-name-prefix dispatch fix)