### PR TITLE
Fix: Auto-detect Docker CE mode on Linux

### DIFF
--- a/pkg/oauth/credhelper_test.go
+++ b/pkg/oauth/credhelper_test.go
@@ -10,50 +10,43 @@ import (
 )
 
 func TestIsCEMode(t *testing.T) {
-	// Test CE mode detection
-	tests := []struct {
-		name     string
-		envValue string
-		expected bool
-	}{
-		{
-			name:     "CE mode enabled",
-			envValue: "true",
-			expected: true,
-		},
-		{
-			name:     "CE mode disabled",
-			envValue: "false",
-			expected: false,
-		},
-		{
-			name:     "CE mode not set",
-			envValue: "",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			oldValue := os.Getenv("DOCKER_MCP_USE_CE")
-			defer func() {
-				if oldValue == "" {
-					os.Unsetenv("DOCKER_MCP_USE_CE")
-				} else {
-					os.Setenv("DOCKER_MCP_USE_CE", oldValue)
-				}
-			}()
-
-			if tt.envValue == "" {
+	// Test CE mode explicit enable via environment variable
+	t.Run("CE mode enabled via env var", func(t *testing.T) {
+		oldValue := os.Getenv("DOCKER_MCP_USE_CE")
+		defer func() {
+			if oldValue == "" {
 				os.Unsetenv("DOCKER_MCP_USE_CE")
 			} else {
-				os.Setenv("DOCKER_MCP_USE_CE", tt.envValue)
+				os.Setenv("DOCKER_MCP_USE_CE", oldValue)
 			}
+		}()
 
-			result := IsCEMode()
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+		os.Setenv("DOCKER_MCP_USE_CE", "true")
+		result := IsCEMode()
+		assert.True(t, result, "Should return true when DOCKER_MCP_USE_CE=true")
+	})
+
+	t.Run("CE mode enabled in container", func(t *testing.T) {
+		oldCEValue := os.Getenv("DOCKER_MCP_USE_CE")
+		oldContainerValue := os.Getenv("DOCKER_MCP_IN_CONTAINER")
+		defer func() {
+			if oldCEValue == "" {
+				os.Unsetenv("DOCKER_MCP_USE_CE")
+			} else {
+				os.Setenv("DOCKER_MCP_USE_CE", oldCEValue)
+			}
+			if oldContainerValue == "" {
+				os.Unsetenv("DOCKER_MCP_IN_CONTAINER")
+			} else {
+				os.Setenv("DOCKER_MCP_IN_CONTAINER", oldContainerValue)
+			}
+		}()
+
+		os.Unsetenv("DOCKER_MCP_USE_CE")
+		os.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
+		result := IsCEMode()
+		assert.True(t, result, "Should return true when running in container")
+	})
 }
 
 func TestReadWriteHelper_Operations(t *testing.T) {

--- a/pkg/oauth/mode.go
+++ b/pkg/oauth/mode.go
@@ -1,11 +1,44 @@
 package oauth
 
-import "os"
+import (
+	"context"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+)
 
 // IsCEMode returns true if running in Docker CE mode (standalone OAuth flows).
 // When false, uses Docker Desktop for OAuth orchestration.
 //
-// Set the environment variable DOCKER_MCP_USE_CE=true to enable CE mode.
+// CE mode is automatically detected on Linux when Docker Desktop is not running.
+// Set the environment variable DOCKER_MCP_USE_CE=true to force CE mode.
 func IsCEMode() bool {
-	return os.Getenv("DOCKER_MCP_USE_CE") == "true"
+	// Allow explicit override via environment variable
+	if os.Getenv("DOCKER_MCP_USE_CE") == "true" {
+		return true
+	}
+
+	// When running inside the gateway container, skip Desktop detection
+	if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" {
+		return true
+	}
+
+	// On Windows and macOS, Docker Desktop is always used
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return false
+	}
+
+	// On Linux, check if Docker Desktop is running
+	// If not running, we're in CE mode
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	if err := desktop.CheckDesktopIsRunning(ctx); err != nil {
+		// Docker Desktop is not running, so we're in CE mode
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
**What I did**
Auto-detect Docker CE mode on Linux without requiring users to manually set the `DOCKER_MCP_USE_CE=true` environment variable.

**Related issue**
Fixes #293

**Problem**
When running `docker mcp gateway run` on Linux with Docker CE, users encountered: Failed to connect to OAuth notifications: 
`Failed to connect to OAuth notifications: Get "http://localhost/notify/notifications/channel/external-oauth": dial unix /root/.docker/desktop/backend.sock: no such file or directory.`

This happened because [`IsCEMode()`](https://github.com/docker/mcp-gateway/blob/main/pkg/oauth/mode.go#L9-L11) only checked for the `DOCKER_MCP_USE_CE` environment variable. When not set, it returned `false`, causing the OAuth
notification monitor to attempt connecting to Docker Desktop's backend socket - which doesn't exist on Docker CE installations.

**Solution**
Modified `IsCEMode()` to auto-detect Docker CE on Linux by checking if Docker Desktop is running, following the same
pattern used in [`pkg/features/features.go#L63-L84`](https://github.com/docker/mcp-gateway/blob/main/pkg/features/features.go#L63-L84).

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="612" height="410" alt="image" src="https://github.com/user-attachments/assets/bf49eb55-fa53-4ff9-8f3a-2d9e389faf73" />
