### PR TITLE
Remove client connections when a profile is removed.

### DIFF
--- a/cmd/docker-mcp/commands/root.go
+++ b/cmd/docker-mcp/commands/root.go
@@ -92,7 +92,7 @@ func Root(ctx context.Context, cwd string, dockerCli command.Cli, features featu
 	})
 
 	if features.IsProfilesFeatureEnabled() {
-		cmd.AddCommand(workingSetCommand())
+		cmd.AddCommand(workingSetCommand(cwd))
 		cmd.AddCommand(catalogNextCommand())
 		cmd.AddCommand(obsoleteCommand("config", "See `docker mcp profile config --help` instead."))
 	} else {

--- a/cmd/docker-mcp/commands/workingset.go
+++ b/cmd/docker-mcp/commands/workingset.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/workingset"
 )
 
-func workingSetCommand() *cobra.Command {
+func workingSetCommand(cwd string) *cobra.Command {
 	cfg := client.ReadConfig()
 
 	cmd := &cobra.Command{
@@ -29,7 +29,7 @@ func workingSetCommand() *cobra.Command {
 	cmd.AddCommand(pushWorkingSetCommand())
 	cmd.AddCommand(pullWorkingSetCommand())
 	cmd.AddCommand(createWorkingSetCommand(cfg))
-	cmd.AddCommand(removeWorkingSetCommand())
+	cmd.AddCommand(removeWorkingSetCommand(cwd))
 	cmd.AddCommand(workingsetServerCommand())
 	cmd.AddCommand(configWorkingSetCommand())
 	cmd.AddCommand(toolsWorkingSetCommand())
@@ -294,7 +294,7 @@ func importWorkingSetCommand() *cobra.Command {
 	}
 }
 
-func removeWorkingSetCommand() *cobra.Command {
+func removeWorkingSetCommand(cwd string) *cobra.Command {
 	return &cobra.Command{
 		Use:     "remove <profile-id>",
 		Aliases: []string{"rm"},
@@ -305,7 +305,11 @@ func removeWorkingSetCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return workingset.Remove(cmd.Context(), dao, args[0])
+			if err = workingset.Remove(cmd.Context(), dao, cwd, args[0]); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 }

--- a/pkg/workingset/remove_test.go
+++ b/pkg/workingset/remove_test.go
@@ -29,7 +29,7 @@ func TestRemoveExistingWorkingSet(t *testing.T) {
 	require.NotNil(t, dbSet)
 
 	// Remove it
-	err = Remove(ctx, dao, "test-set")
+	err = Remove(ctx, dao, t.TempDir(), "test-set")
 	require.NoError(t, err)
 
 	// Verify it's gone
@@ -42,7 +42,7 @@ func TestRemoveNonExistentWorkingSet(t *testing.T) {
 	ctx := t.Context()
 
 	// Try to remove a non-existent working set
-	err := Remove(ctx, dao, "non-existent")
+	err := Remove(ctx, dao, t.TempDir(), "non-existent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -63,7 +63,7 @@ func TestRemoveOneOfMany(t *testing.T) {
 	}
 
 	// Remove the middle one
-	err := Remove(ctx, dao, "b-set")
+	err := Remove(ctx, dao, t.TempDir(), "b-set")
 	require.NoError(t, err)
 
 	// Verify only b-set is gone
@@ -98,11 +98,11 @@ func TestRemoveTwice(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove it
-	err = Remove(ctx, dao, "test-set")
+	err = Remove(ctx, dao, t.TempDir(), "test-set")
 	require.NoError(t, err)
 
 	// Try to remove it again
-	err = Remove(ctx, dao, "test-set")
+	err = Remove(ctx, dao, t.TempDir(), "test-set")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -121,7 +121,7 @@ func TestRemoveCaseSensitive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to remove with wrong case
-	err = Remove(ctx, dao, "TEST-SET")
+	err = Remove(ctx, dao, t.TempDir(), "TEST-SET")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 
@@ -136,7 +136,7 @@ func TestRemoveWithEmptyId(t *testing.T) {
 	ctx := t.Context()
 
 	// Try to remove with empty ID
-	err := Remove(ctx, dao, "")
+	err := Remove(ctx, dao, t.TempDir(), "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }


### PR DESCRIPTION
**What I did**

Fixed a bug where client connections would hang around when a profile is removed. There is one caveat, in that if the `default` profile is removed, we'll also remove the client connections, even if they really just were using `docker mcp gateway run` for dynamic tools. We can consider a workaround if we don't like that behavior. But I generally see that as an edge case.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**