### PR TITLE
Fix long-lived servers mounting volumes as read-only

### DIFF
--- a/pkg/gateway/clientpool.go
+++ b/pkg/gateway/clientpool.go
@@ -352,7 +352,10 @@ func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, readOnly *b
 			continue
 		}
 
-		if readOnly != nil && *readOnly && !strings.HasSuffix(mount, ":ro") {
+		// For long-lived servers, never mount volumes as read-only
+		// because the container will be shared across multiple tool calls
+		isLongLived := serverConfig.Spec.LongLived || cp.LongLived
+		if !isLongLived && readOnly != nil && *readOnly && !strings.HasSuffix(mount, ":ro") {
 			args = append(args, "-v", mount+":ro")
 		} else {
 			args = append(args, "-v", mount)


### PR DESCRIPTION
Long-lived servers were incorrectly mounting volumes as read-only when the first tool call had the read-only flag set. Since long-lived containers are shared across multiple tool calls, volumes should never be mounted read-only regardless of the first call's read-only status.

This change adds a check to skip read-only volume mounting for long-lived servers, ensuring subsequent write operations succeed.

**Related issue**
#305 

