### PR TITLE
Add support for extraHosts in MCP server catalog entries

### DIFF
--- a/examples/playwright-with-extrahosts.yaml
+++ b/examples/playwright-with-extrahosts.yaml
@@ -1,0 +1,17 @@
+registry:
+  playwright:
+    description: Playwright MCP server.
+    title: Playwright
+    type: server
+    longLived: true
+    dateAdded: "2025-05-05T20:04:34Z"
+    image: mcp/playwright@sha256:53da89d1da3dfbb61c10f707c1713cfee1f870f7fba5334e126c6c765e37db56
+    ref: ""
+    readme: http://desktop.docker.com/mcp/catalog/v3/readme/playwright.md
+    toolsUrl: http://desktop.docker.com/mcp/catalog/v3/tools/playwright.json
+    source: https://github.com/microsoft/playwright-mcp/tree/64f65ccd105842204e3e1b1e1a7b28825492b089
+    upstream: https://github.com/microsoft/playwright-mcp
+    icon: https://avatars.githubusercontent.com/u/6154722?v=4
+    extraHosts:
+      - "myapp.local:192.168.1.100"
+      - "testserver:10.0.0.5"

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -32,6 +32,7 @@ type Server struct {
 	User           string    `yaml:"user,omitempty" json:"user,omitempty"`
 	DisableNetwork bool      `yaml:"disableNetwork,omitempty" json:"disableNetwork,omitempty"`
 	AllowHosts     []string  `yaml:"allowHosts,omitempty" json:"allowHosts,omitempty"`
+	ExtraHosts     []string  `yaml:"extraHosts,omitempty" json:"extraHosts,omitempty"`
 	Tools          []Tool    `yaml:"tools,omitempty" json:"tools,omitempty"`
 	Config         []any     `yaml:"config,omitempty" json:"config,omitempty"`
 	Prefix         string    `yaml:"prefix,omitempty" json:"prefix,omitempty"`

--- a/pkg/gateway/clientpool.go
+++ b/pkg/gateway/clientpool.go
@@ -373,6 +373,13 @@ func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, readOnly *b
 		}
 	}
 
+	// Extra hosts (for /etc/hosts entries)
+	for _, host := range serverConfig.Spec.ExtraHosts {
+		if host != "" {
+			args = append(args, "--add-host", host)
+		}
+	}
+
 	return args, env
 }
 

--- a/pkg/gateway/clientpool_test.go
+++ b/pkg/gateway/clientpool_test.go
@@ -160,6 +160,29 @@ user: "1001:2002"
 	assert.Empty(t, env)
 }
 
+func TestApplyConfigExtraHosts(t *testing.T) {
+	catalogYAML := `
+description: Playwright MCP server.
+title: Playwright
+type: server
+longLived: true
+image: mcp/playwright@sha256:53da89d1da3dfbb61c10f707c1713cfee1f870f7fba5334e126c6c765e37db56
+extraHosts:
+  - "myhost:192.168.1.100"
+  - "anotherhost:10.0.0.1"
+  `
+
+	args, env := argsAndEnv(t, "playwright", catalogYAML, "", nil, nil)
+
+	assert.Equal(t, []string{
+		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
+		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=playwright", "-l", "docker-mcp-transport=stdio",
+		"--add-host", "myhost:192.168.1.100",
+		"--add-host", "anotherhost:10.0.0.1",
+	}, args)
+	assert.Empty(t, env)
+}
+
 func TestApplyConfigLongLivedIgnoresReadOnly(t *testing.T) {
 	catalogYAML := `
 longLived: true


### PR DESCRIPTION
Add support for the extraHosts setting in Catalog entries which allows specifying custom hostname-to-IP mappings for MCP containers. When present, the gateway passes these entries to Docker using the --add-host flag, adding static entries to the container's /etc/hosts file.

Changes:
- Add ExtraHosts []string field to catalog.Server struct
- Add --add-host flag support in clientpool.argsAndEnv() function
- Add TestApplyConfigExtraHosts test with playwright-like catalog entry
- Add example catalog file showing usage with playwright server

Example usage in catalog YAML:
  playwright: image: mcp/playwright@sha256:... extraHosts: - "myapp.local:192.168.1.100" - "testserver:10.0.0.5"

