### PR TITLE
Fix: Skip probing Docker API during CLI initialization in container mode

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -28,6 +28,15 @@ func New(ctx context.Context, dockerCli command.Cli) (result Features) {
 	features := &featuresImpl{}
 	result = features
 
+	// When running inside the gateway container (DOCKER_MCP_IN_CONTAINER=1), we
+	// must not touch the Docker API before the CLI is fully initialized. The
+	// plugin lifecycle initializes the Docker CLI later, so probing here would
+	// fail with "no context store initialized". In this mode we skip probing and
+	// fall back to defaults.
+	if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" {
+		return features
+	}
+
 	features.runningDockerDesktop, features.initErr = isRunningInDockerDesktop(ctx, dockerCli)
 	if features.initErr != nil {
 		return


### PR DESCRIPTION
**What I did**
https://github.com/docker/mcp-gateway/pull/280 introduced a check for Docker Desktop Feature Flags.
However, on a fresh system running the gateway container without a Docker Desktop context:
```
> docker context inspect default
[
    {
        "Name": "default",
        "Metadata": {},
        "Endpoints": {
            "docker": {
                "Host": "unix:///var/run/docker.sock",
                "SkipTLSVerify": false
            }
        },
        "TLSMaterial": {},
        "Storage": {
            "MetadataPath": "\u003cIN MEMORY\u003e",
            "TLSPath": "\u003cIN MEMORY\u003e"
        }
    }
]
```
leads to the error `Failed to initialize: unable to resolve docker endpoint: no context store initialized`:
```
...
+ export 'DOCKER_MCP_IN_CONTAINER=1'
Detected dockerd ready for work!
Starting MCP Gateway on port 8080...
+ export 'DOCKER_MCP_IN_DIND=1'
+ echo 'Starting MCP Gateway on port 8080...'
+ exec /docker-mcp gateway run '--port=8080' '--servers=duckduckgo'
Failed to initialize: unable to resolve docker endpoint: no context store initialized
```

I don't know any better way than to skip that check when running in an environment without an initialised context.

---

Some sidenotes: I don't know `GoLang` or the Docker internals. Debugging this took me hours. I couldn't pull the previous version because only the `latest` tag is currently published. Please start using deterministic tags. I was able to implement a hotfix by patching the `Dockerfile` locally to copy from a build step, not from  the published image:
```
Subject: [PATCH] Skip probing Docker API during CLI initialization in container mode
---diff
Index: Dockerfile
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/Dockerfile b/Dockerfile
--- a/Dockerfile	(revision 0f658dbf9d16a7f7a03bf81942a78ae6f547eade)
+++ b/Dockerfile	(date 1765346300271)
@@ -143,7 +143,9 @@
 FROM scratch AS mcp-gateway-dind
 COPY --from=dind / /
 RUN apk add --no-cache socat jq
-COPY --from=docker/mcp-gateway /docker-mcp /
+# Use the locally built gateway binary (includes any patches) instead of the
+# published image binary so container builds pick up source changes.
+COPY --from=build-mcp-gateway /docker-mcp /
 RUN cat <<-'EOF' >/run.sh
 	#!/usr/bin/env sh
 	set -euxo pipefail
```

---

Just seeing now: https://github.com/docker/mcp-gateway/pull/290