### PR TITLE
Fix DCR registration idempotent check.

### DIFF
--- a/pkg/oauth/dcr_registration.go
+++ b/pkg/oauth/dcr_registration.go
@@ -53,8 +53,8 @@ func RegisterProviderWithSnapshot(ctx context.Context, serverName, providerName 
 	client := desktop.NewAuthClient()
 
 	// Idempotent check - already registered?
-	_, err := client.GetDCRClient(ctx, serverName)
-	if err == nil {
+	c, err := client.GetDCRClient(ctx, serverName)
+	if err == nil && c.State == "registered" {
 		return nil // Already registered
 	}
 


### PR DESCRIPTION
**What I did**

Fixed an issue where existing providers in an `unregistered` state wouldn't be listed in the DD OAuth tab even after they've been added to a profile.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**