### PR TITLE
Fix dynamic tools with profiles

### DIFF
--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -85,7 +85,7 @@ type Gateway struct {
 func NewGateway(config Config, docker docker.Client) *Gateway {
 	var configurator Configurator
 	if config.WorkingSet != "" {
-		configurator = NewWorkingSetConfiguration(config.WorkingSet, config.DynamicTools, oci.NewService(), docker)
+		configurator = NewWorkingSetConfiguration(config, oci.NewService(), docker)
 	} else {
 		configurator = &FileBasedConfiguration{
 			ServerNames:        config.ServerNames,


### PR DESCRIPTION
**What I did**

This loads the default `mcp/docker-mcp-catalog` catalog when using profiles so that dynamic tools can be used with it.

A couple caveats to this:
1. It requires pulling the catalog. This will happen automatically by DD. But non-DD users will have to manually pull it.
2. Dynamic tools can't be turned off for profiles except by the feature flag.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**