### PR TITLE
Remote Clients should be long-lived

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -163,3 +163,8 @@ type ServerConfig struct {
 	Config  map[string]any
 	Secrets map[string]string
 }
+
+// IsRemote returns true if this server is a remote MCP server (not a Docker container)
+func (sc *ServerConfig) IsRemote() bool {
+	return sc.Spec.SSEEndpoint != "" || sc.Spec.Remote.URL != ""
+}


### PR DESCRIPTION
The remote clients should be cached by ServerSession

**What I did**

This is an optimization. It's a long-standing issue that the http transport clients can be cached by ServerSession (equivalent to one unique client connection to the gateway). 