### PR TITLE
Cherry-pick: Proactive OAuth token refresh for Desktop mode

### DIFF
--- a/cmd/docker-mcp/secret-management/secret/secretsengine.go
+++ b/cmd/docker-mcp/secret-management/secret/secretsengine.go
@@ -16,9 +16,10 @@ import (
 var ErrSecretNotFound = errors.New("secret not found")
 
 type Envelope struct {
-	ID       string `json:"id"`
-	Value    []byte `json:"value"`
-	Provider string `json:"provider"`
+	ID       string            `json:"id"`
+	Value    []byte            `json:"value"`
+	Provider string            `json:"provider"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 func socketPath() string {

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
@@ -61,33 +62,37 @@ func (p *DCRProvider) GeneratePKCE() string {
 	return oauth2.GenerateVerifier()
 }
 
-// Provider manages OAuth token lifecycle for a single MCP server (CE mode only).
-// Polls token expiry, triggers refresh when needed, and reloads the server connection.
-// In Desktop mode, Secrets Engine handles token refresh and SSE events trigger reloads.
+// Provider manages OAuth token lifecycle for a single MCP server.
+// This is used for background token refresh loops in the gateway.
+// CE mode: refreshes tokens directly via oauth2 library, then reloads.
+// Desktop mode: triggers refresh via GetOAuthApp Desktop API, then SSE events
+// interrupt the timer, trigger reload, and reset retry counters.
 type Provider struct {
 	name              string
 	lastRefreshExpiry time.Time
 	refreshRetryCount int
 	stopOnce          sync.Once
 	stopChan          chan struct{}
+	eventChan         chan Event
 	credHelper        *CredentialHelper
 	reloadFn          func(ctx context.Context, serverName string) error
 }
 
 const maxRefreshRetries = 7 // Max attempts to refresh when expiry hasn't changed
 
-// NewProvider creates a new OAuth provider for token refresh polling
+// NewProvider creates a new OAuth provider for token refresh
 func NewProvider(name string, reloadFn func(context.Context, string) error) *Provider {
 	return &Provider{
 		name:       name,
 		stopChan:   make(chan struct{}),
+		eventChan:  make(chan Event),
 		credHelper: NewOAuthCredentialHelper(),
 		reloadFn:   reloadFn,
 	}
 }
 
-// Run starts the provider's background polling loop.
-// Checks token expiry, triggers refresh when needed, and reloads server connections.
+// Run starts the provider's background loop.
+// Loop dynamically adjusts timing based on token expiry.
 func (p *Provider) Run(ctx context.Context) {
 	log.Logf("- Started OAuth provider loop for %s", p.name)
 	defer log.Logf("- Stopped OAuth provider loop for %s", p.name)
@@ -101,8 +106,9 @@ func (p *Provider) Run(ctx context.Context) {
 			return
 		}
 
-		// Calculate wait duration based on token status
+		// Calculate wait duration and whether to trigger refresh
 		var waitDuration time.Duration
+		var shouldTriggerRefresh bool
 
 		if status.NeedsRefresh {
 			// Token needs refresh - check if expiry unchanged from last attempt
@@ -128,32 +134,63 @@ func (p *Provider) Run(ctx context.Context) {
 				p.name, p.refreshRetryCount, maxRefreshRetries, waitDuration)
 
 			p.lastRefreshExpiry = status.ExpiresAt
-
-			// Refresh token and reload server connection
-			go func() {
-				if err := p.refreshTokenCE(); err != nil {
-					log.Logf("! Token refresh failed for %s: %v", p.name, err)
-					return
-				}
-				// Reload server to pick up the new token
-				if err := p.reloadFn(ctx, p.name); err != nil {
-					log.Logf("! Failed to reload %s after token refresh: %v", p.name, err)
-				}
-			}()
+			shouldTriggerRefresh = true
 
 		} else {
-			// Token still valid
+			if status.ExpiresAt.IsZero() {
+				// No expiry information available — can't schedule proactive refresh.
+				// Fall back to SSE events (Desktop mode) for refresh notification.
+				log.Logf("- No token expiry info for %s, stopping provider loop (SSE events will handle refresh)", p.name)
+				return
+			}
 			timeUntilExpiry := time.Until(status.ExpiresAt)
 			waitDuration = max(0, timeUntilExpiry-10*time.Second)
 			log.Logf("- Token valid for %s, next check in %v", p.name, waitDuration.Round(time.Second))
+			shouldTriggerRefresh = false
 		}
 
-		// Wait until next check, interruptible by stop signal
+		// Trigger refresh if needed
+		if shouldTriggerRefresh {
+			if IsCEMode() {
+				// CE mode: Refresh token directly
+				go func() {
+					if err := p.refreshTokenCE(); err != nil {
+						log.Logf("! Token refresh failed for %s: %v", p.name, err)
+					}
+				}()
+			} else {
+				// Desktop mode: Trigger refresh via Desktop API
+				go func() {
+					authClient := desktop.NewAuthClient()
+					app, err := authClient.GetOAuthApp(context.Background(), p.name)
+					if err != nil {
+						log.Logf("! GetOAuthApp failed for %s: %v", p.name, err)
+						return
+					}
+					if !app.Authorized {
+						log.Logf("! GetOAuthApp returned Authorized=false for %s", p.name)
+						return
+					}
+				}()
+			}
+		}
+
+		// Wait pattern - interruptible by login events
 		if waitDuration > 0 {
 			timer := time.NewTimer(waitDuration)
 			select {
 			case <-timer.C:
-				// Wait complete, continue to next iteration
+				// Wait complete
+			case event := <-p.eventChan:
+				timer.Stop()
+				log.Logf("- Provider %s received event: %s", p.name, event.Type)
+				if err := p.reloadFn(ctx, p.name); err != nil {
+					log.Logf("- Failed to reload %s after %s: %v", p.name, event.Type, err)
+				}
+				if event.Type == EventLoginSuccess {
+					p.refreshRetryCount = 0
+					p.lastRefreshExpiry = time.Time{}
+				}
 			case <-p.stopChan:
 				timer.Stop()
 				return
@@ -170,6 +207,11 @@ func (p *Provider) Stop() {
 	p.stopOnce.Do(func() {
 		close(p.stopChan)
 	})
+}
+
+// SendEvent sends an SSE event to this provider's event channel
+func (p *Provider) SendEvent(event Event) {
+	p.eventChan <- event
 }
 
 // refreshTokenCE refreshes an OAuth token in CE mode


### PR DESCRIPTION
**What I did**
- Cherrypick: https://github.com/docker/mcp-gateway/pull/402 to `main`

**Related issue**
- See: #402

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**