### PR TITLE
fix: oauth provider registration for workingsets

### DIFF
--- a/pkg/oauth/dcr_registration.go
+++ b/pkg/oauth/dcr_registration.go
@@ -45,3 +45,23 @@ func RegisterProviderForLazySetup(ctx context.Context, serverName string) error 
 
 	return client.RegisterDCRClientPending(ctx, serverName, dcrRequest)
 }
+
+// RegisterProviderWithSnapshot registers a DCR provider using OAuth metadata from the server snapshot
+// This avoids querying the catalog since the snapshot already contains all necessary OAuth information
+// Idempotent - safe to call multiple times for the same server
+func RegisterProviderWithSnapshot(ctx context.Context, serverName, providerName string) error {
+	client := desktop.NewAuthClient()
+
+	// Idempotent check - already registered?
+	_, err := client.GetDCRClient(ctx, serverName)
+	if err == nil {
+		return nil // Already registered
+	}
+
+	// Register with Docker Desktop (pending DCR state)
+	dcrRequest := desktop.RegisterDCRRequest{
+		ProviderName: providerName,
+	}
+
+	return client.RegisterDCRClientPending(ctx, serverName, dcrRequest)
+}

--- a/pkg/workingset/oauth.go
+++ b/pkg/workingset/oauth.go
@@ -29,8 +29,9 @@ func RegisterOAuthProvidersForServers(ctx context.Context, servers []Server) {
 		}
 
 		serverName := server.Snapshot.Server.Name
-		if err := oauth.RegisterProviderForLazySetup(ctx, serverName); err != nil {
-			// Log warning but don't fail - user can authorize later via CLI
+		providerName := server.Snapshot.Server.OAuth.Providers[0].Provider
+
+		if err := oauth.RegisterProviderWithSnapshot(ctx, serverName, providerName); err != nil {
 			log.Log(fmt.Sprintf("Warning: Failed to register OAuth provider for %s: %v", serverName, err))
 		}
 	}


### PR DESCRIPTION
**What I did**
Implement RegisterProviderWithSnapshot for DCR provider registration. Previous implementation use the workingset server name to do a lookup in the file-based catalog.

This is unnecessary because the server snapshot data contains the provider. Additionally, this would at times cause errors when the file-based catalog was out of sync with the oci based catalog used with the profiles feature flag enabled.


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**