### PR TITLE
Fix infinite loop in RefreshCapabilities with notification-heavy servers

### DIFF
--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -322,6 +322,15 @@ func (g *Gateway) updateServerCapabilities(serverName string, oldCaps, newCaps *
 	addedResources, removedResources := diffStringSlices(oldCaps.ResourceURIs, newCaps.ResourceURIs)
 	addedTemplates, removedTemplates := diffStringSlices(oldCaps.ResourceTemplateURIs, newCaps.ResourceTemplateURIs)
 
+	// Early exit if nothing changed - prevents unnecessary updates and potential notification loops
+	if len(addedTools) == 0 && len(removedTools) == 0 &&
+		len(addedPrompts) == 0 && len(removedPrompts) == 0 &&
+		len(addedResources) == 0 && len(removedResources) == 0 &&
+		len(addedTemplates) == 0 && len(removedTemplates) == 0 {
+		log.Log("  - No capability changes detected for", serverName, "- skipping update")
+		return nil
+	}
+
 	// Remove old capabilities that are no longer present
 	if len(removedTools) > 0 {
 		g.mcpServer.RemoveTools(removedTools...)


### PR DESCRIPTION
This change prevents the infinite loop that occurred when MCP servers like github-official send capability change notifications, which was causing the gateway to repeatedly refresh and update capabilities.

This is a very recent change in the behavior of github-official server and actually looks to me like a bug in the latest version of the github server.

## Changes Made

### 1. Added Refresh Guard Mechanism (pkg/gateway/run.go)
- Added `refreshMu` mutex and `refreshingServers` map to track ongoing refresh operations per server
- Prevents concurrent/recursive RefreshCapabilities calls for the same server

### 2. Implemented Loop Prevention (pkg/gateway/run.go:415-431)
- Before starting a refresh, check if one is already in progress
- If in progress, log a message and return early (skip the refresh)
- Use `defer` to ensure the refreshing flag is cleared even if an error occurs
- This breaks the infinite loop when servers send multiple notifications

### 3. Added Change Detection (pkg/gateway/reload.go:325-332)
- Added early exit in `updateServerCapabilities` when no capabilities have changed
- Prevents unnecessary updates to `g.mcpServer` when tools/prompts/resources haven't actually changed
- This prevents triggering new notifications when there's nothing new to report

## How It Fixes the Bug

Before:
github-official starts → sends notification → RefreshCapabilities → updates g.mcpServer → triggers another notification → RefreshCapabilities → ∞

After:
github-official starts → sends notification → RefreshCapabilities (marks refreshing) → if another notification arrives → RefreshCapabilities (sees already refreshing) → skips when refresh completes → clears refreshing flag

**Related issue**

#318 