### PR TITLE
Changes to use Docker Desktop proxy

### DIFF
--- a/cmd/docker-mcp/catalog/import.go
+++ b/cmd/docker-mcp/catalog/import.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/tui"
 )
 
@@ -23,13 +24,13 @@ func isValidURL(u string) bool {
 	return true
 }
 
-func DownloadFile(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func DownloadFile(ctx context.Context, downloadURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	client := &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: desktop.ProxyTransport(),
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -37,7 +38,7 @@ func DownloadFile(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("downloading %q (status code: %d)", url, resp.StatusCode)
+		return nil, fmt.Errorf("downloading %q (status code: %d)", downloadURL, resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
 }

--- a/cmd/docker-mcp/commands/import.go
+++ b/cmd/docker-mcp/commands/import.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/oci"
 )
 
@@ -30,7 +31,9 @@ func runMcpregistryImport(ctx context.Context, serverURL string, servers *[]cata
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: desktop.ProxyTransport(),
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to fetch server definition: %w", err)

--- a/cmd/docker-mcp/server/inspect.go
+++ b/cmd/docker-mcp/server/inspect.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/catalog"
 	"github.com/docker/mcp-gateway/pkg/config"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/docker"
 )
 
@@ -126,7 +127,7 @@ func fetch(ctx context.Context, url string) ([]byte, error) {
 	}
 
 	client := &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: desktop.ProxyTransport(),
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/user"
 )
 
@@ -83,7 +84,7 @@ func readFileOrURL(ctx context.Context, fileOrURL string) ([]byte, error) {
 		}
 
 		client := &http.Client{
-			Transport: http.DefaultTransport,
+			Transport: desktop.ProxyTransport(),
 		}
 
 		resp, err := client.Do(req)

--- a/pkg/desktop/connection_other.go
+++ b/pkg/desktop/connection_other.go
@@ -20,6 +20,10 @@ func dialSecrets(ctx context.Context) (net.Conn, error) {
 	return dial(ctx, Paths().JFSSocket)
 }
 
+func dialHTTPProxy(ctx context.Context) (net.Conn, error) {
+	return dial(ctx, Paths().HTTPProxySocket)
+}
+
 func dial(ctx context.Context, path string) (net.Conn, error) {
 	dialer := net.Dialer{}
 	return dialer.DialContext(ctx, "unix", path)

--- a/pkg/desktop/connection_windows.go
+++ b/pkg/desktop/connection_windows.go
@@ -19,6 +19,10 @@ func dialSecrets(ctx context.Context) (net.Conn, error) {
 	return dial(ctx, Paths().JFSSocket)
 }
 
+func dialHTTPProxy(ctx context.Context) (net.Conn, error) {
+	return dial(ctx, Paths().HTTPProxySocket)
+}
+
 func dial(ctx context.Context, path string) (net.Conn, error) {
 	return winio.DialPipeContext(ctx, path)
 }

--- a/pkg/desktop/paths.go
+++ b/pkg/desktop/paths.go
@@ -8,6 +8,7 @@ type DockerDesktopPaths struct {
 	RawDockerSocket      string
 	JFSSocket            string
 	ToolsSocket          string
+	HTTPProxySocket      string
 	CredentialHelperPath func() string
 }
 

--- a/pkg/desktop/sockets_darwin.go
+++ b/pkg/desktop/sockets_darwin.go
@@ -22,6 +22,7 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 		RawDockerSocket:      filepath.Join(data, "docker.raw.sock"),
 		JFSSocket:            filepath.Join(data, "jfs.sock"),
 		ToolsSocket:          filepath.Join(data, "tools.sock"),
+		HTTPProxySocket:      filepath.Join(data, "httpproxy.sock"),
 		CredentialHelperPath: getCredentialHelperPath,
 	}, nil
 }

--- a/pkg/desktop/sockets_linux.go
+++ b/pkg/desktop/sockets_linux.go
@@ -28,6 +28,7 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 			RawDockerSocket:      filepath.Join(home, ".docker/desktop/docker.raw.sock"),
 			JFSSocket:            filepath.Join(home, ".docker/desktop/jfs.sock"),
 			ToolsSocket:          filepath.Join(home, ".docker/desktop/tools.sock"),
+			HTTPProxySocket:      filepath.Join(home, ".docker/desktop/httpproxy.sock"),
 			CredentialHelperPath: getCredentialHelperPath,
 		}, nil
 	}

--- a/pkg/desktop/sockets_windows.go
+++ b/pkg/desktop/sockets_windows.go
@@ -19,6 +19,7 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 		RawDockerSocket:      `\\.\pipe\docker_engine_linux`,
 		JFSSocket:            `\\.\pipe\dockerJfs`,
 		ToolsSocket:          `\\.\pipe\dockerTools`,
+		HTTPProxySocket:      `\\.\pipe\dockerHttpProxy`,
 		CredentialHelperPath: getCredentialHelperPath,
 	}, nil
 }

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 // Fetches a URL and returns the body as a byte slice.
@@ -19,7 +21,7 @@ func Untrusted(ctx context.Context, url string) ([]byte, error) {
 
 	client := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: http.DefaultTransport,
+		Transport: desktop.ProxyTransport(),
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/gateway/embeddings/oci.go
+++ b/pkg/gateway/embeddings/oci.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/user"
 )
@@ -56,7 +57,7 @@ func Pull(ctx context.Context) error {
 	}
 
 	// Pull the image
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx), remote.WithTransport(desktop.ProxyTransport()))
 	if err != nil {
 		return fmt.Errorf("failed to pull image: %w", err)
 	}
@@ -310,7 +311,7 @@ func Push(ctx context.Context, vectorDBPath string, ociRef string) error {
 
 	// Push the image to the registry
 	log.Logf("Pushing image to %s", ociRef)
-	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx)); err != nil {
+	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx), remote.WithTransport(desktop.ProxyTransport())); err != nil {
 		return fmt.Errorf("failed to push image: %w", err)
 	}
 

--- a/pkg/gateway/findtools.go
+++ b/pkg/gateway/findtools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/gateway/embeddings"
 	"github.com/docker/mcp-gateway/pkg/log"
 )
@@ -49,7 +50,9 @@ func generateEmbedding(ctx context.Context, text string) ([]float64, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: desktop.ProxyTransport(),
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -358,7 +358,8 @@ func shortenURL(ctx context.Context, longURL string) (string, error) {
 
 	// Make the request
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Transport: desktop.ProxyTransport(),
+		Timeout:   10 * time.Second,
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/gateway/registry.go
+++ b/pkg/gateway/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oci"
 )
@@ -33,7 +34,9 @@ func (g *Gateway) readServersFromURL(ctx context.Context, url string) (map[strin
 	req.Header.Set("User-Agent", "docker-mcp-gateway/1.0.0")
 
 	// Make the HTTP request
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: desktop.ProxyTransport(),
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch URL: %w", err)

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/shlex"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/logs"
 )
 
@@ -187,7 +188,7 @@ func (i *Interceptor) runHTTP(ctx context.Context, message []byte) ([]byte, erro
 	}
 
 	client := &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: desktop.ProxyTransport(),
 	}
 
 	response, err := client.Do(request)

--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -11,6 +11,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/oauth"
 )
 
@@ -73,7 +74,7 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	// Create HTTP client with custom headers
 	httpClient := &http.Client{
 		Transport: &headerRoundTripper{
-			base:    http.DefaultTransport,
+			base:    desktop.ProxyTransport(),
 			headers: headers,
 		},
 	}

--- a/pkg/oauth/mode.go
+++ b/pkg/oauth/mode.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/docker/mcp-gateway/pkg/features"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 // IsCEMode returns true if running in Docker CE mode (standalone OAuth flows).
@@ -24,5 +24,5 @@ func IsCEMode() bool {
 
 	// Use the same logic as feature flags
 	// IsCEMode is the inverse of IsRunningInDockerDesktop
-	return !features.IsRunningInDockerDesktop(context.Background())
+	return !desktop.IsRunningInDockerDesktop(context.Background())
 }

--- a/pkg/oci/artifacts.go
+++ b/pkg/oci/artifacts.go
@@ -16,6 +16,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	oci "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 const MCPServerArtifactType = "application/vnd.docker.mcp.server"
@@ -152,12 +154,12 @@ func uploadBlob(ctx context.Context, ref name.Reference, data []byte, _ digest.D
 	layer := static.NewLayer(data, types.MediaType("application/octet-stream"))
 
 	// Write the layer (blob) to the repository with authentication
-	return remote.WriteLayer(repo, layer, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+	return remote.WriteLayer(repo, layer, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx), remote.WithTransport(desktop.ProxyTransport()))
 }
 
 func uploadManifest(ctx context.Context, ref name.Reference, manifestBytes []byte) error {
 	// Create a custom image with the manifest
-	return remote.Put(ref, &customManifest{data: manifestBytes}, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+	return remote.Put(ref, &customManifest{data: manifestBytes}, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx), remote.WithTransport(desktop.ProxyTransport()))
 }
 
 // customManifest implements v1.Image interface for custom manifest
@@ -249,7 +251,7 @@ func ReadArtifact[T any](ociRef string, expectedArtifactType string) (T, error) 
 	}
 
 	// Get the image/artifact from the registry
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithTransport(desktop.ProxyTransport()))
 	if err != nil {
 		return *new(T), fmt.Errorf("failed to fetch image/artifact %s: %w", ociRef, err)
 	}

--- a/pkg/oci/import.go
+++ b/pkg/oci/import.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 func ImportToServer(registryURL string) (catalog.Server, error) {
@@ -22,7 +23,8 @@ func ImportToServer(registryURL string) (catalog.Server, error) {
 
 	// Fetch JSON document from registryUrl
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Transport: desktop.ProxyTransport(),
+		Timeout:   30 * time.Second,
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, registryURL, nil)
@@ -64,7 +66,8 @@ func Import(registryURL string, ociRepository string, push bool) error {
 
 	// Fetch JSON document from registryUrl
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Transport: desktop.ProxyTransport(),
+		Timeout:   30 * time.Second,
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, registryURL, nil)
@@ -163,7 +166,7 @@ func Import(registryURL string, ociRepository string, push bool) error {
 	firstRef := ociReferences[0]
 
 	// Verify the reference can be resolved
-	subjectDescriptor, err := remote.Get(firstRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	subjectDescriptor, err := remote.Get(firstRef, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithTransport(desktop.ProxyTransport()))
 	if err != nil {
 		return fmt.Errorf("failed to resolve reference %s: %w", firstRef.Name(), err)
 	}

--- a/pkg/oci/service.go
+++ b/pkg/oci/service.go
@@ -10,6 +10,8 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 type Service interface {
@@ -49,7 +51,7 @@ func (s *service) GetLocalImage(ctx context.Context, ref name.Reference) (v1.Ima
 }
 
 func (s *service) GetRemoteImage(ctx context.Context, ref name.Reference) (v1.Image, error) {
-	return remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+	return remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx), remote.WithTransport(desktop.ProxyTransport()))
 }
 
 func IsNoSuchImageError(err error) bool {

--- a/pkg/registryapi/client.go
+++ b/pkg/registryapi/client.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	registryapi "github.com/modelcontextprotocol/registry/pkg/api/v0"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 type Client interface {
@@ -21,7 +23,10 @@ type client struct {
 
 func NewClient() Client {
 	return &client{
-		client: &http.Client{Timeout: 20 * time.Second},
+		client: &http.Client{
+			Transport: desktop.ProxyTransport(),
+			Timeout:   20 * time.Second,
+		},
 	}
 }
 

--- a/pkg/signatures/signatures.go
+++ b/pkg/signatures/signatures.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/version"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 )
 
 // https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub
@@ -62,6 +63,7 @@ func Verify(ctx context.Context, images []string) error {
 					ociremote.WithRemoteOptions(
 						remote.WithContext(ctxVerify),
 						remote.WithUserAgent(version.UserAgent()),
+						remote.WithTransport(desktop.ProxyTransport()),
 						// remote.WithAuthFromKeychain(authn.DefaultKeychain),
 					),
 				},


### PR DESCRIPTION
**What I did**
Changed the default http client transport to use Docker Desktop proxy.

- Use Sync.Once to initialize desktopProxyTransportInst which uses http.DefaultTransport if Docker Desktop is not running, otherwise creates a transport that forwards the http requests via Docker Desktop proxy.

- I had to move features.IsRunningInDockerDesktop() from features package to desktop package. Because I cannot access features package in desktop package as it results in a circular dependency between those two packages.

**Related issue**
Fixes https://docker.atlassian.net/browse/DDB-378

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**