### PR TITLE
gateway: fix panic when using mcp-add over stdio clients

### DIFF
--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -151,10 +151,10 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 
 		// If secrets or config are missing, handle based on client type
 		if len(missingSecrets) > 0 || len(missingConfig) > 0 {
-			// Check if the client is nanobot
+			// Safely determine client name (InitializeParams may be nil for some transports)
 			clientName := ""
-			if req.Session.InitializeParams().ClientInfo != nil {
-				clientName = req.Session.InitializeParams().ClientInfo.Name
+			if init := req.Session.InitializeParams(); init != nil && init.ClientInfo != nil {
+				clientName = init.ClientInfo.Name
 			}
 
 			if clientName == "nanobot" && len(missingSecrets) > 0 {
@@ -256,17 +256,31 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 			}
 		}
 
-		// Register DCR client and make sure OAuth provider is started if this is a remote OAuth server
-		if g.McpOAuthDcrEnabled && serverConfig != nil && serverConfig.Spec.IsRemoteOAuthServer() {
-			authorized, oauthText := g.getRemoteOAuthServerStatus(ctx, serverName, req, shouldSendTools)
-			if !authorized {
-				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{
-						Text: oauthText,
-					}},
-				}, nil
+		// Handle OAuth DCR only when the client supports elicitation (e.g. not stdio-based clients)
+		if g.McpOAuthDcrEnabled &&
+			serverConfig != nil &&
+			serverConfig.Spec.IsRemoteOAuthServer() {
+
+			init := req.Session.InitializeParams()
+			if init != nil &&
+				init.Capabilities != nil &&
+				init.Capabilities.Elicitation != nil {
+
+				authorized, oauthText := g.getRemoteOAuthServerStatus(
+					ctx,
+					serverName,
+					req,
+					shouldSendTools,
+				)
+				if !authorized {
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{
+							Text: oauthText,
+						}},
+					}, nil
+				}
+				responseText = oauthText
 			}
-			responseText = oauthText
 		}
 
 		return &mcp.CallToolResult{
@@ -406,8 +420,11 @@ func (g *Gateway) getRemoteOAuthServerStatus(ctx context.Context, serverName str
 		g.startProvider(ctx, serverName)
 	}
 
-	// Check if current serverSession supports elicitations
-	if req.Session.InitializeParams().Capabilities != nil && req.Session.InitializeParams().Capabilities.Elicitation != nil {
+	// Proceed with elicitation only if the client supports it
+	init := req.Session.InitializeParams()
+	if init != nil &&
+		init.Capabilities != nil &&
+		init.Capabilities.Elicitation != nil {
 		// Elicit a response from the client asking whether to open a browser for authorization
 		elicitResult, err := req.Session.Elicit(ctx, &mcp.ElicitParams{
 			Message: fmt.Sprintf("Would you like to open a browser to authorize the '%s' server?", serverName),


### PR DESCRIPTION
## What I did

Hardened the `mcp-add` execution flow to safely support stdio-based MCP clients by guarding access to optional session initialization data and client capabilities.

This change ensures that dynamically adding servers no longer assumes the presence of `InitializeParams` or elicitation support, preventing nil pointer dereferences when running over stdio transports (e.g. Cursor IDE).
Existing interactive behavior is preserved for clients that explicitly advertise elicitation support.

## Related issue

Fixed #335

## What was the problem ?

When using `mcp-add` dynamically over **stdio-based MCP clients**, the MCP Gateway could crash with:

```panic: runtime error: invalid memory address or nil pointer dereference```
```github.com/docker/mcp-gateway/pkg/gateway/mcpadd.go:188```

This occurred because:

- The gateway assumed `req.Session.InitializeParams()` was always non-nil
- OAuth / elicitation logic accessed client capabilities unconditionally
- stdio transports do not provide initialization metadata or elicitation support

As a result:

- The gateway process crashed
- All subsequent MCP calls failed with `"Not connected"`
- Users were forced to rely on manual pre-enablement as a workaround

## Before / After (summary)

### Before

- Unconditional access to `InitializeParams` and client capabilities
- OAuth and elicitation logic executed for all clients
- `mcp-add` could crash the gateway process

### After

- All access to session initialization data and capabilities is guarded
- Elicitation and OAuth logic only runs when explicitly supported
- `mcp-add` works reliably across stdio and interactive clients

## Screenshots with Explain

### Missing secrets / config handling

This logic safely detects the client type before deciding how to handle missing secrets or configuration.

Since `InitializeParams` may be `nil` on some transports, the client name is resolved defensively to avoid panics. If the client is **nanobot** and only secrets are missing, the gateway returns an interactive secret input flow. All other clients receive a non-interactive error with setup instructions.
This ensures correct behavior across different MCP transports while preventing invalid assumptions about client capabilities.

<img width="1061" height="462" alt="image" src="https://github.com/user-attachments/assets/96cb763e-ae72-41fb-8e02-3034e328ad59" />

### OAuth DCR gating based on client capabilities

OAuth DCR handling is executed only when explicitly enabled and when the target server requires remote OAuth. Before triggering any authorization flow, the gateway verifies that the client supports **elicitation** via `InitializeParams`.
This prevents OAuth flows from running on stdio-based or non-interactive clients, avoiding invalid assumptions about client capabilities and eliminating potential nil pointer panics.

<img width="1015" height="787" alt="image" src="https://github.com/user-attachments/assets/55168461-6dfc-4a28-b26b-6eaab786b797" />

### Conditional OAuth elicitation

The gateway attempts OAuth authorization elicitation only when the client explicitly advertises support for elicitation in its initialization capabilities.
This ensures that interactive authorization prompts are never triggered on non-interactive or stdio-based clients, preserving correct behavior across transports and preventing invalid session assumptions.

<img width="1037" height="612" alt="image" src="https://github.com/user-attachments/assets/982589d1-9e4a-4f3c-8d51-2f052b8cbc8b" />

