### PR TITLE
added PR reviewer workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,28 @@
+name: PR Review
+
+on:
+  issue_comment: # Enables /review command in PR comments
+    types: [created]
+  pull_request_review_comment: # Captures feedback on review comments for learning
+    types: [created]
+  pull_request_target: # Triggers auto-review on PR open; uses base branch context so secrets work with forks
+    types: [ready_for_review, opened]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@latest
+    # Scoped to the job so other jobs in this workflow aren't over-permissioned
+    permissions:
+      contents: read       # Read repository files and PR diffs
+      pull-requests: write # Post review comments and approve/request changes
+      issues: write        # Create security incident issues if secrets are detected in output
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CAGENT_ORG_MEMBERSHIP_TOKEN: ${{ secrets.CAGENT_ORG_MEMBERSHIP_TOKEN }} # PAT with read:org scope; gates auto-reviews to org members only
+      CAGENT_REVIEWER_APP_ID: ${{ secrets.CAGENT_REVIEWER_APP_ID }} # GitHub App ID; reviews appear as your app instead of github-actions[bot]
+      CAGENT_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.CAGENT_REVIEWER_APP_PRIVATE_KEY }} # GitHub App private key; paired with App ID above
+    with:
+      add-prompt-files: "CLAUDE.md"


### PR DESCRIPTION
**What I did**

Added an automated PR review workflow powered by the shared `docker/cagent-action` reusable workflow. This enables AI-assisted code review on every new or ready-for-review PR, as well as on-demand via `/review` in PR comments. The workflow feeds the repo's `CLAUDE.md` as additional context so reviews are informed by project-specific conventions.

Key details:
- Triggers on PR opened, PR marked ready for review, issue comments, and review comments
- Uses `pull_request_target` so secrets are available even for fork PRs
- Explicitly passes required secrets rather than using `secrets: inherit`
- Reviews appear under the `docker-agent` identity (not the generic `github-actions[bot]`)
- Auto-reviews are gated to org members only via `CAGENT_ORG_MEMBERSHIP_TOKEN`
- Scoped permissions: read for contents, write for pull-requests and issues

**Related issue**

Closes https://github.com/docker/gordon/issues/132

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1024" height="1024" alt="ai-review" src="https://github.com/user-attachments/assets/b4c42be9-c111-4f33-912f-6121f4060aea" />
