### PR TITLE
Fix opencode profile association

### DIFF
--- a/pkg/client/config.yml
+++ b/pkg/client/config.yml
@@ -204,7 +204,7 @@ system:
       windows:
         - $USERPROFILE\.config\opencode\opencode.json
     yq:
-      list: '.mcp | to_entries | map({"name": .key, "command": .value.command[0], "args": (.value.command[1:] // []), "type": "stdio"})'
+      list: '.mcp | to_entries | map({"name": .key, "command": .value.command[0], "args": ((.value.command | .[1:]) // []), "type": "stdio"})'
       set: |
         .mcp[$NAME] = {
           "type": "local",

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -136,6 +136,22 @@ func Test_yq_list(t *testing.T) {
 				HTTPServers: []MCPServerHTTP{},
 			},
 		},
+		{
+			name:    "OpenCode",
+			cfg:     config.System["opencode"],
+			content: "list/opencode.json",
+			result: &MCPJSONLists{
+				STDIOServers: []MCPServerSTDIO{
+					{
+						Name:    "MCP_DOCKER",
+						Command: "docker",
+						Args:    []string{"mcp", "gateway", "run", "--profile", "test"},
+					},
+				},
+				SSEServers:  []MCPServerSSE{},
+				HTTPServers: []MCPServerHTTP{},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/client/testdata/list/opencode.json
+++ b/pkg/client/testdata/list/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "MCP_DOCKER": {
+      "type": "local",
+      "command": ["docker", "mcp", "gateway", "run", "--profile", "test"],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
**What I did**

There was a bug in the opencode config yaml that caused the args in the config to be parsed as `local command` instead of `mcp gateway run --profile <profile>`.  This was due to a yq parsing quirk where `.value.command[1:]` slices on the `.value` instead of the `.command`. This fixes that.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**