### PR TITLE
Unhide oauth command in CLI help output

### DIFF
--- a/cmd/docker-mcp/commands/oauth.go
+++ b/cmd/docker-mcp/commands/oauth.go
@@ -8,8 +8,8 @@ import (
 
 func oauthCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "oauth",
-		Hidden: true,
+		Use:   "oauth",
+		Short: "Manage OAuth app authorizations",
 	}
 	cmd.AddCommand(lsOauthCommand())
 	cmd.AddCommand(authorizeOauthCommand())

--- a/docs/generator/reference/docker_mcp.yaml
+++ b/docs/generator/reference/docker_mcp.yaml
@@ -14,6 +14,7 @@ cname:
     - docker mcp config
     - docker mcp feature
     - docker mcp gateway
+    - docker mcp oauth
     - docker mcp secret
     - docker mcp server
     - docker mcp tools
@@ -24,6 +25,7 @@ clink:
     - docker_mcp_config.yaml
     - docker_mcp_feature.yaml
     - docker_mcp_gateway.yaml
+    - docker_mcp_oauth.yaml
     - docker_mcp_secret.yaml
     - docker_mcp_server.yaml
     - docker_mcp_tools.yaml

--- a/docs/generator/reference/docker_mcp_oauth.yaml
+++ b/docs/generator/reference/docker_mcp_oauth.yaml
@@ -1,4 +1,6 @@
 command: docker mcp oauth
+short: Manage OAuth app authorizations
+long: Manage OAuth app authorizations
 pname: docker mcp
 plink: docker_mcp.yaml
 cname:
@@ -10,7 +12,7 @@ clink:
     - docker_mcp_oauth_ls.yaml
     - docker_mcp_oauth_revoke.yaml
 deprecated: false
-hidden: true
+hidden: false
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/docs/generator/reference/docker_mcp_oauth_authorize.yaml
+++ b/docs/generator/reference/docker_mcp_oauth_authorize.yaml
@@ -25,7 +25,7 @@ options:
       kubernetes: false
       swarm: false
 deprecated: false
-hidden: true
+hidden: false
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/docs/generator/reference/docker_mcp_oauth_ls.yaml
+++ b/docs/generator/reference/docker_mcp_oauth_ls.yaml
@@ -16,7 +16,7 @@ options:
       kubernetes: false
       swarm: false
 deprecated: false
-hidden: true
+hidden: false
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/docs/generator/reference/docker_mcp_oauth_revoke.yaml
+++ b/docs/generator/reference/docker_mcp_oauth_revoke.yaml
@@ -5,7 +5,7 @@ usage: docker mcp oauth revoke <app>
 pname: docker mcp oauth
 plink: docker_mcp_oauth.yaml
 deprecated: false
-hidden: true
+hidden: false
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/docs/generator/reference/mcp.md
+++ b/docs/generator/reference/mcp.md
@@ -12,6 +12,7 @@ Manage MCP servers and clients
 | [`config`](mcp_config.md)   | Manage the configuration                |
 | [`feature`](mcp_feature.md) | Manage experimental features            |
 | [`gateway`](mcp_gateway.md) | Manage the MCP Server gateway           |
+| [`oauth`](mcp_oauth.md)     | Manage OAuth app authorizations         |
 | [`secret`](mcp_secret.md)   | Manage secrets in the local OS Keychain |
 | [`server`](mcp_server.md)   | Manage servers                          |
 | [`tools`](mcp_tools.md)     | Manage tools                            |

--- a/docs/generator/reference/mcp_oauth.md
+++ b/docs/generator/reference/mcp_oauth.md
@@ -1,0 +1,17 @@
+# docker mcp oauth
+
+<!---MARKER_GEN_START-->
+Manage OAuth app authorizations
+
+### Subcommands
+
+| Name                                  | Description                        |
+|:--------------------------------------|:-----------------------------------|
+| [`authorize`](mcp_oauth_authorize.md) | Authorize the specified OAuth app. |
+| [`ls`](mcp_oauth_ls.md)               | List available OAuth apps.         |
+| [`revoke`](mcp_oauth_revoke.md)       | Revoke the specified OAuth app.    |
+
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/generator/reference/mcp_oauth_authorize.md
+++ b/docs/generator/reference/mcp_oauth_authorize.md
@@ -1,0 +1,15 @@
+# docker mcp oauth authorize
+
+<!---MARKER_GEN_START-->
+Authorize the specified OAuth app.
+
+### Options
+
+| Name             | Type     | Default | Description                                                     |
+|:-----------------|:---------|:--------|:----------------------------------------------------------------|
+| `--open-browser` | `bool`   |         | Open the authorization URL in the default browser automatically |
+| `--scopes`       | `string` |         | OAuth scopes to request (space-separated)                       |
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/generator/reference/mcp_oauth_ls.md
+++ b/docs/generator/reference/mcp_oauth_ls.md
@@ -1,0 +1,14 @@
+# docker mcp oauth ls
+
+<!---MARKER_GEN_START-->
+List available OAuth apps.
+
+### Options
+
+| Name     | Type   | Default | Description    |
+|:---------|:-------|:--------|:---------------|
+| `--json` | `bool` |         | Print as JSON. |
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/generator/reference/mcp_oauth_revoke.md
+++ b/docs/generator/reference/mcp_oauth_revoke.md
@@ -1,0 +1,8 @@
+# docker mcp oauth revoke
+
+<!---MARKER_GEN_START-->
+Revoke the specified OAuth app.
+
+
+<!---MARKER_GEN_END-->
+


### PR DESCRIPTION
## Summary
- The `oauth` command tree (`ls`, `authorize`, `revoke`) was marked `Hidden: true` when first extracted in 458522a2 and never promoted to visible as the feature matured
- Removes `Hidden: true` and adds a `Short` description so `oauth` appears alongside the other top-level commands in `docker mcp --help`
- Reference docs are 100% generated via `make docs` — regenerated to reflect the change

## Test plan
- [x] Run `docker mcp --help` and verify `oauth` appears in the available commands list

```
❯ docker mcp
Docker MCP Toolkit's CLI - Manage your MCP servers and clients.

Usage: docker mcp [OPTIONS]

Flags:
  -v, --version   Print version information and quit

Available Commands:
  catalog     Manage MCP server catalogs
  client      Manage MCP clients
  config      Manage the configuration
  feature     Manage experimental features
  gateway     Manage the MCP Server gateway
  oauth       Manage OAuth app authorizations
  secret      Manage secrets in the local OS Keychain
  server      Manage servers
  tools       Manage tools
  version     Show the version information
```

- [x] Run `docker mcp oauth --help` and verify subcommands (`ls`, `authorize`, `revoke`) are listed

```
❯ docker mcp oauth --help
Docker MCP Toolkit's CLI - Manage your MCP servers and clients.

Usage: docker mcp oauth

Available Commands:
  authorize   Authorize the specified OAuth app.
  ls          List available OAuth apps.
  revoke      Revoke the specified OAuth app.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)