### PR TITLE
feat: use underscores intead of hyphens in profile id generation

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -77,7 +77,7 @@ docker mcp profile create --name "My Servers" --id my-servers \
 
 **Notes:**
 - `--name` is required and serves as the human-readable name
-- `--id` is optional; if not provided, it's generated from the name (lowercase, alphanumeric with hyphens)
+- `--id` is optional; if not provided, it's generated from the name (lowercase, alphanumeric with underscores)
 - `--server` can be specified multiple times to add multiple servers
 - Server references must be either:
   - `docker://` prefix for OCI images

--- a/pkg/workingset/create_test.go
+++ b/pkg/workingset/create_test.go
@@ -101,11 +101,11 @@ func TestCreateWithDockerImages(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the working set was created
-	dbSet, err := dao.GetWorkingSet(ctx, "my-test-set")
+	dbSet, err := dao.GetWorkingSet(ctx, "my_test_set")
 	require.NoError(t, err)
 	require.NotNil(t, dbSet)
 
-	assert.Equal(t, "my-test-set", dbSet.ID)
+	assert.Equal(t, "my_test_set", dbSet.ID)
 	assert.Equal(t, "My Test Set", dbSet.Name)
 	assert.Len(t, dbSet.Servers, 2)
 
@@ -127,7 +127,7 @@ func TestCreateWithRegistryServers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the working set was created
-	dbSet, err := dao.GetWorkingSet(ctx, "registry-set")
+	dbSet, err := dao.GetWorkingSet(ctx, "registry_set")
 	require.NoError(t, err)
 	require.NotNil(t, dbSet)
 
@@ -151,7 +151,7 @@ func TestCreateWithMixedServers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the working set was created
-	dbSet, err := dao.GetWorkingSet(ctx, "mixed-set")
+	dbSet, err := dao.GetWorkingSet(ctx, "mixed_set")
 	require.NoError(t, err)
 	require.NotNil(t, dbSet)
 
@@ -231,9 +231,9 @@ func TestCreateGeneratesUniqueIds(t *testing.T) {
 	}
 
 	// Verify ID pattern
-	assert.Contains(t, ids, "test-set")
-	assert.Contains(t, ids, "test-set-2")
-	assert.Contains(t, ids, "test-set-3")
+	assert.Contains(t, ids, "test_set")
+	assert.Contains(t, ids, "test_set_2")
+	assert.Contains(t, ids, "test_set_3")
 }
 
 func TestCreateWithInvalidServerFormat(t *testing.T) {
@@ -266,7 +266,7 @@ func TestCreateWithEmptyServers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the working set was created with no servers
-	dbSet, err := dao.GetWorkingSet(ctx, "empty-set")
+	dbSet, err := dao.GetWorkingSet(ctx, "empty_set")
 	require.NoError(t, err)
 	require.NotNil(t, dbSet)
 
@@ -283,7 +283,7 @@ func TestCreateAddsDefaultSecrets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify default secrets were added
-	dbSet, err := dao.GetWorkingSet(ctx, "test-set")
+	dbSet, err := dao.GetWorkingSet(ctx, "test_set")
 	require.NoError(t, err)
 	require.NotNil(t, dbSet)
 
@@ -301,22 +301,22 @@ func TestCreateNameWithSpecialCharacters(t *testing.T) {
 		{
 			name:       "name with spaces",
 			inputName:  "My Test Set",
-			expectedID: "my-test-set",
+			expectedID: "my_test_set",
 		},
 		{
 			name:       "name with special chars",
 			inputName:  "Test@Set#123!",
-			expectedID: "test-set-123-",
+			expectedID: "test_set_123_",
 		},
 		{
 			name:       "name with multiple spaces",
 			inputName:  "Test   Set",
-			expectedID: "test-set",
+			expectedID: "test_set",
 		},
 		{
 			name:       "name with underscores",
 			inputName:  "Test_Set_Name",
-			expectedID: "test-set-name",
+			expectedID: "test_set_name",
 		},
 	}
 

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -349,9 +349,9 @@ func (s *Server) BasicName() string {
 }
 
 func createWorkingSetID(ctx context.Context, name string, dao db.DAO) (string, error) {
-	// Replace all non-alphanumeric characters with a hyphen and make all uppercase lowercase
+	// Replace all non-alphanumeric characters with an underscore and make all uppercase lowercase
 	re := regexp.MustCompile("[^a-zA-Z0-9]+")
-	cleaned := re.ReplaceAllString(name, "-")
+	cleaned := re.ReplaceAllString(name, "_")
 	baseName := strings.ToLower(cleaned)
 
 	existingSets, err := dao.FindWorkingSetsByIDPrefix(ctx, baseName)
@@ -371,7 +371,7 @@ func createWorkingSetID(ctx context.Context, name string, dao db.DAO) (string, e
 	// TODO(cody): there are better ways to do this, but this is a simple brute force for now
 	// Append a number to the base name
 	for i := 2; i <= 100; i++ {
-		newName := fmt.Sprintf("%s-%d", baseName, i)
+		newName := fmt.Sprintf("%s_%d", baseName, i)
 		if !takenIDs[newName] {
 			return newName, nil
 		}

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -911,24 +911,24 @@ func TestCreateWorkingSetID(t *testing.T) {
 		{
 			name:       "name with spaces",
 			inputName:  "My Working Set",
-			expectedID: "my-working-set",
+			expectedID: "my_working_set",
 		},
 		{
 			name:       "name with special characters",
 			inputName:  "My@Working#Set!",
-			expectedID: "my-working-set-",
+			expectedID: "my_working_set_",
 		},
 		{
 			name:        "name with collision",
 			inputName:   "test",
 			existingIDs: []string{"test"},
-			expectedID:  "test-2",
+			expectedID:  "test_2",
 		},
 		{
 			name:        "name with multiple collisions",
 			inputName:   "test",
-			existingIDs: []string{"test", "test-2", "test-3"},
-			expectedID:  "test-4",
+			existingIDs: []string{"test", "test_2", "test_3"},
+			expectedID:  "test_4",
 		},
 	}
 


### PR DESCRIPTION
**What I did**
When only a profile name is provided and the id is generated it will replace special characters with underscores instead of hyphens. Hyphens were problematic because they were being interpreted as command line flags.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**