### PR TITLE
Call RegisterProviderForLazySetup during profile creation

### DIFF
--- a/pkg/workingset/create.go
+++ b/pkg/workingset/create.go
@@ -60,6 +60,8 @@ func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, 
 		workingSet.Servers = append(workingSet.Servers, ss...)
 	}
 
+	RegisterOAuthProvidersForServers(ctx, workingSet.Servers)
+
 	if err := workingSet.Validate(); err != nil {
 		return fmt.Errorf("invalid profile: %w", err)
 	}

--- a/pkg/workingset/import.go
+++ b/pkg/workingset/import.go
@@ -45,6 +45,8 @@ func Import(ctx context.Context, dao db.DAO, ociService oci.Service, filename st
 		}
 	}
 
+	RegisterOAuthProvidersForServers(ctx, workingSet.Servers)
+
 	if err := workingSet.Validate(); err != nil {
 		return fmt.Errorf("invalid profile: %w", err)
 	}

--- a/pkg/workingset/oauth.go
+++ b/pkg/workingset/oauth.go
@@ -1,0 +1,37 @@
+package workingset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/mcp-gateway/pkg/log"
+	"github.com/docker/mcp-gateway/pkg/oauth"
+)
+
+// RegisterOAuthProvidersForServers registers OAuth providers with Docker Desktop
+// for any remote OAuth servers in the list. This enables servers to appear
+// in the OAuth tab for authorization.
+//
+// This function is idempotent and safe to call multiple times for the same servers.
+// In CE mode, this is a no-op since OAuth DCR happens during the authorize command.
+func RegisterOAuthProvidersForServers(ctx context.Context, servers []Server) {
+	// Skip in CE mode - DCR happens during oauth authorize command
+	if oauth.IsCEMode() {
+		return
+	}
+
+	for _, server := range servers {
+		if server.Snapshot == nil {
+			continue
+		}
+		if !server.Snapshot.Server.IsRemoteOAuthServer() {
+			continue
+		}
+
+		serverName := server.Snapshot.Server.Name
+		if err := oauth.RegisterProviderForLazySetup(ctx, serverName); err != nil {
+			// Log warning but don't fail - user can authorize later via CLI
+			log.Log(fmt.Sprintf("Warning: Failed to register OAuth provider for %s: %v", serverName, err))
+		}
+	}
+}

--- a/pkg/workingset/pull.go
+++ b/pkg/workingset/pull.go
@@ -31,6 +31,8 @@ func Pull(ctx context.Context, dao db.DAO, ociService oci.Service, ref string) e
 		}
 	}
 
+	RegisterOAuthProvidersForServers(ctx, workingSet.Servers)
+
 	if err := workingSet.Validate(); err != nil {
 		return fmt.Errorf("invalid profile: %w", err)
 	}

--- a/pkg/workingset/server.go
+++ b/pkg/workingset/server.go
@@ -52,6 +52,8 @@ func AddServers(ctx context.Context, dao db.DAO, registryClient registryapi.Clie
 		newServers[i].Secrets = defaultSecret
 	}
 
+	RegisterOAuthProvidersForServers(ctx, newServers)
+
 	workingSet.Servers = append(workingSet.Servers, newServers...)
 
 	if err := workingSet.Validate(); err != nil {


### PR DESCRIPTION
**What I did**
-  Fixes OAuth providers not appearing in the Docker Desktop OAuth tab when servers are added via profiles:
- When using docker mcp server enable <server>, remote OAuth servers correctly appear in the OAuth tab. However, when adding servers through profiles (docker mcp profile create, profile server add, profile import, profile pull), the OAuth providers were not being registered with Docker Desktop, causing them to be invisible in the OAuth tab.

- Added `RegisterOAuthProvidersForServers()` helper function that calls `RegisterProviderForLazySetup()` for any remote OAuth servers when they're added to a profile. This aligns the profile flow with the existing global server enable flow

**Related issue**
- OAuth provider doesn't show up in Docker Desktop OAuth Tab

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**