### PR TITLE
Add npm/npx server support to MCP catalog 

### DIFF
--- a/cmd/docker-mcp/commands/catalog_next.go
+++ b/cmd/docker-mcp/commands/catalog_next.go
@@ -42,6 +42,7 @@ func createCatalogNextCommand() *cobra.Command {
 		Servers               []string
 		Exclude               []string
 		IncludePyPI           bool
+		IncludeNPM            bool
 	}
 
 	cmd := &cobra.Command{
@@ -92,6 +93,10 @@ When using --server without --from-profile, --from-legacy-catalog, or --from-com
 				return fmt.Errorf("--include-pypi can only be used when creating a catalog from a community registry")
 			}
 
+			if opts.IncludeNPM && opts.FromCommunityRegistry == "" {
+				return fmt.Errorf("--include-npm can only be used when creating a catalog from a community registry")
+			}
+
 			if len(opts.Exclude) > 0 && opts.FromCommunityRegistry == "" {
 				return fmt.Errorf("--exclude can only be used when creating a catalog from a community registry")
 			}
@@ -102,7 +107,16 @@ When using --server without --from-profile, --from-legacy-catalog, or --from-com
 			}
 			registryClient := registryapi.NewClient()
 			ociService := oci.NewService()
-			return catalognext.Create(cmd.Context(), dao, registryClient, ociService, args[0], opts.Servers, opts.FromWorkingSet, opts.FromLegacyCatalog, opts.FromCommunityRegistry, opts.Title, opts.IncludePyPI, opts.Exclude)
+			return catalognext.Create(cmd.Context(), dao, registryClient, ociService, args[0], catalognext.CreateOptions{
+				Servers:              opts.Servers,
+				WorkingSetID:         opts.FromWorkingSet,
+				LegacyCatalogURL:     opts.FromLegacyCatalog,
+				CommunityRegistryRef: opts.FromCommunityRegistry,
+				Title:                opts.Title,
+				IncludePyPI:          opts.IncludePyPI,
+				IncludeNPM:           opts.IncludeNPM,
+				ExcludeServers:       opts.Exclude,
+			})
 		},
 	}
 
@@ -116,6 +130,8 @@ When using --server without --from-profile, --from-legacy-catalog, or --from-com
 	flags.StringArrayVar(&opts.Exclude, "exclude", []string{}, "Server name to exclude from the catalog (can be specified multiple times, only valid with --from-community-registry)")
 	flags.BoolVar(&opts.IncludePyPI, "include-pypi", false, "Include PyPI servers when creating a catalog from a community registry")
 	cmd.Flags().MarkHidden("include-pypi") //nolint:errcheck
+	flags.BoolVar(&opts.IncludeNPM, "include-npm", false, "Include npm servers when creating a catalog from a community registry")
+	cmd.Flags().MarkHidden("include-npm") //nolint:errcheck
 
 	return cmd
 }

--- a/pkg/catalog/npm.go
+++ b/pkg/catalog/npm.go
@@ -33,19 +33,21 @@ type npmPackageInfo struct {
 	} `json:"engines"`
 }
 
-// NewNPMVersionResolver creates a resolver that queries the npm registry API.
-func NewNPMVersionResolver(httpClient *http.Client) NPMVersionResolver {
+const defaultNPMRegistryURL = "https://registry.npmjs.org"
+
+// NewNPMVersionResolver creates a resolver that queries the given npm registry URL.
+func NewNPMVersionResolver(httpClient *http.Client, npmRegistryURL string) NPMVersionResolver {
 	return func(ctx context.Context, identifier, version, registryBaseURL string) (string, bool) {
 		// Only query npm for standard npm registry
-		if registryBaseURL != "" && registryBaseURL != "https://registry.npmjs.org" {
+		if registryBaseURL != "" && registryBaseURL != npmRegistryURL {
 			return "", true // assume found for non-standard registries
 		}
 
 		var url string
 		if version != "" {
-			url = fmt.Sprintf("https://registry.npmjs.org/%s/%s", identifier, version)
+			url = fmt.Sprintf("%s/%s/%s", npmRegistryURL, identifier, version)
 		} else {
-			url = fmt.Sprintf("https://registry.npmjs.org/%s/latest", identifier)
+			url = fmt.Sprintf("%s/%s/latest", npmRegistryURL, identifier)
 		}
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -78,7 +80,7 @@ func DefaultNPMVersionResolver() NPMVersionResolver {
 		Transport: desktop.ProxyTransport(),
 		Timeout:   10 * time.Second,
 	}
-	return NewNPMVersionResolver(client)
+	return NewNPMVersionResolver(client, defaultNPMRegistryURL)
 }
 
 // parseNodeVersion extracts the Node.js major version from a semver constraint.

--- a/pkg/catalog/npm.go
+++ b/pkg/catalog/npm.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	defaultNodeVersion = "22"
+	defaultNodeVersion = "24"
 	nodeBaseImage      = "node"
 )
 
 var (
-	nodeVersionRe     = regexp.MustCompile(`(?:>=|>|\^|~)\s*(\d+)`)
-	bareNodeVersionRe = regexp.MustCompile(`^\s*(\d+)\s*$`)
+	nodePinVersionRe    = regexp.MustCompile(`(?:\^|~)\s*(\d+)`)
+	nodeLowerBoundRe    = regexp.MustCompile(`(?:>=|>)\s*\d+`)
+	bareNodeVersionRe   = regexp.MustCompile(`^\s*(\d+)\s*$`)
 )
 
 // NPMVersionResolver resolves the minimum Node.js version for an npm package.
@@ -80,18 +81,25 @@ func DefaultNPMVersionResolver() NPMVersionResolver {
 	return NewNPMVersionResolver(client)
 }
 
-// parseNodeVersion extracts the minimum major Node.js version from a semver constraint.
-// It looks for the first >=, >, ^, or ~ operator and returns the major version number.
+// parseNodeVersion extracts the Node.js major version from a semver constraint.
+// Pinning operators (^ or ~) resolve to a specific major version.
+// >= and > mean "this or newer", so we use the latest (default).
 // A bare major version (e.g., "18") is also accepted.
-// Examples: ">=18" -> "18", "^20.0.0" -> "20", ">=16.17.0" -> "16", "18" -> "18", "" -> "" (use default)
+// Examples: "^20.0.0" -> "20", "~18" -> "18", ">=18" -> "" (use latest), ">16" -> "" (use latest),
+// "18" -> "18", "" -> "" (use default)
 func parseNodeVersion(enginesNode string) string {
 	if enginesNode == "" {
 		return ""
 	}
 
-	match := nodeVersionRe.FindStringSubmatch(enginesNode)
-	if match != nil {
+	// Check for pinning constraints (^ or ~) first - these specify a major version
+	if match := nodePinVersionRe.FindStringSubmatch(enginesNode); match != nil {
 		return match[1]
+	}
+
+	// >= and > mean "this or newer", so use the latest (default)
+	if nodeLowerBoundRe.MatchString(enginesNode) {
+		return ""
 	}
 
 	// Fall back to bare major version (e.g., "18")

--- a/pkg/catalog/npm.go
+++ b/pkg/catalog/npm.go
@@ -1,0 +1,112 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+)
+
+const (
+	defaultNodeVersion = "22"
+	nodeBaseImage      = "node"
+)
+
+var (
+	nodeVersionRe     = regexp.MustCompile(`(?:>=|>|\^|~)\s*(\d+)`)
+	bareNodeVersionRe = regexp.MustCompile(`^\s*(\d+)\s*$`)
+)
+
+// NPMVersionResolver resolves the minimum Node.js version for an npm package.
+// It returns the minimum Node.js major version string (e.g., "18") or empty string if unknown,
+// and a boolean indicating whether the package was found.
+type NPMVersionResolver func(ctx context.Context, identifier, version, registryBaseURL string) (string, bool)
+
+type npmPackageInfo struct {
+	Engines struct {
+		Node string `json:"node"`
+	} `json:"engines"`
+}
+
+// NewNPMVersionResolver creates a resolver that queries the npm registry API.
+func NewNPMVersionResolver(httpClient *http.Client) NPMVersionResolver {
+	return func(ctx context.Context, identifier, version, registryBaseURL string) (string, bool) {
+		// Only query npm for standard npm registry
+		if registryBaseURL != "" && registryBaseURL != "https://registry.npmjs.org" {
+			return "", true // assume found for non-standard registries
+		}
+
+		var url string
+		if version != "" {
+			url = fmt.Sprintf("https://registry.npmjs.org/%s/%s", identifier, version)
+		} else {
+			url = fmt.Sprintf("https://registry.npmjs.org/%s/latest", identifier)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return "", false
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return "", false
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return "", false
+		}
+
+		var info npmPackageInfo
+		if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+			return "", false
+		}
+
+		return parseNodeVersion(info.Engines.Node), true
+	}
+}
+
+// DefaultNPMVersionResolver creates a resolver using the default HTTP client with proxy transport.
+func DefaultNPMVersionResolver() NPMVersionResolver {
+	client := &http.Client{
+		Transport: desktop.ProxyTransport(),
+		Timeout:   10 * time.Second,
+	}
+	return NewNPMVersionResolver(client)
+}
+
+// parseNodeVersion extracts the minimum major Node.js version from a semver constraint.
+// It looks for the first >=, >, ^, or ~ operator and returns the major version number.
+// A bare major version (e.g., "18") is also accepted.
+// Examples: ">=18" -> "18", "^20.0.0" -> "20", ">=16.17.0" -> "16", "18" -> "18", "" -> "" (use default)
+func parseNodeVersion(enginesNode string) string {
+	if enginesNode == "" {
+		return ""
+	}
+
+	match := nodeVersionRe.FindStringSubmatch(enginesNode)
+	if match != nil {
+		return match[1]
+	}
+
+	// Fall back to bare major version (e.g., "18")
+	if bare := bareNodeVersionRe.FindStringSubmatch(enginesNode); bare != nil {
+		return bare[1]
+	}
+
+	return ""
+}
+
+// nodeVersionToImageTag maps a Node.js major version to the appropriate Docker image tag.
+func nodeVersionToImageTag(nodeVersion string) string {
+	if nodeVersion == "" {
+		nodeVersion = defaultNodeVersion
+	}
+
+	return fmt.Sprintf("%s:%s-bookworm-slim", nodeBaseImage, nodeVersion)
+}

--- a/pkg/catalog/npm.go
+++ b/pkg/catalog/npm.go
@@ -17,9 +17,9 @@ const (
 )
 
 var (
-	nodePinVersionRe    = regexp.MustCompile(`(?:\^|~)\s*(\d+)`)
-	nodeLowerBoundRe    = regexp.MustCompile(`(?:>=|>)\s*\d+`)
-	bareNodeVersionRe   = regexp.MustCompile(`^\s*(\d+)\s*$`)
+	nodePinVersionRe  = regexp.MustCompile(`(?:\^|~)\s*(\d+)`)
+	nodeLowerBoundRe  = regexp.MustCompile(`(?:>=|>)\s*\d+`)
+	bareNodeVersionRe = regexp.MustCompile(`^\s*(\d+)\s*$`)
 )
 
 // NPMVersionResolver resolves the minimum Node.js version for an npm package.

--- a/pkg/catalog/npm_integration_test.go
+++ b/pkg/catalog/npm_integration_test.go
@@ -2,62 +2,56 @@ package catalog
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net"
 	"net/http"
-	"net/url"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
-	"time"
 )
 
-// TestIntegrationNPMTransformBatch fetches real npm-only servers from the MCP community
-// registry and validates that TransformToDocker produces correct output for each one.
-// This test exercises the full npm transformation pipeline against live registry data.
+// registryListResponse matches the community registry list endpoint response.
+type registryListResponse struct {
+	Servers  []serverResponseJSON `json:"servers"`
+	Metadata struct {
+		NextCursor string `json:"nextCursor"`
+		Count      int    `json:"count"`
+	} `json:"metadata"`
+}
+
+type serverResponseJSON struct {
+	Server ServerDetail `json:"server"`
+}
+
+// TestNPMTransformBatch loads npm servers from testdata and validates that
+// TransformToDocker produces correct output for each one.
 //
-// Run with: go test -count=1 ./pkg/catalog/... -run TestIntegrationNPMTransformBatch -v -timeout 5m
-func TestIntegrationNPMTransformBatch(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	// Use an explicit transport that bypasses any system/Desktop proxy settings,
-	// since the Go default transport may pick up macOS proxy configuration.
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig:     &tls.Config{},
-			DialContext:         (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
-			TLSHandshakeTimeout: 10 * time.Second,
-		},
-	}
-
-	// Fetch npm-only servers from the community registry (direct HTTP, no Desktop proxy).
-	// Paginates up to maxPages to collect a broad sample. The registry has ~16K servers
-	// total with ~49% being npm, so 50 pages of 100 covers a good sample.
-	servers, pagesRead, err := fetchNPMOnlyServers(ctx, client, 500, 30)
+// Run with: go test -count=1 ./pkg/catalog/... -run TestNPMTransformBatch -v
+func TestNPMTransformBatch(t *testing.T) {
+	data, err := os.ReadFile("testdata/npm_registry_servers.json")
 	if err != nil {
-		// Network errors during pagination are not fatal - test what we got
-		t.Logf("Warning: registry fetch stopped early after %d pages: %v", pagesRead, err)
+		t.Fatalf("reading testdata: %v", err)
 	}
 
+	var listResp registryListResponse
+	if err := json.Unmarshal(data, &listResp); err != nil {
+		t.Fatalf("parsing testdata: %v", err)
+	}
+
+	servers := listResp.Servers
 	if len(servers) == 0 {
-		t.Fatal("No npm-only servers found in registry - cannot validate npm support")
+		t.Fatal("No servers found in testdata")
 	}
 
-	t.Logf("Fetched %d npm-only stdio servers across %d pages of registry results", len(servers), pagesRead)
+	t.Logf("Loaded %d npm servers from testdata", len(servers))
 
 	// Mock resolver returns empty string so we use default node version.
-	// This avoids hammering the npm registry during batch testing.
 	mockResolver := func(_ context.Context, _, _, _ string) (string, bool) {
 		return "", true
 	}
+
+	ctx := t.Context()
 
 	var (
 		passed  int
@@ -156,10 +150,10 @@ func TestIntegrationNPMTransformBatch(t *testing.T) {
 	}
 
 	t.Logf("\n=== NPM Transform Batch Results ===")
-	t.Logf("Total servers fetched: %d", len(servers))
-	t.Logf("Passed:                %d", passed)
-	t.Logf("Failed:                %d", failed)
-	t.Logf("Skipped (remote/err):  %d", skipped)
+	t.Logf("Total servers loaded: %d", len(servers))
+	t.Logf("Passed:               %d", passed)
+	t.Logf("Failed:               %d", failed)
+	t.Logf("Skipped (remote/err): %d", skipped)
 
 	if failed > 0 {
 		t.Errorf("%d servers failed transformation validation", failed)
@@ -168,40 +162,82 @@ func TestIntegrationNPMTransformBatch(t *testing.T) {
 	if passed == 0 {
 		t.Error("No servers passed npm transformation - something is wrong")
 	}
-
-	successRate := float64(passed) / float64(passed+failed) * 100
-	t.Logf("Success rate:          %.1f%% (%d/%d of transformable servers)", successRate, passed, passed+failed)
 }
 
-// TestIntegrationNPMVersionResolver tests the real npm registry version resolver
-// against a set of known npm MCP packages.
+// TestNPMVersionResolver tests the npm registry version resolver using a local
+// httptest server that serves responses from testdata files.
 //
-// Run with: go test -count=1 ./pkg/catalog/... -run TestIntegrationNPMVersionResolver -v
-func TestIntegrationNPMVersionResolver(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
+// Run with: go test -count=1 ./pkg/catalog/... -run TestNPMVersionResolver -v
+func TestNPMVersionResolver(t *testing.T) {
+	// Map of npm registry URL paths to testdata files
+	packageFiles := map[string]string{
+		"/@anthropic-ai/claude-code/latest": "testdata/npm_package_claude_code.json",
+		"/@agenttrust/mcp-server/1.1.1":    "testdata/npm_package_agenttrust.json",
+		"/@contextlayer/mcp/0.0.3":          "testdata/npm_package_contextlayer.json",
 	}
 
-	resolverClient := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig:     &tls.Config{},
-			DialContext:         (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
-			TLSHandshakeTimeout: 10 * time.Second,
-		},
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		file, ok := packageFiles[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		data, err := os.ReadFile(file)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	// Create a resolver that points to our test server instead of the real npm registry.
+	// We construct the resolver manually rather than using NewNPMVersionResolver because
+	// the standard resolver hardcodes the npm registry URL.
+	resolver := func(ctx context.Context, identifier, version, _ string) (string, bool) {
+		var url string
+		if version != "" {
+			url = fmt.Sprintf("%s/%s/%s", srv.URL, identifier, version)
+		} else {
+			url = fmt.Sprintf("%s/%s/latest", srv.URL, identifier)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return "", false
+		}
+
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			return "", false
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return "", false
+		}
+
+		var info npmPackageInfo
+		if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+			return "", false
+		}
+
+		return parseNodeVersion(info.Engines.Node), true
 	}
-	resolver := NewNPMVersionResolver(resolverClient)
-	ctx := context.Background()
+
+	ctx := t.Context()
 
 	tests := []struct {
-		identifier string
-		version    string
-		wantFound  bool
+		identifier  string
+		version     string
+		wantFound   bool
+		wantVersion string
 	}{
-		{"@anthropic-ai/claude-code", "", true},
-		{"@agenttrust/mcp-server", "1.1.1", true},
-		{"@contextlayer/mcp", "0.0.3", true},
-		{"@nonexistent-scope/definitely-not-a-real-package", "99.99.99", false},
+		{"@anthropic-ai/claude-code", "", true, ""},
+		{"@agenttrust/mcp-server", "1.1.1", true, ""},
+		{"@contextlayer/mcp", "0.0.3", true, ""},
+		{"@nonexistent-scope/definitely-not-a-real-package", "99.99.99", false, ""},
 	}
 
 	for _, tt := range tests {
@@ -211,101 +247,12 @@ func TestIntegrationNPMVersionResolver(t *testing.T) {
 			if found != tt.wantFound {
 				t.Errorf("found=%v, want %v", found, tt.wantFound)
 			}
+			if found && nodeVer != tt.wantVersion {
+				t.Errorf("nodeVer=%q, want %q", nodeVer, tt.wantVersion)
+			}
 			if found {
 				t.Logf("%s: engines.node resolved to %q (will use image %s)", name, nodeVer, nodeVersionToImageTag(nodeVer))
 			}
 		})
 	}
-}
-
-// registryListResponse matches the community registry list endpoint response.
-type registryListResponse struct {
-	Servers  []serverResponseJSON `json:"servers"`
-	Metadata struct {
-		NextCursor string `json:"nextCursor"`
-		Count      int    `json:"count"`
-	} `json:"metadata"`
-}
-
-type serverResponseJSON struct {
-	Server ServerDetail `json:"server"`
-}
-
-// fetchNPMOnlyServers fetches npm-only servers from the MCP community registry.
-// It paginates through the registry collecting servers that have only npm packages
-// with stdio transport. Stops after maxServers are collected or maxPages are read.
-// Returns partial results with a non-nil error if a page fetch fails.
-func fetchNPMOnlyServers(ctx context.Context, client *http.Client, maxServers int, maxPages int) ([]serverResponseJSON, int, error) {
-	var npmServers []serverResponseJSON
-	cursor := ""
-	baseURL := "https://registry.modelcontextprotocol.io/v0/servers?version=latest&limit=100"
-	pagesRead := 0
-
-	for len(npmServers) < maxServers && pagesRead < maxPages {
-		reqURL := baseURL
-		if cursor != "" {
-			reqURL += "&cursor=" + url.QueryEscape(cursor)
-		}
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-		if err != nil {
-			return npmServers, pagesRead, fmt.Errorf("creating request: %w", err)
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			// Return what we have so far on network error
-			return npmServers, pagesRead, fmt.Errorf("fetching page %d: %w", pagesRead+1, err)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return npmServers, pagesRead, fmt.Errorf("reading page %d: %w", pagesRead+1, err)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return npmServers, pagesRead, fmt.Errorf("page %d returned %d: %s", pagesRead+1, resp.StatusCode, string(body[:min(200, len(body))]))
-		}
-
-		var listResp registryListResponse
-		if err := json.Unmarshal(body, &listResp); err != nil {
-			return npmServers, pagesRead, fmt.Errorf("parsing page %d: %w", pagesRead+1, err)
-		}
-
-		pagesRead++
-
-		for _, s := range listResp.Servers {
-			pkgs := s.Server.Packages
-			hasNPMStdio := false
-			hasOCI := false
-			hasPyPI := false
-			for _, p := range pkgs {
-				switch p.RegistryType {
-				case "oci":
-					hasOCI = true
-				case "pypi":
-					hasPyPI = true
-				case "npm":
-					if p.Transport.Type == "stdio" {
-						hasNPMStdio = true
-					}
-				}
-			}
-			if hasNPMStdio && !hasOCI && !hasPyPI {
-				npmServers = append(npmServers, s)
-			}
-		}
-
-		if listResp.Metadata.NextCursor == "" || len(listResp.Servers) == 0 {
-			break
-		}
-		cursor = listResp.Metadata.NextCursor
-	}
-
-	if len(npmServers) > maxServers {
-		npmServers = npmServers[:maxServers]
-	}
-
-	return npmServers, pagesRead, nil
 }

--- a/pkg/catalog/npm_integration_test.go
+++ b/pkg/catalog/npm_integration_test.go
@@ -1,0 +1,311 @@
+package catalog
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIntegrationNPMTransformBatch fetches real npm-only servers from the MCP community
+// registry and validates that TransformToDocker produces correct output for each one.
+// This test exercises the full npm transformation pipeline against live registry data.
+//
+// Run with: go test -count=1 ./pkg/catalog/... -run TestIntegrationNPMTransformBatch -v -timeout 5m
+func TestIntegrationNPMTransformBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Use an explicit transport that bypasses any system/Desktop proxy settings,
+	// since the Go default transport may pick up macOS proxy configuration.
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig:     &tls.Config{},
+			DialContext:         (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+
+	// Fetch npm-only servers from the community registry (direct HTTP, no Desktop proxy).
+	// Paginates up to maxPages to collect a broad sample. The registry has ~16K servers
+	// total with ~49% being npm, so 50 pages of 100 covers a good sample.
+	servers, pagesRead, err := fetchNPMOnlyServers(ctx, client, 500, 30)
+	if err != nil {
+		// Network errors during pagination are not fatal - test what we got
+		t.Logf("Warning: registry fetch stopped early after %d pages: %v", pagesRead, err)
+	}
+
+	if len(servers) == 0 {
+		t.Fatal("No npm-only servers found in registry - cannot validate npm support")
+	}
+
+	t.Logf("Fetched %d npm-only stdio servers across %d pages of registry results", len(servers), pagesRead)
+
+	// Mock resolver returns empty string so we use default node version.
+	// This avoids hammering the npm registry during batch testing.
+	mockResolver := func(_ context.Context, _, _, _ string) (string, bool) {
+		return "", true
+	}
+
+	var (
+		passed  int
+		failed  int
+		skipped int
+	)
+
+	for _, s := range servers {
+		name := s.Server.Name
+		t.Run(name, func(t *testing.T) {
+			result, source, err := TransformToDocker(ctx, s.Server,
+				WithNPMResolver(mockResolver),
+			)
+			if err != nil {
+				t.Logf("SKIP %s: transform error: %v", name, err)
+				skipped++
+				return
+			}
+
+			if source != TransformSourceNPM {
+				// Server has a remote transport that took precedence
+				t.Logf("SKIP %s: resolved as %s (not npm)", name, source)
+				skipped++
+				return
+			}
+
+			// Validate image
+			if !strings.HasPrefix(result.Image, "node:") {
+				t.Errorf("%s: expected image starting with 'node:', got '%s'", name, result.Image)
+				failed++
+				return
+			}
+			if !strings.HasSuffix(result.Image, "-bookworm-slim") {
+				t.Errorf("%s: expected image ending with '-bookworm-slim', got '%s'", name, result.Image)
+				failed++
+				return
+			}
+
+			// Validate command starts with npx --yes
+			if len(result.Command) < 3 {
+				t.Errorf("%s: expected command length >= 3, got %d: %v", name, len(result.Command), result.Command)
+				failed++
+				return
+			}
+			if result.Command[0] != "npx" {
+				t.Errorf("%s: expected command[0] 'npx', got '%s'", name, result.Command[0])
+				failed++
+				return
+			}
+			if result.Command[1] != "--yes" {
+				t.Errorf("%s: expected command[1] '--yes', got '%s'", name, result.Command[1])
+				failed++
+				return
+			}
+
+			// Validate type and longLived
+			if result.Type != "server" {
+				t.Errorf("%s: expected type 'server', got '%s'", name, result.Type)
+				failed++
+				return
+			}
+			if !result.LongLived {
+				t.Errorf("%s: expected longLived=true", name)
+				failed++
+				return
+			}
+
+			// Validate volumes contain npm cache
+			if len(result.Volumes) == 0 {
+				t.Errorf("%s: expected at least one volume for npm cache", name)
+				failed++
+				return
+			}
+			hasNPMCache := false
+			for _, v := range result.Volumes {
+				if strings.Contains(v, ":/root/.npm") && strings.HasPrefix(v, "docker-mcp-npm-cache-") {
+					hasNPMCache = true
+					break
+				}
+			}
+			if !hasNPMCache {
+				t.Errorf("%s: expected npm cache volume, got %v", name, result.Volumes)
+				failed++
+				return
+			}
+
+			// Validate metadata has registry URL
+			if result.Metadata == nil || result.Metadata.RegistryURL == "" {
+				t.Errorf("%s: expected metadata.registryUrl to be set", name)
+				failed++
+				return
+			}
+
+			passed++
+		})
+	}
+
+	t.Logf("\n=== NPM Transform Batch Results ===")
+	t.Logf("Total servers fetched: %d", len(servers))
+	t.Logf("Passed:                %d", passed)
+	t.Logf("Failed:                %d", failed)
+	t.Logf("Skipped (remote/err):  %d", skipped)
+
+	if failed > 0 {
+		t.Errorf("%d servers failed transformation validation", failed)
+	}
+
+	if passed == 0 {
+		t.Error("No servers passed npm transformation - something is wrong")
+	}
+
+	successRate := float64(passed) / float64(passed+failed) * 100
+	t.Logf("Success rate:          %.1f%% (%d/%d of transformable servers)", successRate, passed, passed+failed)
+}
+
+// TestIntegrationNPMVersionResolver tests the real npm registry version resolver
+// against a set of known npm MCP packages.
+//
+// Run with: go test -count=1 ./pkg/catalog/... -run TestIntegrationNPMVersionResolver -v
+func TestIntegrationNPMVersionResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	resolverClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig:     &tls.Config{},
+			DialContext:         (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+	resolver := NewNPMVersionResolver(resolverClient)
+	ctx := context.Background()
+
+	tests := []struct {
+		identifier string
+		version    string
+		wantFound  bool
+	}{
+		{"@anthropic-ai/claude-code", "", true},
+		{"@agenttrust/mcp-server", "1.1.1", true},
+		{"@contextlayer/mcp", "0.0.3", true},
+		{"@nonexistent-scope/definitely-not-a-real-package", "99.99.99", false},
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("%s@%s", tt.identifier, tt.version)
+		t.Run(name, func(t *testing.T) {
+			nodeVer, found := resolver(ctx, tt.identifier, tt.version, "")
+			if found != tt.wantFound {
+				t.Errorf("found=%v, want %v", found, tt.wantFound)
+			}
+			if found {
+				t.Logf("%s: engines.node resolved to %q (will use image %s)", name, nodeVer, nodeVersionToImageTag(nodeVer))
+			}
+		})
+	}
+}
+
+// registryListResponse matches the community registry list endpoint response.
+type registryListResponse struct {
+	Servers  []serverResponseJSON `json:"servers"`
+	Metadata struct {
+		NextCursor string `json:"nextCursor"`
+		Count      int    `json:"count"`
+	} `json:"metadata"`
+}
+
+type serverResponseJSON struct {
+	Server ServerDetail `json:"server"`
+}
+
+// fetchNPMOnlyServers fetches npm-only servers from the MCP community registry.
+// It paginates through the registry collecting servers that have only npm packages
+// with stdio transport. Stops after maxServers are collected or maxPages are read.
+// Returns partial results with a non-nil error if a page fetch fails.
+func fetchNPMOnlyServers(ctx context.Context, client *http.Client, maxServers int, maxPages int) ([]serverResponseJSON, int, error) {
+	var npmServers []serverResponseJSON
+	cursor := ""
+	baseURL := "https://registry.modelcontextprotocol.io/v0/servers?version=latest&limit=100"
+	pagesRead := 0
+
+	for len(npmServers) < maxServers && pagesRead < maxPages {
+		reqURL := baseURL
+		if cursor != "" {
+			reqURL += "&cursor=" + url.QueryEscape(cursor)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return npmServers, pagesRead, fmt.Errorf("creating request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			// Return what we have so far on network error
+			return npmServers, pagesRead, fmt.Errorf("fetching page %d: %w", pagesRead+1, err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return npmServers, pagesRead, fmt.Errorf("reading page %d: %w", pagesRead+1, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return npmServers, pagesRead, fmt.Errorf("page %d returned %d: %s", pagesRead+1, resp.StatusCode, string(body[:min(200, len(body))]))
+		}
+
+		var listResp registryListResponse
+		if err := json.Unmarshal(body, &listResp); err != nil {
+			return npmServers, pagesRead, fmt.Errorf("parsing page %d: %w", pagesRead+1, err)
+		}
+
+		pagesRead++
+
+		for _, s := range listResp.Servers {
+			pkgs := s.Server.Packages
+			hasNPMStdio := false
+			hasOCI := false
+			hasPyPI := false
+			for _, p := range pkgs {
+				switch p.RegistryType {
+				case "oci":
+					hasOCI = true
+				case "pypi":
+					hasPyPI = true
+				case "npm":
+					if p.Transport.Type == "stdio" {
+						hasNPMStdio = true
+					}
+				}
+			}
+			if hasNPMStdio && !hasOCI && !hasPyPI {
+				npmServers = append(npmServers, s)
+			}
+		}
+
+		if listResp.Metadata.NextCursor == "" || len(listResp.Servers) == 0 {
+			break
+		}
+		cursor = listResp.Metadata.NextCursor
+	}
+
+	if len(npmServers) > maxServers {
+		npmServers = npmServers[:maxServers]
+	}
+
+	return npmServers, pagesRead, nil
+}

--- a/pkg/catalog/npm_integration_test.go
+++ b/pkg/catalog/npm_integration_test.go
@@ -172,7 +172,7 @@ func TestNPMVersionResolver(t *testing.T) {
 	// Map of npm registry URL paths to testdata files
 	packageFiles := map[string]string{
 		"/@anthropic-ai/claude-code/latest": "testdata/npm_package_claude_code.json",
-		"/@agenttrust/mcp-server/1.1.1":    "testdata/npm_package_agenttrust.json",
+		"/@agenttrust/mcp-server/1.1.1":     "testdata/npm_package_agenttrust.json",
 		"/@contextlayer/mcp/0.0.3":          "testdata/npm_package_contextlayer.json",
 	}
 
@@ -188,7 +188,7 @@ func TestNPMVersionResolver(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(data)
+		_, _ = w.Write(data)
 	}))
 	defer srv.Close()
 

--- a/pkg/catalog/npm_integration_test.go
+++ b/pkg/catalog/npm_integration_test.go
@@ -119,30 +119,34 @@ func TestNPMTransformBatch(t *testing.T) {
 				return
 			}
 
-			// Validate volumes contain npm cache
-			if len(result.Volumes) == 0 {
-				t.Errorf("%s: expected at least one volume for npm cache", name)
-				failed++
-				return
-			}
-			hasNPMCache := false
-			for _, v := range result.Volumes {
-				if strings.Contains(v, ":/root/.npm") && strings.HasPrefix(v, "docker-mcp-npm-cache-") {
-					hasNPMCache = true
-					break
+			// Validate volumes contain npm cache (unless a user override dropped it)
+			if result.User == "" {
+				if len(result.Volumes) == 0 {
+					t.Errorf("%s: expected at least one volume for npm cache", name)
+					failed++
+					return
+				}
+				hasNPMCache := false
+				for _, v := range result.Volumes {
+					if strings.Contains(v, ":/root/.npm") && strings.HasPrefix(v, "docker-mcp-npm-cache-") {
+						hasNPMCache = true
+						break
+					}
+				}
+				if !hasNPMCache {
+					t.Errorf("%s: expected npm cache volume, got %v", name, result.Volumes)
+					failed++
+					return
 				}
 			}
-			if !hasNPMCache {
-				t.Errorf("%s: expected npm cache volume, got %v", name, result.Volumes)
-				failed++
-				return
-			}
 
-			// Validate metadata has registry URL
-			if result.Metadata == nil || result.Metadata.RegistryURL == "" {
-				t.Errorf("%s: expected metadata.registryUrl to be set", name)
-				failed++
-				return
+			// Validate metadata has registry URL (only when server has a version)
+			if s.Server.Version != "" {
+				if result.Metadata == nil || result.Metadata.RegistryURL == "" {
+					t.Errorf("%s: expected metadata.registryUrl to be set", name)
+					failed++
+					return
+				}
 			}
 
 			passed++
@@ -192,39 +196,8 @@ func TestNPMVersionResolver(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Create a resolver that points to our test server instead of the real npm registry.
-	// We construct the resolver manually rather than using NewNPMVersionResolver because
-	// the standard resolver hardcodes the npm registry URL.
-	resolver := func(ctx context.Context, identifier, version, _ string) (string, bool) {
-		var url string
-		if version != "" {
-			url = fmt.Sprintf("%s/%s/%s", srv.URL, identifier, version)
-		} else {
-			url = fmt.Sprintf("%s/%s/latest", srv.URL, identifier)
-		}
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return "", false
-		}
-
-		resp, err := srv.Client().Do(req)
-		if err != nil {
-			return "", false
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return "", false
-		}
-
-		var info npmPackageInfo
-		if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-			return "", false
-		}
-
-		return parseNodeVersion(info.Engines.Node), true
-	}
+	// Use the production resolver pointed at our test server.
+	resolver := NewNPMVersionResolver(srv.Client(), srv.URL)
 
 	ctx := t.Context()
 

--- a/pkg/catalog/npm_test.go
+++ b/pkg/catalog/npm_test.go
@@ -11,20 +11,20 @@ func TestParseNodeVersion(t *testing.T) {
 		want        string
 	}{
 		{"empty string", "", ""},
-		{"greater than or equal", ">=18", "18"},
-		{"greater than or equal with patch", ">=16.17.0", "16"},
-		{"greater than or equal with minor", ">=20.0", "20"},
+		{"greater than or equal", ">=18", ""},
+		{"greater than or equal with patch", ">=16.17.0", ""},
+		{"greater than or equal with minor", ">=20.0", ""},
 		{"caret constraint", "^18", "18"},
 		{"caret with patch", "^20.0.0", "20"},
 		{"tilde constraint", "~18", "18"},
 		{"tilde with minor", "~20.11", "20"},
-		{"greater than", ">16", "16"},
-		{"range with upper bound", ">=18 <22", "18"},
+		{"greater than", ">16", ""},
+		{"range with upper bound", ">=18 <22", ""},
 		{"or range", "18 || 20 || 22", ""},
 		{"garbage input", "foobar", ""},
 		{"just a number", "18", "18"},
-		{"with spaces", ">= 18", "18"},
-		{"complex range", ">=18.0.0 <25.0.0", "18"},
+		{"with spaces", ">= 18", ""},
+		{"complex range", ">=18.0.0 <25.0.0", ""},
 	}
 
 	for _, tt := range tests {
@@ -43,7 +43,7 @@ func TestNodeVersionToImageTag(t *testing.T) {
 		nodeVersion string
 		want        string
 	}{
-		{"empty defaults to 22", "", "node:22-bookworm-slim"},
+		{"empty defaults to 24", "", "node:24-bookworm-slim"},
 		{"node 18", "18", "node:18-bookworm-slim"},
 		{"node 20", "20", "node:20-bookworm-slim"},
 		{"node 22", "22", "node:22-bookworm-slim"},

--- a/pkg/catalog/npm_test.go
+++ b/pkg/catalog/npm_test.go
@@ -1,0 +1,61 @@
+package catalog
+
+import (
+	"testing"
+)
+
+func TestParseNodeVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		enginesNode string
+		want        string
+	}{
+		{"empty string", "", ""},
+		{"greater than or equal", ">=18", "18"},
+		{"greater than or equal with patch", ">=16.17.0", "16"},
+		{"greater than or equal with minor", ">=20.0", "20"},
+		{"caret constraint", "^18", "18"},
+		{"caret with patch", "^20.0.0", "20"},
+		{"tilde constraint", "~18", "18"},
+		{"tilde with minor", "~20.11", "20"},
+		{"greater than", ">16", "16"},
+		{"range with upper bound", ">=18 <22", "18"},
+		{"or range", "18 || 20 || 22", ""},
+		{"garbage input", "foobar", ""},
+		{"just a number", "18", "18"},
+		{"with spaces", ">= 18", "18"},
+		{"complex range", ">=18.0.0 <25.0.0", "18"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNodeVersion(tt.enginesNode)
+			if got != tt.want {
+				t.Errorf("parseNodeVersion(%q) = %q, want %q", tt.enginesNode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeVersionToImageTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodeVersion string
+		want        string
+	}{
+		{"empty defaults to 22", "", "node:22-bookworm-slim"},
+		{"node 18", "18", "node:18-bookworm-slim"},
+		{"node 20", "20", "node:20-bookworm-slim"},
+		{"node 22", "22", "node:22-bookworm-slim"},
+		{"node 24", "24", "node:24-bookworm-slim"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nodeVersionToImageTag(tt.nodeVersion)
+			if got != tt.want {
+				t.Errorf("nodeVersionToImageTag(%q) = %q, want %q", tt.nodeVersion, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/catalog/registry_to_catalog.go
+++ b/pkg/catalog/registry_to_catalog.go
@@ -80,9 +80,26 @@ type (
 // Helper Functions
 
 func extractServerName(fullName string) string {
-	// com.docker.mcp/server-name -> com-docker-mcp-server-name
-	name := strings.ReplaceAll(fullName, "/", "-")
-	name = strings.ReplaceAll(name, ".", "-")
+	// Produce a name that is safe for Docker volume names, secret names, and config schema names.
+	// Docker volume names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*.
+	// We replace any non-alphanumeric/non-hyphen character with '-' and trim leading
+	// non-alphanumeric characters so names like "@scope/pkg" become "scope-pkg".
+	var b strings.Builder
+	for _, r := range fullName {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	name := b.String()
+	// Trim leading non-alphanumeric characters (hyphens, etc.)
+	name = strings.TrimLeftFunc(name, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9')
+	})
+	if name == "" {
+		name = "server"
+	}
 	return name
 }
 
@@ -605,6 +622,15 @@ func TransformToDocker(ctx context.Context, serverDetail ServerDetail, opts ...T
 	if pkg != nil {
 		if user := extractUserFromRuntimeArgs(pkg.RuntimeArguments, serverName); user != "" {
 			server.User = user
+			// A non-root user cannot write to /root/.npm or /root/.cache/uv, so
+			// drop any cache volumes that target /root/ to avoid silent failures.
+			filtered := server.Volumes[:0]
+			for _, v := range server.Volumes {
+				if !strings.Contains(v, ":/root/") {
+					filtered = append(filtered, v)
+				}
+			}
+			server.Volumes = filtered
 		}
 	}
 

--- a/pkg/catalog/registry_to_catalog.go
+++ b/pkg/catalog/registry_to_catalog.go
@@ -23,6 +23,7 @@ type TransformSource string
 const (
 	TransformSourceOCI    TransformSource = "oci"
 	TransformSourcePyPI   TransformSource = "pypi"
+	TransformSourceNPM    TransformSource = "npm"
 	TransformSourceRemote TransformSource = "remote"
 )
 
@@ -32,6 +33,8 @@ type TransformOption func(*transformOptions)
 type transformOptions struct {
 	allowPyPI    bool
 	pypiResolver PyPIVersionResolver
+	allowNPM     bool
+	npmResolver  NPMVersionResolver
 }
 
 // WithAllowPyPI controls whether PyPI packages are considered during transformation.
@@ -47,6 +50,22 @@ func WithAllowPyPI(allow bool) TransformOption {
 func WithPyPIResolver(resolver PyPIVersionResolver) TransformOption {
 	return func(o *transformOptions) {
 		o.pypiResolver = resolver
+	}
+}
+
+// WithAllowNPM controls whether npm packages are considered during transformation.
+// By default, npm packages are allowed.
+func WithAllowNPM(allow bool) TransformOption {
+	return func(o *transformOptions) {
+		o.allowNPM = allow
+	}
+}
+
+// WithNPMResolver sets the npm version resolver used to determine the Node.js
+// version for npm packages. If not set, the default Node.js version is used.
+func WithNPMResolver(resolver NPMVersionResolver) TransformOption {
+	return func(o *transformOptions) {
+		o.npmResolver = resolver
 	}
 }
 
@@ -226,6 +245,36 @@ func extractPyPIInfo(pkg model.Package, pythonVersion string, serverName string)
 	// Add uv cache volume (keyed per server to avoid cross-contamination)
 	volumeName := fmt.Sprintf("docker-mcp-uv-cache-%s", serverName)
 	volumes = []string{volumeName + ":/root/.cache/uv"}
+
+	return image, command, volumes
+}
+
+func extractNPMInfo(pkg model.Package, nodeVersion string, serverName string) (image string, command []string, volumes []string) {
+	if pkg.RegistryType != "npm" {
+		return "", nil, nil
+	}
+
+	// Set the Node.js Docker image based on version
+	image = nodeVersionToImageTag(nodeVersion)
+
+	// Build npx command with --yes to avoid interactive prompts
+	command = []string{"npx", "--yes"}
+
+	// Add custom registry if specified (and not default npm registry)
+	if pkg.RegistryBaseURL != "" && pkg.RegistryBaseURL != "https://registry.npmjs.org" {
+		command = append(command, "--registry", pkg.RegistryBaseURL)
+	}
+
+	// Add package identifier with optional version
+	if pkg.Version != "" {
+		command = append(command, fmt.Sprintf("%s@%s", pkg.Identifier, pkg.Version))
+	} else {
+		command = append(command, pkg.Identifier)
+	}
+
+	// Add npm cache volume (keyed per server to avoid cross-contamination)
+	volumeName := fmt.Sprintf("docker-mcp-npm-cache-%s", serverName)
+	volumes = []string{volumeName + ":/root/.npm"}
 
 	return image, command, volumes
 }
@@ -411,6 +460,7 @@ func getPublisherProvidedMeta(meta *v0.ServerMeta) map[string]any {
 func TransformToDocker(ctx context.Context, serverDetail ServerDetail, opts ...TransformOption) (*Server, TransformSource, error) {
 	options := transformOptions{
 		allowPyPI: true,
+		allowNPM:  true,
 	}
 	for _, opt := range opts {
 		opt(&options)
@@ -430,6 +480,15 @@ func TransformToDocker(ctx context.Context, serverDetail ServerDetail, opts ...T
 	if pkg == nil && options.allowPyPI {
 		for i := range serverDetail.Packages {
 			if serverDetail.Packages[i].RegistryType == "pypi" &&
+				serverDetail.Packages[i].Transport.Type == "stdio" {
+				pkg = &serverDetail.Packages[i]
+				break
+			}
+		}
+	}
+	if pkg == nil && options.allowNPM {
+		for i := range serverDetail.Packages {
+			if serverDetail.Packages[i].RegistryType == "npm" &&
 				serverDetail.Packages[i].Transport.Type == "stdio" {
 				pkg = &serverDetail.Packages[i]
 				break
@@ -480,6 +539,24 @@ func TransformToDocker(ctx context.Context, serverDetail ServerDetail, opts ...T
 				server.LongLived = true
 				source = TransformSourcePyPI
 			}
+		case "npm":
+			var nodeVersion string
+			if options.npmResolver != nil {
+				nv, found := options.npmResolver(ctx, pkg.Identifier, pkg.Version, pkg.RegistryBaseURL)
+				if !found && remote == nil { // Only fail if we can't use a remote fallback
+					return nil, "", fmt.Errorf("npm package %s@%s was not found", pkg.Identifier, pkg.Version)
+				}
+				nodeVersion = nv
+			}
+			image, command, volumes := extractNPMInfo(*pkg, nodeVersion, serverName)
+			if image != "" {
+				server.Image = image
+				server.Command = command
+				server.Volumes = volumes
+				server.Type = "server"
+				server.LongLived = true
+				source = TransformSourceNPM
+			}
 		default:
 			return nil, "", fmt.Errorf("unsupported registry type: %s", pkg.RegistryType)
 		}
@@ -515,8 +592,8 @@ func TransformToDocker(ctx context.Context, serverDetail ServerDetail, opts ...T
 
 	// Add package arguments
 	if pkg != nil && len(pkg.PackageArguments) > 0 {
-		if pkg.RegistryType == "pypi" {
-			// For PyPI: append package args to the uvx command
+		if pkg.RegistryType == "pypi" || pkg.RegistryType == "npm" {
+			// For PyPI/npm: append package args to the uvx/npx command
 			server.Command = append(server.Command, convertPackageArgsToCommand(pkg.PackageArguments, serverName)...)
 		} else {
 			// For OCI: package args become the full command

--- a/pkg/catalog/registry_to_catalog.go
+++ b/pkg/catalog/registry_to_catalog.go
@@ -38,7 +38,7 @@ type transformOptions struct {
 }
 
 // WithAllowPyPI controls whether PyPI packages are considered during transformation.
-// By default, PyPI packages are allowed.
+// By default, PyPI packages are not allowed.
 func WithAllowPyPI(allow bool) TransformOption {
 	return func(o *transformOptions) {
 		o.allowPyPI = allow
@@ -54,7 +54,7 @@ func WithPyPIResolver(resolver PyPIVersionResolver) TransformOption {
 }
 
 // WithAllowNPM controls whether npm packages are considered during transformation.
-// By default, npm packages are allowed.
+// By default, npm packages are not allowed.
 func WithAllowNPM(allow bool) TransformOption {
 	return func(o *transformOptions) {
 		o.allowNPM = allow

--- a/pkg/catalog/registry_to_catalog_test.go
+++ b/pkg/catalog/registry_to_catalog_test.go
@@ -1221,3 +1221,633 @@ func TestTransformPyPIPackageNotFound(t *testing.T) {
 		t.Errorf("Expected package identifier and version in error message, got: %v", err)
 	}
 }
+
+// transformTestJSONWithOpts is a test helper that accepts variadic TransformOptions.
+func transformTestJSONWithOpts(t *testing.T, registryJSON string, opts ...TransformOption) (Server, string) {
+	t.Helper()
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+	result, _, err := TransformToDocker(t.Context(), serverResponse.Server, opts...)
+	if err != nil {
+		t.Fatalf("TransformToDocker failed: %v", err)
+	}
+	catalogJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal catalog JSON: %v", err)
+	}
+	return *result, string(catalogJSON)
+}
+
+func TestTransformNPM(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "ai.agenttrust/mcp-server",
+			"title": "AgentTrust",
+			"description": "Identity, trust, and A2A orchestration for autonomous AI agents.",
+			"version": "1.1.1",
+			"packages": [{
+				"registryType": "npm",
+				"registryBaseUrl": "https://registry.npmjs.org",
+				"identifier": "@agenttrust/mcp-server",
+				"version": "1.1.1",
+				"transport": {"type": "stdio"},
+				"environmentVariables": [
+					{
+						"name": "AGENTTRUST_API_KEY",
+						"description": "Your AgentTrust API key",
+						"isSecret": true,
+						"isRequired": true
+					}
+				]
+			}]
+		}
+	}`
+
+	mockResolver := func(_ context.Context, _, _, _ string) (string, bool) {
+		return "22", true
+	}
+
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON, WithNPMResolver(mockResolver))
+
+	if result.Name != "ai-agenttrust-mcp-server" {
+		t.Errorf("Expected name 'ai-agenttrust-mcp-server', got '%s'", result.Name)
+	}
+	if result.Title != "AgentTrust" {
+		t.Errorf("Expected title 'AgentTrust', got '%s'", result.Title)
+	}
+	if result.Type != "server" {
+		t.Errorf("Expected type 'server', got '%s'", result.Type)
+	}
+
+	expectedImage := "node:22-bookworm-slim"
+	if result.Image != expectedImage {
+		t.Errorf("Expected image '%s', got '%s'", expectedImage, result.Image)
+	}
+
+	expectedCommand := []string{"npx", "--yes", "@agenttrust/mcp-server@1.1.1"}
+	if len(result.Command) != len(expectedCommand) {
+		t.Errorf("Expected command length %d, got %d", len(expectedCommand), len(result.Command))
+	} else {
+		for i, cmd := range expectedCommand {
+			if result.Command[i] != cmd {
+				t.Errorf("Expected command[%d] '%s', got '%s'", i, cmd, result.Command[i])
+			}
+		}
+	}
+
+	if !result.LongLived {
+		t.Error("Expected npm server to be long-lived")
+	}
+
+	if len(result.Volumes) == 0 {
+		t.Error("Expected volumes to be present")
+	} else {
+		expectedVolume := "docker-mcp-npm-cache-ai-agenttrust-mcp-server:/root/.npm"
+		if result.Volumes[0] != expectedVolume {
+			t.Errorf("Expected volume '%s', got '%s'", expectedVolume, result.Volumes[0])
+		}
+	}
+
+	if len(result.Secrets) == 0 {
+		t.Error("Expected secrets to be present")
+	} else {
+		found := false
+		for _, secret := range result.Secrets {
+			if secret.Name == "ai-agenttrust-mcp-server.AGENTTRUST_API_KEY" {
+				if secret.Env != "AGENTTRUST_API_KEY" {
+					t.Errorf("Expected secret env 'AGENTTRUST_API_KEY', got '%s'", secret.Env)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("Expected AGENTTRUST_API_KEY secret")
+		}
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}
+
+func TestTransformNPMScopedPackage(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.github.playwright/mcp",
+			"title": "Playwright MCP Server",
+			"description": "MCP server for Playwright browser automation",
+			"version": "0.1.0",
+			"packages": [{
+				"registryType": "npm",
+				"identifier": "@playwright/mcp",
+				"version": "0.1.0",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	mockResolver := func(_ context.Context, _, _, _ string) (string, bool) {
+		return "18", true
+	}
+
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON, WithNPMResolver(mockResolver))
+
+	expectedImage := "node:18-bookworm-slim"
+	if result.Image != expectedImage {
+		t.Errorf("Expected image '%s', got '%s'", expectedImage, result.Image)
+	}
+
+	expectedCommand := []string{"npx", "--yes", "@playwright/mcp@0.1.0"}
+	if len(result.Command) != len(expectedCommand) {
+		t.Errorf("Expected command length %d, got %d", len(expectedCommand), len(result.Command))
+	} else {
+		for i, cmd := range expectedCommand {
+			if result.Command[i] != cmd {
+				t.Errorf("Expected command[%d] '%s', got '%s'", i, cmd, result.Command[i])
+			}
+		}
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}
+
+func TestTransformNPMWithCustomRegistry(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "com.example/custom-npm-server",
+			"title": "Custom npm Server",
+			"description": "MCP server from custom npm registry",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"registryBaseUrl": "https://custom.registry.com",
+				"identifier": "my-custom-package",
+				"version": "1.0.0",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON)
+
+	if result.Type != "server" {
+		t.Errorf("Expected type 'server', got '%s'", result.Type)
+	}
+
+	expectedCommand := []string{"npx", "--yes", "--registry", "https://custom.registry.com", "my-custom-package@1.0.0"}
+	if len(result.Command) != len(expectedCommand) {
+		t.Errorf("Expected command length %d, got %d", len(expectedCommand), len(result.Command))
+	} else {
+		for i, cmd := range expectedCommand {
+			if result.Command[i] != cmd {
+				t.Errorf("Expected command[%d] '%s', got '%s'", i, cmd, result.Command[i])
+			}
+		}
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}
+
+func TestTransformNPMWithPackageArgs(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.example/npm-with-args",
+			"title": "npm Server with Arguments",
+			"description": "MCP server with command-line arguments",
+			"version": "2.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"identifier": "telbase",
+				"version": "2.0.0",
+				"transport": {"type": "stdio"},
+				"packageArguments": [
+					{
+						"type": "positional",
+						"value": "mcp"
+					},
+					{
+						"type": "positional",
+						"value": "serve"
+					}
+				]
+			}]
+		}
+	}`
+
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON)
+
+	if result.Type != "server" {
+		t.Errorf("Expected type 'server', got '%s'", result.Type)
+	}
+
+	expectedCommand := []string{"npx", "--yes", "telbase@2.0.0", "mcp", "serve"}
+	if len(result.Command) != len(expectedCommand) {
+		t.Errorf("Expected command length %d, got %d", len(expectedCommand), len(result.Command))
+	} else {
+		for i, cmd := range expectedCommand {
+			if result.Command[i] != cmd {
+				t.Errorf("Expected command[%d] '%s', got '%s'", i, cmd, result.Command[i])
+			}
+		}
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}
+
+func TestTransformNPMWithoutVersion(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.example/npm-no-version",
+			"title": "npm Server No Version",
+			"description": "MCP server without version specified",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"identifier": "@contextlayer/mcp",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON)
+
+	if result.Type != "server" {
+		t.Errorf("Expected type 'server', got '%s'", result.Type)
+	}
+
+	expectedCommand := []string{"npx", "--yes", "@contextlayer/mcp"}
+	if len(result.Command) != len(expectedCommand) {
+		t.Errorf("Expected command length %d, got %d", len(expectedCommand), len(result.Command))
+	} else {
+		for i, cmd := range expectedCommand {
+			if result.Command[i] != cmd {
+				t.Errorf("Expected command[%d] '%s', got '%s'", i, cmd, result.Command[i])
+			}
+		}
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}
+
+func TestTransformNPMWithEnvVariables(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.example/npm-with-env",
+			"title": "npm Server with Environment Variables",
+			"description": "MCP server with environment variables",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"identifier": "my-env-server",
+				"version": "1.0.0",
+				"transport": {"type": "stdio"},
+				"environmentVariables": [
+					{
+						"name": "API_KEY",
+						"description": "API key for authentication",
+						"isSecret": true,
+						"isRequired": true
+					},
+					{
+						"name": "LOG_LEVEL",
+						"value": "{log_level}",
+						"variables": {
+							"log_level": {
+								"description": "Logging level",
+								"default": "info"
+							}
+						}
+					}
+				]
+			}]
+		}
+	}`
+
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON)
+
+	if result.Type != "server" {
+		t.Errorf("Expected type 'server', got '%s'", result.Type)
+	}
+
+	// Verify secrets
+	if len(result.Secrets) == 0 {
+		t.Error("Expected secrets to be present")
+	} else {
+		found := false
+		for _, secret := range result.Secrets {
+			if secret.Name == "io-example-npm-with-env.API_KEY" {
+				if secret.Env != "API_KEY" {
+					t.Errorf("Expected secret env 'API_KEY', got '%s'", secret.Env)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("Expected API_KEY secret")
+		}
+	}
+
+	// Verify environment variables
+	if len(result.Env) == 0 {
+		t.Error("Expected environment variables to be present")
+	} else {
+		found := false
+		for _, env := range result.Env {
+			if env.Name == "LOG_LEVEL" {
+				if env.Value != "{{io-example-npm-with-env.log_level}}" {
+					t.Errorf("Expected LOG_LEVEL value '{{io-example-npm-with-env.log_level}}', got '%s'", env.Value)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("Expected LOG_LEVEL environment variable")
+		}
+	}
+
+	// Verify config
+	if len(result.Config) == 0 {
+		t.Error("Expected config to be present")
+	} else {
+		configMap, ok := result.Config[0].(map[string]any)
+		if !ok {
+			t.Fatal("Expected config to be a map[string]any")
+		}
+		properties, ok := configMap["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected properties in config")
+		}
+		if _, ok := properties["log_level"]; !ok {
+			t.Error("Expected log_level in config properties")
+		}
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}
+
+func TestTransformNPMDisallowed(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/npm-only-server",
+			"title": "npm Only Server",
+			"description": "Server with only npm package",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"registryBaseUrl": "https://registry.npmjs.org",
+				"identifier": "@example/mcp-server",
+				"version": "1.0.0",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+
+	_, _, err := TransformToDocker(t.Context(), serverResponse.Server, WithAllowNPM(false))
+	if err == nil {
+		t.Fatal("Expected error when npm is disallowed, got nil")
+	}
+	if !strings.Contains(err.Error(), "incompatible server") {
+		t.Errorf("Expected incompatible server error, got: %v", err)
+	}
+}
+
+func TestTransformNPMAllowedByDefault(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/npm-default",
+			"title": "npm Default Server",
+			"description": "Server with only npm package",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"registryBaseUrl": "https://registry.npmjs.org",
+				"identifier": "@example/mcp-server",
+				"version": "1.0.0",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+
+	result, source, err := TransformToDocker(t.Context(), serverResponse.Server)
+	if err != nil {
+		t.Fatalf("Expected success for npm with default options, got: %v", err)
+	}
+	if source != TransformSourceNPM {
+		t.Errorf("Expected source %q, got %q", TransformSourceNPM, source)
+	}
+	if result.Type != "server" {
+		t.Errorf("Expected type 'server', got '%s'", result.Type)
+	}
+	if result.Image == "" {
+		t.Error("Expected image to be set for npm server")
+	}
+}
+
+func TestTransformNPMPackageNotFound(t *testing.T) {
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/npm-not-found",
+			"title": "npm Not Found Server",
+			"description": "Server whose npm package does not exist",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"registryBaseUrl": "https://registry.npmjs.org",
+				"identifier": "@nonexistent/mcp-server",
+				"version": "9.9.9",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	notFoundResolver := func(_ context.Context, _, _, _ string) (string, bool) {
+		return "", false
+	}
+
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+
+	_, _, err := TransformToDocker(t.Context(), serverResponse.Server, WithNPMResolver(notFoundResolver))
+	if err == nil {
+		t.Fatal("Expected error when npm package is not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "was not found") {
+		t.Errorf("Expected 'was not found' in error message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "@nonexistent/mcp-server@9.9.9") {
+		t.Errorf("Expected package identifier and version in error message, got: %v", err)
+	}
+}
+
+func TestTransformNPMPackageNotFoundWithRemoteFallback(t *testing.T) {
+	// When npm resolver returns not-found but a remote transport exists,
+	// the server should fall back to remote instead of erroring.
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/npm-with-remote-fallback",
+			"title": "npm Server with Remote Fallback",
+			"description": "Server with npm package and remote transport",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"registryBaseUrl": "https://registry.npmjs.org",
+				"identifier": "@nonexistent/mcp-server",
+				"version": "9.9.9",
+				"transport": {"type": "stdio"}
+			}],
+			"remotes": [{
+				"type": "sse",
+				"url": "https://example.com/mcp"
+			}]
+		}
+	}`
+
+	notFoundResolver := func(_ context.Context, _, _, _ string) (string, bool) {
+		return "", false
+	}
+
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+
+	result, source, err := TransformToDocker(t.Context(), serverResponse.Server, WithNPMResolver(notFoundResolver))
+	if err != nil {
+		t.Fatalf("Expected success with remote fallback, got: %v", err)
+	}
+	if source != TransformSourceRemote {
+		t.Errorf("Expected source %q, got %q", TransformSourceRemote, source)
+	}
+	if result.Remote.URL != "https://example.com/mcp" {
+		t.Errorf("Expected remote URL 'https://example.com/mcp', got '%s'", result.Remote.URL)
+	}
+	if result.Type != "remote" {
+		t.Errorf("Expected type 'remote', got '%s'", result.Type)
+	}
+}
+
+func TestTransformNPMPreferOCIOverNPM(t *testing.T) {
+	// When a server has both OCI and npm packages, OCI should be preferred.
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/oci-and-npm",
+			"title": "Server with OCI and npm",
+			"description": "Server with both package types",
+			"version": "1.0.0",
+			"packages": [
+				{
+					"registryType": "npm",
+					"identifier": "@example/mcp-server",
+					"version": "1.0.0",
+					"transport": {"type": "stdio"}
+				},
+				{
+					"registryType": "oci",
+					"identifier": "ghcr.io/example/server:1.0.0",
+					"transport": {"type": "stdio"}
+				}
+			]
+		}
+	}`
+
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+
+	result, source, err := TransformToDocker(t.Context(), serverResponse.Server)
+	if err != nil {
+		t.Fatalf("Expected success, got: %v", err)
+	}
+	if source != TransformSourceOCI {
+		t.Errorf("Expected source %q, got %q", TransformSourceOCI, source)
+	}
+	if result.Image != "ghcr.io/example/server:1.0.0" {
+		t.Errorf("Expected OCI image, got '%s'", result.Image)
+	}
+}
+
+func TestTransformNPMPreferPyPIOverNPM(t *testing.T) {
+	// When a server has both PyPI and npm packages, PyPI should be preferred.
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/pypi-and-npm",
+			"title": "Server with PyPI and npm",
+			"description": "Server with both package types",
+			"version": "1.0.0",
+			"packages": [
+				{
+					"registryType": "npm",
+					"identifier": "@example/mcp-server",
+					"version": "1.0.0",
+					"transport": {"type": "stdio"}
+				},
+				{
+					"registryType": "pypi",
+					"identifier": "example-mcp-server",
+					"version": "1.0.0",
+					"transport": {"type": "stdio"}
+				}
+			]
+		}
+	}`
+
+	var serverResponse v0.ServerResponse
+	if err := json.Unmarshal([]byte(registryJSON), &serverResponse); err != nil {
+		t.Fatalf("Failed to parse registry JSON: %v", err)
+	}
+
+	result, source, err := TransformToDocker(t.Context(), serverResponse.Server)
+	if err != nil {
+		t.Fatalf("Expected success, got: %v", err)
+	}
+	if source != TransformSourcePyPI {
+		t.Errorf("Expected source %q, got %q", TransformSourcePyPI, source)
+	}
+	if !strings.HasPrefix(result.Image, "ghcr.io/astral-sh/uv:") {
+		t.Errorf("Expected uv image for PyPI, got '%s'", result.Image)
+	}
+}
+
+func TestTransformNPMNilResolver(t *testing.T) {
+	// When no npm resolver is provided, the default Node version should be used.
+	registryJSON := `{
+		"server": {
+			"name": "io.github.example/npm-nil-resolver",
+			"title": "npm Server No Resolver",
+			"description": "npm server without resolver",
+			"version": "1.0.0",
+			"packages": [{
+				"registryType": "npm",
+				"identifier": "@example/mcp-server",
+				"version": "1.0.0",
+				"transport": {"type": "stdio"}
+			}]
+		}
+	}`
+
+	// Explicitly pass no npm resolver
+	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON)
+
+	expectedImage := "node:22-bookworm-slim"
+	if result.Image != expectedImage {
+		t.Errorf("Expected default image '%s', got '%s'", expectedImage, result.Image)
+	}
+
+	t.Logf("Catalog JSON:\n%s", catalogJSON)
+}

--- a/pkg/catalog/registry_to_catalog_test.go
+++ b/pkg/catalog/registry_to_catalog_test.go
@@ -1844,7 +1844,7 @@ func TestTransformNPMNilResolver(t *testing.T) {
 	// Explicitly pass no npm resolver
 	result, catalogJSON := transformTestJSONWithOpts(t, registryJSON)
 
-	expectedImage := "node:22-bookworm-slim"
+	expectedImage := "node:24-bookworm-slim"
 	if result.Image != expectedImage {
 		t.Errorf("Expected default image '%s', got '%s'", expectedImage, result.Image)
 	}

--- a/pkg/catalog/testdata/npm_package_agenttrust.json
+++ b/pkg/catalog/testdata/npm_package_agenttrust.json
@@ -1,0 +1,7 @@
+{
+  "name": "@agenttrust/mcp-server",
+  "version": "1.1.1",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/pkg/catalog/testdata/npm_package_claude_code.json
+++ b/pkg/catalog/testdata/npm_package_claude_code.json
@@ -1,0 +1,7 @@
+{
+  "name": "@anthropic-ai/claude-code",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/pkg/catalog/testdata/npm_package_contextlayer.json
+++ b/pkg/catalog/testdata/npm_package_contextlayer.json
@@ -1,0 +1,4 @@
+{
+  "name": "@contextlayer/mcp",
+  "version": "0.0.3"
+}

--- a/pkg/catalog/testdata/npm_registry_servers.json
+++ b/pkg/catalog/testdata/npm_registry_servers.json
@@ -1,0 +1,254 @@
+{
+  "servers": [
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "ai.agenttrust/mcp-server",
+        "description": "Identity, trust, and A2A orchestration for autonomous AI agents.",
+        "title": "AgentTrust MCP Server",
+        "version": "1.1.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@agenttrust/mcp-server",
+            "version": "1.1.1",
+            "transport": { "type": "stdio" },
+            "environmentVariables": [
+              {
+                "name": "AGENTTRUST_API_KEY",
+                "description": "API key for AgentTrust",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/simple-npm-server",
+        "description": "A simple npm MCP server for testing.",
+        "title": "Simple NPM Server",
+        "version": "2.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "simple-npm-server",
+            "version": "2.0.0",
+            "transport": { "type": "stdio" }
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/scoped-server",
+        "description": "A scoped npm package server.",
+        "title": "Scoped Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@scope/mcp-tools",
+            "version": "0.5.0",
+            "transport": { "type": "stdio" },
+            "packageArguments": [
+              {
+                "type": "positional",
+                "value": "--stdio"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/env-server",
+        "description": "An npm server with environment variables.",
+        "title": "Env Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@example/env-mcp",
+            "version": "1.0.0",
+            "transport": { "type": "stdio" },
+            "environmentVariables": [
+              {
+                "name": "API_KEY",
+                "description": "API key",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "DEBUG",
+                "description": "Enable debug mode",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "false"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/remote-and-npm",
+        "description": "A server with both npm and remote transports.",
+        "title": "Remote And NPM Server",
+        "version": "1.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "remote-npm-server",
+            "version": "1.2.0",
+            "transport": { "type": "stdio" }
+          }
+        ],
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "https://api.example.com/mcp"
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/custom-registry",
+        "description": "An npm server from a custom registry.",
+        "title": "Custom Registry Server",
+        "version": "3.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@custom/mcp-server",
+            "version": "3.0.0",
+            "registryBaseUrl": "https://npm.custom.io",
+            "transport": { "type": "stdio" }
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/no-version-server",
+        "description": "An npm server without a pinned version.",
+        "title": "No Version Server",
+        "version": "0.0.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "no-version-mcp",
+            "transport": { "type": "stdio" }
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/multi-env-server",
+        "description": "An npm server with multiple env vars and secrets.",
+        "title": "Multi Env Server",
+        "version": "1.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multi/mcp-server",
+            "version": "1.5.0",
+            "transport": { "type": "stdio" },
+            "environmentVariables": [
+              {
+                "name": "TOKEN",
+                "description": "Auth token",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "REGION",
+                "description": "AWS region",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "us-east-1"
+              },
+              {
+                "name": "ENDPOINT",
+                "description": "Custom endpoint URL",
+                "isRequired": false,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/icon-server",
+        "description": "An npm server with an icon.",
+        "title": "Icon Server",
+        "version": "1.0.0",
+        "icons": [
+          { "src": "https://example.com/icon.png" }
+        ],
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "icon-mcp",
+            "version": "1.0.0",
+            "transport": { "type": "stdio" }
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.user/complex-server",
+        "description": "An npm server with complex config.",
+        "title": "Complex Server",
+        "version": "2.1.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@complex/mcp-tools",
+            "version": "2.1.0",
+            "transport": { "type": "stdio" },
+            "packageArguments": [
+              {
+                "type": "positional",
+                "value": "serve"
+              },
+              {
+                "type": "positional",
+                "value": "--stdio"
+              }
+            ],
+            "environmentVariables": [
+              {
+                "name": "SERVICE_KEY",
+                "description": "Service key",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "count": 10
+  }
+}

--- a/pkg/catalog/testdata/npm_registry_servers.json
+++ b/pkg/catalog/testdata/npm_registry_servers.json
@@ -3,24 +3,16 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "ai.agenttrust/mcp-server",
-        "description": "Identity, trust, and A2A orchestration for autonomous AI agents.",
-        "title": "AgentTrust MCP Server",
-        "version": "1.1.1",
+        "name": "io.github.modelcontextprotocol/server-filesystem",
+        "description": "Provides file system access for reading, writing, and managing files and directories.",
+        "title": "Filesystem MCP Server",
+        "version": "0.6.2",
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "@agenttrust/mcp-server",
-            "version": "1.1.1",
-            "transport": { "type": "stdio" },
-            "environmentVariables": [
-              {
-                "name": "AGENTTRUST_API_KEY",
-                "description": "API key for AgentTrust",
-                "isRequired": true,
-                "isSecret": true
-              }
-            ]
+            "identifier": "@modelcontextprotocol/server-filesystem",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
           }
         ]
       }
@@ -28,16 +20,16 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/simple-npm-server",
-        "description": "A simple npm MCP server for testing.",
-        "title": "Simple NPM Server",
-        "version": "2.0.0",
+        "name": "io.github.modelcontextprotocol/server-github",
+        "description": "Access GitHub repositories, issues, pull requests, and code through the MCP protocol.",
+        "title": "GitHub MCP Server",
+        "version": "0.6.2",
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "simple-npm-server",
-            "version": "2.0.0",
-            "transport": { "type": "stdio" }
+            "identifier": "@modelcontextprotocol/server-github",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
           }
         ]
       }
@@ -45,22 +37,16 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/scoped-server",
-        "description": "A scoped npm package server.",
-        "title": "Scoped Server",
-        "version": "0.5.0",
+        "name": "io.github.modelcontextprotocol/server-postgres",
+        "description": "Connect to PostgreSQL databases and run queries through a natural language interface.",
+        "title": "PostgreSQL MCP Server",
+        "version": "0.6.2",
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "@scope/mcp-tools",
-            "version": "0.5.0",
-            "transport": { "type": "stdio" },
-            "packageArguments": [
-              {
-                "type": "positional",
-                "value": "--stdio"
-              }
-            ]
+            "identifier": "@modelcontextprotocol/server-postgres",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
           }
         ]
       }
@@ -68,26 +54,963 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/env-server",
-        "description": "An npm server with environment variables.",
-        "title": "Env Server",
+        "name": "io.github.modelcontextprotocol/server-slack",
+        "description": "Interact with Slack workspaces: read channels, post messages, manage users.",
+        "title": "Slack MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-slack",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.modelcontextprotocol/server-google-maps",
+        "description": "Use Google Maps APIs including geocoding, directions, and place searches.",
+        "title": "Google Maps MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-google-maps",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.modelcontextprotocol/server-brave-search",
+        "description": "Perform web searches using the Brave Search API.",
+        "title": "Brave Search MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-brave-search",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.modelcontextprotocol/server-memory",
+        "description": "Persistent key-value memory store accessible across sessions.",
+        "title": "Memory MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-memory",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.modelcontextprotocol/server-puppeteer",
+        "description": "Control a headless Chrome browser for web scraping and automation.",
+        "title": "Puppeteer MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-puppeteer",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.modelcontextprotocol/server-sqlite",
+        "description": "Interact with SQLite databases: read schema, run queries, and inspect data.",
+        "title": "SQLite MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-sqlite",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.modelcontextprotocol/server-everything",
+        "description": "A demo server that exercises every MCP feature for testing and exploration.",
+        "title": "Everything MCP Server",
+        "version": "0.6.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-everything",
+            "version": "0.6.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "com.example/mcp-server-linear",
+        "description": "Manage Linear issues, projects, and cycles directly from your AI assistant.",
+        "title": "Linear MCP Server",
+        "version": "2.1.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@example/mcp-server-linear",
+            "version": "2.1.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "com.example/mcp-server-notion",
+        "description": "Read and write Notion pages, databases, and blocks.",
+        "title": "Notion MCP Server",
+        "version": "1.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@example/mcp-server-notion",
+            "version": "1.3.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "com.example/mcp-server-jira",
+        "description": "Create, update, and search Jira issues and projects.",
+        "title": "Jira MCP Server",
+        "version": "1.0.5",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@example/mcp-server-jira",
+            "version": "1.0.5",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.acme/mcp-server-stripe",
+        "description": "Interact with the Stripe API: manage customers, charges, and subscriptions.",
+        "title": "Stripe MCP Server",
+        "version": "0.9.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@acme/mcp-server-stripe",
+            "version": "0.9.1",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.acme/mcp-server-sendgrid",
+        "description": "Send transactional emails and manage contacts via SendGrid.",
+        "title": "SendGrid MCP Server",
         "version": "1.0.0",
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "@example/env-mcp",
+            "identifier": "@acme/mcp-server-sendgrid",
             "version": "1.0.0",
-            "transport": { "type": "stdio" },
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.acme/mcp-server-twilio",
+        "description": "Send SMS and make calls via the Twilio API.",
+        "title": "Twilio MCP Server",
+        "version": "1.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@acme/mcp-server-twilio",
+            "version": "1.2.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.devtools/mcp-server-datadog",
+        "description": "Query Datadog metrics, logs, and monitors.",
+        "title": "Datadog MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@devtools/mcp-server-datadog",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.devtools/mcp-server-pagerduty",
+        "description": "Acknowledge, resolve, and create PagerDuty incidents from your AI assistant.",
+        "title": "PagerDuty MCP Server",
+        "version": "0.3.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@devtools/mcp-server-pagerduty",
+            "version": "0.3.1",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.cloudtools/mcp-server-aws",
+        "description": "Interact with AWS services including EC2, S3, Lambda, and IAM.",
+        "title": "AWS MCP Server",
+        "version": "0.7.3",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@cloudtools/mcp-server-aws",
+            "version": "0.7.3",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.cloudtools/mcp-server-gcp",
+        "description": "Access Google Cloud Platform services: GCS, BigQuery, Cloud Run, and more.",
+        "title": "Google Cloud MCP Server",
+        "version": "0.5.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@cloudtools/mcp-server-gcp",
+            "version": "0.5.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-calculator",
+        "description": "A simple calculator MCP server for arithmetic and expression evaluation.",
+        "title": "Calculator MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-calculator",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-weather",
+        "description": "Get current weather and forecasts for any location worldwide.",
+        "title": "Weather MCP Server",
+        "version": "2.0.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-weather",
+            "version": "2.0.1",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-clock",
+        "description": "Provides current time and timezone conversion utilities.",
+        "title": "Clock MCP Server",
+        "version": "0.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-clock",
+            "version": "0.2.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-currency",
+        "description": "Convert between currencies using live exchange rates.",
+        "title": "Currency MCP Server",
+        "version": "1.1.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-currency",
+            "version": "1.1.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-url-fetch",
+        "description": "Fetch the contents of a URL and return it as text or structured data.",
+        "title": "URL Fetch MCP Server",
+        "version": "0.8.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-url-fetch",
+            "version": "0.8.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-base64",
+        "description": "Encode and decode Base64 strings and binary data.",
+        "title": "Base64 MCP Server",
+        "version": "0.1.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-base64",
+            "version": "0.1.2",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-uuid",
+        "description": "Generate and validate UUIDs of all standard versions.",
+        "title": "UUID MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-uuid",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-hash",
+        "description": "Compute cryptographic hashes including MD5, SHA-1, SHA-256, and more.",
+        "title": "Hash MCP Server",
+        "version": "0.2.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-hash",
+            "version": "0.2.1",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-diff",
+        "description": "Compute textual diffs between strings or files using standard algorithms.",
+        "title": "Diff MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-diff",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-regex",
+        "description": "Test and apply regular expressions with detailed match explanations.",
+        "title": "Regex MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-regex",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-artifactory",
+        "description": "Browse and download artifacts from a JFrog Artifactory instance.",
+        "title": "Artifactory MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-artifactory",
+            "version": "1.0.0",
+            "registryBaseUrl": "https://artifactory.example.corp/api/npm/npm-virtual/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-nexus",
+        "description": "Access artifacts and metadata from a Sonatype Nexus Repository.",
+        "title": "Nexus MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-nexus",
+            "version": "0.3.0",
+            "registryBaseUrl": "https://nexus.internal.corp/repository/npm-group/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-github-packages",
+        "description": "Install and query packages from the GitHub Packages npm registry.",
+        "title": "GitHub Packages MCP Server",
+        "version": "0.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-github-packages",
+            "version": "0.2.0",
+            "registryBaseUrl": "https://npm.pkg.github.com/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-verdaccio",
+        "description": "Connect to a Verdaccio private registry for package management.",
+        "title": "Verdaccio MCP Server",
+        "version": "0.1.5",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-verdaccio",
+            "version": "0.1.5",
+            "registryBaseUrl": "https://verdaccio.mycompany.io/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-gitlab-packages",
+        "description": "Access packages published to GitLab's npm package registry.",
+        "title": "GitLab Packages MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-gitlab-packages",
+            "version": "0.4.0",
+            "registryBaseUrl": "https://gitlab.example.com/api/v4/projects/42/packages/npm/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-aws-codeartifact",
+        "description": "Pull packages from an AWS CodeArtifact domain.",
+        "title": "AWS CodeArtifact MCP Server",
+        "version": "0.6.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-aws-codeartifact",
+            "version": "0.6.0",
+            "registryBaseUrl": "https://mycompany-123456789.d.codeartifact.us-east-1.amazonaws.com/npm/my-repo/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-azure-artifacts",
+        "description": "Access npm packages stored in Azure Artifacts feeds.",
+        "title": "Azure Artifacts MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-azure-artifacts",
+            "version": "0.5.0",
+            "registryBaseUrl": "https://pkgs.dev.azure.com/myorg/myproject/_packaging/myfeed/npm/registry/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.enterprise/mcp-server-custom-registry",
+        "description": "An MCP server installed from a private self-hosted npm registry mirror.",
+        "title": "Custom Registry MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@enterprise/mcp-server-custom-registry",
+            "version": "1.0.0",
+            "registryBaseUrl": "https://npm.internal.example.net/",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.apitools/mcp-server-openai",
+        "description": "Call OpenAI chat completions and embedding APIs directly from MCP.",
+        "title": "OpenAI MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@apitools/mcp-server-openai",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"},
             "environmentVariables": [
               {
-                "name": "API_KEY",
-                "description": "API key",
+                "name": "OPENAI_API_KEY",
+                "description": "Your OpenAI API secret key.",
                 "isRequired": true,
                 "isSecret": true
               },
               {
-                "name": "DEBUG",
-                "description": "Enable debug mode",
+                "name": "OPENAI_MODEL",
+                "description": "The model to use for completions.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "gpt-4o"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.apitools/mcp-server-anthropic",
+        "description": "Run Claude models via the Anthropic API.",
+        "title": "Anthropic MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@apitools/mcp-server-anthropic",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "ANTHROPIC_API_KEY",
+                "description": "Your Anthropic API key.",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.apitools/mcp-server-github-token",
+        "description": "Authenticated GitHub API access using a personal access token.",
+        "title": "GitHub Token MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@apitools/mcp-server-github-token",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "GITHUB_TOKEN",
+                "description": "Personal access token with repo and read:org scopes.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "GITHUB_ORG",
+                "description": "Default GitHub organization to scope operations to.",
+                "isRequired": false,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.apitools/mcp-server-aws-credentials",
+        "description": "AWS API access using static credentials or assumed roles.",
+        "title": "AWS Credentials MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@apitools/mcp-server-aws-credentials",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "AWS_ACCESS_KEY_ID",
+                "description": "AWS access key ID.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "AWS_SECRET_ACCESS_KEY",
+                "description": "AWS secret access key.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "AWS_REGION",
+                "description": "Default AWS region.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "us-east-1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.apitools/mcp-server-database-url",
+        "description": "Database access using a connection URL with embedded credentials.",
+        "title": "Database URL MCP Server",
+        "version": "0.8.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@apitools/mcp-server-database-url",
+            "version": "0.8.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "DATABASE_URL",
+                "description": "Full database connection URL including username, password, host, and database name.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "DATABASE_POOL_SIZE",
+                "description": "Maximum number of connections in the pool.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "10"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.commerce/mcp-server-shopify",
+        "description": "Manage Shopify store products, orders, and customers.",
+        "title": "Shopify MCP Server",
+        "version": "1.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@commerce/mcp-server-shopify",
+            "version": "1.2.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "SHOPIFY_STORE_DOMAIN",
+                "description": "Your Shopify store domain, e.g. mystore.myshopify.com.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "SHOPIFY_ACCESS_TOKEN",
+                "description": "Shopify Admin API access token.",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.commerce/mcp-server-hubspot",
+        "description": "Access and manage HubSpot CRM contacts, deals, and companies.",
+        "title": "HubSpot MCP Server",
+        "version": "0.9.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@commerce/mcp-server-hubspot",
+            "version": "0.9.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "HUBSPOT_API_KEY",
+                "description": "HubSpot private app API key.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "HUBSPOT_PORTAL_ID",
+                "description": "Your HubSpot portal ID.",
+                "isRequired": true,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.analytics/mcp-server-mixpanel",
+        "description": "Query Mixpanel events, funnels, and user profiles.",
+        "title": "Mixpanel MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@analytics/mcp-server-mixpanel",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "MIXPANEL_SERVICE_ACCOUNT_USER",
+                "description": "Mixpanel service account username.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "MIXPANEL_SERVICE_ACCOUNT_SECRET",
+                "description": "Mixpanel service account secret.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "MIXPANEL_PROJECT_ID",
+                "description": "The Mixpanel project ID to query.",
+                "isRequired": true,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.analytics/mcp-server-segment",
+        "description": "Pull data from Segment sources and write to destinations.",
+        "title": "Segment MCP Server",
+        "version": "0.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@analytics/mcp-server-segment",
+            "version": "0.2.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "SEGMENT_WRITE_KEY",
+                "description": "Segment source write key.",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.analytics/mcp-server-amplitude",
+        "description": "Analyze Amplitude events, cohorts, and charts.",
+        "title": "Amplitude MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@analytics/mcp-server-amplitude",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "AMPLITUDE_API_KEY",
+                "description": "Amplitude project API key.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "AMPLITUDE_SECRET_KEY",
+                "description": "Amplitude project secret key.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "AMPLITUDE_REGION",
+                "description": "Amplitude data residency region.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "US"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv/mcp-server-redis",
+        "description": "Connect to Redis and perform key-value operations, pub/sub, and stream reads.",
+        "title": "Redis MCP Server",
+        "version": "1.1.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv/mcp-server-redis",
+            "version": "1.1.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "REDIS_HOST",
+                "description": "Redis server hostname.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "localhost"
+              },
+              {
+                "name": "REDIS_PORT",
+                "description": "Redis server port.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "6379"
+              },
+              {
+                "name": "REDIS_PASSWORD",
+                "description": "Redis AUTH password (leave empty if not set).",
+                "isRequired": false,
+                "isSecret": true
+              },
+              {
+                "name": "REDIS_TLS",
+                "description": "Enable TLS for the Redis connection.",
                 "isRequired": false,
                 "isSecret": false,
                 "value": "false"
@@ -100,90 +1023,113 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/remote-and-npm",
-        "description": "A server with both npm and remote transports.",
-        "title": "Remote And NPM Server",
-        "version": "1.2.0",
+        "name": "io.github.multienv/mcp-server-elasticsearch",
+        "description": "Index, search, and manage data in Elasticsearch clusters.",
+        "title": "Elasticsearch MCP Server",
+        "version": "0.6.0",
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "remote-npm-server",
-            "version": "1.2.0",
-            "transport": { "type": "stdio" }
-          }
-        ],
-        "remotes": [
-          {
-            "type": "streamable-http",
-            "url": "https://api.example.com/mcp"
-          }
-        ]
-      }
-    },
-    {
-      "server": {
-        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/custom-registry",
-        "description": "An npm server from a custom registry.",
-        "title": "Custom Registry Server",
-        "version": "3.0.0",
-        "packages": [
-          {
-            "registryType": "npm",
-            "identifier": "@custom/mcp-server",
-            "version": "3.0.0",
-            "registryBaseUrl": "https://npm.custom.io",
-            "transport": { "type": "stdio" }
-          }
-        ]
-      }
-    },
-    {
-      "server": {
-        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/no-version-server",
-        "description": "An npm server without a pinned version.",
-        "title": "No Version Server",
-        "version": "0.0.1",
-        "packages": [
-          {
-            "registryType": "npm",
-            "identifier": "no-version-mcp",
-            "transport": { "type": "stdio" }
-          }
-        ]
-      }
-    },
-    {
-      "server": {
-        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/multi-env-server",
-        "description": "An npm server with multiple env vars and secrets.",
-        "title": "Multi Env Server",
-        "version": "1.5.0",
-        "packages": [
-          {
-            "registryType": "npm",
-            "identifier": "@multi/mcp-server",
-            "version": "1.5.0",
-            "transport": { "type": "stdio" },
+            "identifier": "@multienv/mcp-server-elasticsearch",
+            "version": "0.6.0",
+            "transport": {"type": "stdio"},
             "environmentVariables": [
               {
-                "name": "TOKEN",
-                "description": "Auth token",
+                "name": "ELASTICSEARCH_URL",
+                "description": "Elasticsearch cluster URL including scheme and port.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "ELASTICSEARCH_API_KEY",
+                "description": "API key for authenticating to Elasticsearch.",
+                "isRequired": false,
+                "isSecret": true
+              },
+              {
+                "name": "ELASTICSEARCH_USERNAME",
+                "description": "Basic auth username.",
+                "isRequired": false,
+                "isSecret": false
+              },
+              {
+                "name": "ELASTICSEARCH_PASSWORD",
+                "description": "Basic auth password.",
+                "isRequired": false,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv/mcp-server-kafka",
+        "description": "Produce and consume messages on Kafka topics.",
+        "title": "Kafka MCP Server",
+        "version": "0.4.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv/mcp-server-kafka",
+            "version": "0.4.1",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "KAFKA_BROKERS",
+                "description": "Comma-separated list of Kafka broker addresses.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "KAFKA_SASL_USERNAME",
+                "description": "SASL username for authentication.",
+                "isRequired": false,
+                "isSecret": false
+              },
+              {
+                "name": "KAFKA_SASL_PASSWORD",
+                "description": "SASL password for authentication.",
+                "isRequired": false,
+                "isSecret": true
+              },
+              {
+                "name": "KAFKA_CLIENT_ID",
+                "description": "Client ID reported to the broker.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "mcp-server-kafka"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv/mcp-server-mongodb",
+        "description": "Perform CRUD operations and aggregations on MongoDB collections.",
+        "title": "MongoDB MCP Server",
+        "version": "0.7.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv/mcp-server-mongodb",
+            "version": "0.7.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "MONGODB_CONNECTION_STRING",
+                "description": "MongoDB connection string including username, password, and database.",
                 "isRequired": true,
                 "isSecret": true
               },
               {
-                "name": "REGION",
-                "description": "AWS region",
-                "isRequired": false,
-                "isSecret": false,
-                "value": "us-east-1"
-              },
-              {
-                "name": "ENDPOINT",
-                "description": "Custom endpoint URL",
+                "name": "MONGODB_DATABASE",
+                "description": "Default database to connect to.",
                 "isRequired": false,
                 "isSecret": false
               }
@@ -195,19 +1141,37 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/icon-server",
-        "description": "An npm server with an icon.",
-        "title": "Icon Server",
+        "name": "io.github.multienv/mcp-server-supabase",
+        "description": "Interact with Supabase databases, auth, and storage buckets.",
+        "title": "Supabase MCP Server",
         "version": "1.0.0",
-        "icons": [
-          { "src": "https://example.com/icon.png" }
-        ],
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "icon-mcp",
+            "identifier": "@multienv/mcp-server-supabase",
             "version": "1.0.0",
-            "transport": { "type": "stdio" }
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "SUPABASE_URL",
+                "description": "Your Supabase project URL.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "SUPABASE_SERVICE_ROLE_KEY",
+                "description": "Supabase service role key with full access.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "SUPABASE_SCHEMA",
+                "description": "Default schema to use for database queries.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "public"
+              }
+            ]
           }
         ]
       }
@@ -215,30 +1179,838 @@
     {
       "server": {
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-        "name": "io.github.user/complex-server",
-        "description": "An npm server with complex config.",
-        "title": "Complex Server",
-        "version": "2.1.0",
+        "name": "io.github.clitools/mcp-server-stdio-runner",
+        "description": "Run arbitrary shell commands and return their stdout and stderr.",
+        "title": "Shell Runner MCP Server",
+        "version": "0.4.0",
         "packages": [
           {
             "registryType": "npm",
-            "identifier": "@complex/mcp-tools",
-            "version": "2.1.0",
-            "transport": { "type": "stdio" },
+            "identifier": "@clitools/mcp-server-stdio-runner",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
             "packageArguments": [
-              {
-                "type": "positional",
-                "value": "serve"
-              },
-              {
-                "type": "positional",
-                "value": "--stdio"
-              }
-            ],
+              {"type": "positional", "value": "--stdio"},
+              {"type": "positional", "value": "--allow-all"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.clitools/mcp-server-serve",
+        "description": "Start a local static file server and expose directory contents.",
+        "title": "Serve MCP Server",
+        "version": "2.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@clitools/mcp-server-serve",
+            "version": "2.0.0",
+            "transport": {"type": "stdio"},
+            "packageArguments": [
+              {"type": "positional", "value": "serve"},
+              {"type": "positional", "value": "--stdio"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.clitools/mcp-server-watch",
+        "description": "Watch the filesystem for changes and emit events.",
+        "title": "Watch MCP Server",
+        "version": "1.0.2",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@clitools/mcp-server-watch",
+            "version": "1.0.2",
+            "transport": {"type": "stdio"},
+            "packageArguments": [
+              {"type": "positional", "value": "watch"},
+              {"type": "positional", "value": "--recursive"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.clitools/mcp-server-build",
+        "description": "Trigger and monitor build pipelines from an AI assistant.",
+        "title": "Build MCP Server",
+        "version": "0.9.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@clitools/mcp-server-build",
+            "version": "0.9.0",
+            "transport": {"type": "stdio"},
+            "packageArguments": [
+              {"type": "positional", "value": "--mode"},
+              {"type": "positional", "value": "stdio"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.clitools/mcp-server-lint",
+        "description": "Run linters on code files and report issues and auto-fix suggestions.",
+        "title": "Lint MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@clitools/mcp-server-lint",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "packageArguments": [
+              {"type": "positional", "value": "--stdio"},
+              {"type": "positional", "value": "--format"},
+              {"type": "positional", "value": "json"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.clitools/mcp-server-test-runner",
+        "description": "Execute test suites and return structured results.",
+        "title": "Test Runner MCP Server",
+        "version": "1.1.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@clitools/mcp-server-test-runner",
+            "version": "1.1.0",
+            "transport": {"type": "stdio"},
+            "packageArguments": [
+              {"type": "positional", "value": "run"},
+              {"type": "positional", "value": "--reporter"},
+              {"type": "positional", "value": "json"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.clitools/mcp-server-format",
+        "description": "Auto-format source code using Prettier, gofmt, or black.",
+        "title": "Format MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@clitools/mcp-server-format",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"},
+            "packageArguments": [
+              {"type": "positional", "value": "--stdio"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.remote/mcp-server-search-hybrid",
+        "description": "Search the web using both an npm fallback and a hosted streaming HTTP endpoint.",
+        "title": "Hybrid Search MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@remote/mcp-server-search-hybrid",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"},
             "environmentVariables": [
               {
-                "name": "SERVICE_KEY",
-                "description": "Service key",
+                "name": "SEARCH_API_KEY",
+                "description": "API key for the search service.",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ],
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "https://api.search-service.example.com/mcp"
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.remote/mcp-server-vector-db",
+        "description": "Query a vector database with both a local npm client and a cloud fallback.",
+        "title": "Vector DB MCP Server",
+        "version": "0.8.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@remote/mcp-server-vector-db",
+            "version": "0.8.0",
+            "transport": {"type": "stdio"}
+          }
+        ],
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "https://vectors.example.io/mcp"
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.remote/mcp-server-llm-gateway",
+        "description": "Route requests to multiple LLM providers via a hosted gateway or local proxy.",
+        "title": "LLM Gateway MCP Server",
+        "version": "1.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@remote/mcp-server-llm-gateway",
+            "version": "1.2.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "GATEWAY_ENDPOINT",
+                "description": "URL of the local or self-hosted gateway endpoint.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "http://localhost:8080"
+              }
+            ]
+          }
+        ],
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "https://llm-gateway.example.com/mcp"
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.remote/mcp-server-rag",
+        "description": "Retrieval-augmented generation server with local embedding and remote retrieval.",
+        "title": "RAG MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@remote/mcp-server-rag",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"}
+          }
+        ],
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "https://rag.example.com/mcp/v1"
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.remote/mcp-server-code-execution",
+        "description": "Execute code snippets remotely in a sandboxed environment.",
+        "title": "Code Execution MCP Server",
+        "version": "0.9.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@remote/mcp-server-code-execution",
+            "version": "0.9.0",
+            "transport": {"type": "stdio"}
+          }
+        ],
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "https://sandbox.coderunner.example.net/mcp"
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.iconpack/mcp-server-git",
+        "description": "Perform Git operations: commit, diff, log, and branch management.",
+        "title": "Git MCP Server",
+        "version": "1.0.0",
+        "icons": [
+          {"src": "https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png"}
+        ],
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@iconpack/mcp-server-git",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.iconpack/mcp-server-docker",
+        "description": "Manage Docker containers, images, volumes, and networks.",
+        "title": "Docker MCP Server",
+        "version": "0.7.0",
+        "icons": [
+          {"src": "https://www.docker.com/wp-content/uploads/2022/03/Moby-logo.png"}
+        ],
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@iconpack/mcp-server-docker",
+            "version": "0.7.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.iconpack/mcp-server-kubernetes",
+        "description": "Inspect and manage Kubernetes pods, deployments, services, and namespaces.",
+        "title": "Kubernetes MCP Server",
+        "version": "0.5.0",
+        "icons": [
+          {"src": "https://kubernetes.io/images/kubernetes-horizontal-color.png"}
+        ],
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@iconpack/mcp-server-kubernetes",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.iconpack/mcp-server-terraform",
+        "description": "Plan and apply Terraform configurations from an AI assistant.",
+        "title": "Terraform MCP Server",
+        "version": "0.3.0",
+        "icons": [
+          {"src": "https://www.terraform.io/assets/images/og-image-8b3e4f7d.png"}
+        ],
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@iconpack/mcp-server-terraform",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.iconpack/mcp-server-ansible",
+        "description": "Run Ansible playbooks and inventory queries.",
+        "title": "Ansible MCP Server",
+        "version": "0.2.0",
+        "icons": [
+          {"src": "https://www.ansible.com/hubfs/2016_Images/Assets/Ansible-Mark-Large-RGB-Pool.png"}
+        ],
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@iconpack/mcp-server-ansible",
+            "version": "0.2.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.noversion/mcp-server-graphql",
+        "description": "Introspect and query GraphQL endpoints.",
+        "title": "GraphQL MCP Server",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@noversion/mcp-server-graphql",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.noversion/mcp-server-grpc",
+        "description": "Call gRPC services using reflection or provided proto definitions.",
+        "title": "gRPC MCP Server",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@noversion/mcp-server-grpc",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.noversion/mcp-server-rest-client",
+        "description": "Issue HTTP requests and inspect responses for any REST API.",
+        "title": "REST Client MCP Server",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@noversion/mcp-server-rest-client",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.noversion/mcp-server-openapi-explorer",
+        "description": "Load an OpenAPI spec and explore endpoints, schemas, and examples.",
+        "title": "OpenAPI Explorer MCP Server",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@noversion/mcp-server-openapi-explorer",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.noversion/mcp-server-proto-tools",
+        "description": "Encode and decode Protobuf messages given a .proto schema.",
+        "title": "Proto Tools MCP Server",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@noversion/mcp-server-proto-tools",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.useroverride/mcp-server-node-script",
+        "description": "Run arbitrary Node.js scripts as an unprivileged user.",
+        "title": "Node Script MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@useroverride/mcp-server-node-script",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-u", "value": "node"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.useroverride/mcp-server-sandbox",
+        "description": "Sandboxed execution environment running as a restricted user.",
+        "title": "Sandbox MCP Server",
+        "version": "0.6.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@useroverride/mcp-server-sandbox",
+            "version": "0.6.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-u", "value": "nobody"},
+              {"type": "named", "name": "--read-only", "value": ""}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.useroverride/mcp-server-rootless",
+        "description": "Run an MCP server process as a non-root user inside the container.",
+        "title": "Rootless MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@useroverride/mcp-server-rootless",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-u", "value": "1001:1001"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.useroverride/mcp-server-ci-runner",
+        "description": "CI-oriented MCP server running as the ci user for reproducible builds.",
+        "title": "CI Runner MCP Server",
+        "version": "0.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@useroverride/mcp-server-ci-runner",
+            "version": "0.2.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-u", "value": "ci"},
+              {"type": "named", "name": "-e", "value": "CI=true"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.useroverride/mcp-server-daemon",
+        "description": "Long-lived MCP server daemon running as a dedicated service account.",
+        "title": "Daemon MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@useroverride/mcp-server-daemon",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-u", "value": "daemon"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.volumes/mcp-server-data-processor",
+        "description": "Process large data files from a mounted host volume.",
+        "title": "Data Processor MCP Server",
+        "version": "1.0.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@volumes/mcp-server-data-processor",
+            "version": "1.0.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-v", "value": "/data:/data"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.volumes/mcp-server-config-reader",
+        "description": "Read application configuration from a bind-mounted directory.",
+        "title": "Config Reader MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@volumes/mcp-server-config-reader",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-v", "value": "/etc/myapp:/config:ro"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.volumes/mcp-server-workspace",
+        "description": "Operate on a shared workspace directory via bind mount.",
+        "title": "Workspace MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@volumes/mcp-server-workspace",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-v", "value": "/workspace:/workspace"},
+              {"type": "named", "name": "-w", "value": "/workspace"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.volumes/mcp-server-log-analyzer",
+        "description": "Analyze application logs from a host path mounted read-only.",
+        "title": "Log Analyzer MCP Server",
+        "version": "0.7.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@volumes/mcp-server-log-analyzer",
+            "version": "0.7.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-v", "value": "/var/log/myapp:/logs:ro"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.volumes/mcp-server-db-backup",
+        "description": "Read database backup files from a mounted network-attached storage volume.",
+        "title": "DB Backup Reader MCP Server",
+        "version": "0.2.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@volumes/mcp-server-db-backup",
+            "version": "0.2.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-v", "value": "/mnt/nas/backups:/backups:ro"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-vault",
+        "description": "Read and write secrets in a HashiCorp Vault instance.",
+        "title": "Vault MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-vault",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "VAULT_ADDR",
+                "description": "Address of the Vault server.",
+                "isRequired": true,
+                "isSecret": false,
+                "value": "http://127.0.0.1:8200"
+              },
+              {
+                "name": "VAULT_TOKEN",
+                "description": "Vault authentication token.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "VAULT_NAMESPACE",
+                "description": "Vault namespace to use.",
+                "isRequired": false,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-splunk",
+        "description": "Search and alert on Splunk indexes and dashboards.",
+        "title": "Splunk MCP Server",
+        "version": "0.6.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-splunk",
+            "version": "0.6.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "SPLUNK_HOST",
+                "description": "Splunk instance hostname.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "SPLUNK_PORT",
+                "description": "Splunk REST API port.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "8089"
+              },
+              {
+                "name": "SPLUNK_TOKEN",
+                "description": "Splunk authentication token.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "SPLUNK_INDEX",
+                "description": "Default Splunk index to search.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "main"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-prometheus",
+        "description": "Query Prometheus metrics using PromQL.",
+        "title": "Prometheus MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-prometheus",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "PROMETHEUS_URL",
+                "description": "Base URL of the Prometheus server.",
+                "isRequired": true,
+                "isSecret": false,
+                "value": "http://localhost:9090"
+              },
+              {
+                "name": "PROMETHEUS_BEARER_TOKEN",
+                "description": "Bearer token for Prometheus authentication.",
+                "isRequired": false,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-grafana",
+        "description": "Query Grafana dashboards and panels, and manage alerts.",
+        "title": "Grafana MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-grafana",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "GRAFANA_URL",
+                "description": "Grafana instance base URL.",
+                "isRequired": true,
+                "isSecret": false,
+                "value": "http://localhost:3000"
+              },
+              {
+                "name": "GRAFANA_API_KEY",
+                "description": "Grafana service account API key.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "GRAFANA_ORG_ID",
+                "description": "Grafana organization ID.",
+                "isRequired": false,
+                "isSecret": false,
+                "value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-okta",
+        "description": "Manage Okta users, groups, and applications.",
+        "title": "Okta MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-okta",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "OKTA_DOMAIN",
+                "description": "Your Okta organization domain, e.g. mycompany.okta.com.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "OKTA_API_TOKEN",
+                "description": "Okta API token with required scopes.",
                 "isRequired": true,
                 "isSecret": true
               }
@@ -246,9 +2018,275 @@
           }
         ]
       }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-auth0",
+        "description": "Manage Auth0 users, roles, and connections.",
+        "title": "Auth0 MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-auth0",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "AUTH0_DOMAIN",
+                "description": "Your Auth0 tenant domain.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "AUTH0_CLIENT_ID",
+                "description": "Auth0 machine-to-machine application client ID.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "AUTH0_CLIENT_SECRET",
+                "description": "Auth0 machine-to-machine application client secret.",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-cloudflare",
+        "description": "Manage Cloudflare DNS records, workers, and KV namespaces.",
+        "title": "Cloudflare MCP Server",
+        "version": "0.5.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-cloudflare",
+            "version": "0.5.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "CLOUDFLARE_API_TOKEN",
+                "description": "Cloudflare API token with zone and worker permissions.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "CLOUDFLARE_ACCOUNT_ID",
+                "description": "Cloudflare account ID.",
+                "isRequired": true,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-vercel",
+        "description": "Deploy and manage Vercel projects, domains, and environment variables.",
+        "title": "Vercel MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-vercel",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "VERCEL_TOKEN",
+                "description": "Vercel personal access token.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "VERCEL_TEAM_ID",
+                "description": "Team ID for team-scoped operations.",
+                "isRequired": false,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-netlify",
+        "description": "Manage Netlify sites, deploys, and forms.",
+        "title": "Netlify MCP Server",
+        "version": "0.3.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-netlify",
+            "version": "0.3.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "NETLIFY_AUTH_TOKEN",
+                "description": "Netlify personal access token.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "NETLIFY_SITE_ID",
+                "description": "Default site ID for operations.",
+                "isRequired": false,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-sentry",
+        "description": "Triage Sentry issues, releases, and performance spans.",
+        "title": "Sentry MCP Server",
+        "version": "0.6.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-sentry",
+            "version": "0.6.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "SENTRY_AUTH_TOKEN",
+                "description": "Sentry authentication token.",
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "SENTRY_ORG",
+                "description": "Sentry organization slug.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "SENTRY_PROJECT",
+                "description": "Default Sentry project slug.",
+                "isRequired": false,
+                "isSecret": false
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-yaml-validator",
+        "description": "Validate and pretty-print YAML documents.",
+        "title": "YAML Validator MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-yaml-validator",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-json-schema",
+        "description": "Validate JSON documents against a JSON Schema and report errors.",
+        "title": "JSON Schema Validator MCP Server",
+        "version": "0.3.1",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-json-schema",
+            "version": "0.3.1",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.basictools/mcp-server-csv-parser",
+        "description": "Parse CSV files and run column-level queries and transformations.",
+        "title": "CSV Parser MCP Server",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "mcp-server-csv-parser",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.multienv2/mcp-server-firebase",
+        "description": "Read and write Firebase Firestore documents and Realtime Database nodes.",
+        "title": "Firebase MCP Server",
+        "version": "0.4.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@multienv2/mcp-server-firebase",
+            "version": "0.4.0",
+            "transport": {"type": "stdio"},
+            "environmentVariables": [
+              {
+                "name": "FIREBASE_PROJECT_ID",
+                "description": "Firebase project ID.",
+                "isRequired": true,
+                "isSecret": false
+              },
+              {
+                "name": "FIREBASE_SERVICE_ACCOUNT_KEY",
+                "description": "JSON-encoded service account key for Firebase Admin SDK.",
+                "isRequired": true,
+                "isSecret": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+        "name": "io.github.volumes/mcp-server-model-weights",
+        "description": "Serve local ML model weights from a bind-mounted model directory.",
+        "title": "Model Weights MCP Server",
+        "version": "0.1.0",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@volumes/mcp-server-model-weights",
+            "version": "0.1.0",
+            "transport": {"type": "stdio"},
+            "runtimeArguments": [
+              {"type": "named", "name": "-v", "value": "/models:/models:ro"},
+              {"type": "named", "name": "-u", "value": "nobody"}
+            ]
+          }
+        ]
+      }
     }
   ],
-  "metadata": {
-    "count": 10
-  }
+  "metadata": {"count": 100}
 }

--- a/pkg/catalog_next/create.go
+++ b/pkg/catalog_next/create.go
@@ -21,7 +21,19 @@ import (
 	"github.com/docker/mcp-gateway/pkg/workingset"
 )
 
-func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, ociService oci.Service, refStr string, servers []string, workingSetID string, legacyCatalogURL string, communityRegistryRef string, title string, includePyPI bool, excludeServers []string) error {
+// CreateOptions configures catalog creation behavior.
+type CreateOptions struct {
+	Servers              []string
+	WorkingSetID         string
+	LegacyCatalogURL     string
+	CommunityRegistryRef string
+	Title                string
+	IncludePyPI          bool
+	IncludeNPM           bool
+	ExcludeServers       []string
+}
+
+func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, ociService oci.Service, refStr string, opts CreateOptions) error {
 	telemetry.Init()
 	start := time.Now()
 	var success bool
@@ -38,30 +50,30 @@ func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, 
 	}
 
 	var catalog Catalog
-	if workingSetID != "" {
-		catalog, err = createCatalogFromWorkingSet(ctx, dao, workingSetID)
+	if opts.WorkingSetID != "" {
+		catalog, err = createCatalogFromWorkingSet(ctx, dao, opts.WorkingSetID)
 		if err != nil {
 			return fmt.Errorf("failed to create catalog from profile: %w", err)
 		}
-	} else if legacyCatalogURL != "" {
-		catalog, err = createCatalogFromLegacyCatalog(ctx, legacyCatalogURL)
+	} else if opts.LegacyCatalogURL != "" {
+		catalog, err = createCatalogFromLegacyCatalog(ctx, opts.LegacyCatalogURL)
 		if err != nil {
 			return fmt.Errorf("failed to create catalog from legacy catalog: %w", err)
 		}
-	} else if communityRegistryRef != "" {
-		catalog, err = createCatalogFromCommunityRegistry(ctx, registryClient, communityRegistryRef, includePyPI, excludeServers)
+	} else if opts.CommunityRegistryRef != "" {
+		catalog, err = createCatalogFromCommunityRegistry(ctx, registryClient, opts.CommunityRegistryRef, opts.IncludePyPI, opts.IncludeNPM, opts.ExcludeServers)
 		if err != nil {
 			return fmt.Errorf("failed to create catalog from community registry: %w", err)
 		}
 	} else {
 		// Construct from servers
-		if title == "" {
+		if opts.Title == "" {
 			return fmt.Errorf("title is required when creating a catalog without using an existing legacy catalog, profile, or community registry")
 		}
 		catalog = Catalog{
 			CatalogArtifact: CatalogArtifact{
-				Title:   title,
-				Servers: make([]Server, 0, len(servers)),
+				Title:   opts.Title,
+				Servers: make([]Server, 0, len(opts.Servers)),
 			},
 			Source: SourcePrefixUser + "cli",
 		}
@@ -69,11 +81,11 @@ func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, 
 
 	catalog.Ref = oci.FullNameWithoutDigest(ref)
 
-	if title != "" {
-		catalog.Title = title
+	if opts.Title != "" {
+		catalog.Title = opts.Title
 	}
 
-	if err := addServersToCatalog(ctx, dao, registryClient, ociService, &catalog, servers); err != nil {
+	if err := addServersToCatalog(ctx, dao, registryClient, ociService, &catalog, opts.Servers); err != nil {
 		return err
 	}
 
@@ -203,13 +215,14 @@ type communityRegistryResult struct {
 	serversAdded   int
 	serversOCI     int
 	serversPyPI    int
+	serversNPM     int
 	serversRemote  int
 	serversSkipped int
 	totalServers   int
 	skippedByType  map[string]int
 }
 
-func createCatalogFromCommunityRegistry(ctx context.Context, registryClient registryapi.Client, registryRef string, includePyPI bool, excludeServers []string) (Catalog, error) {
+func createCatalogFromCommunityRegistry(ctx context.Context, registryClient registryapi.Client, registryRef string, includePyPI bool, includeNPM bool, excludeServers []string) (Catalog, error) {
 	baseURL := "https://" + registryRef
 	servers, err := registryClient.ListServers(ctx, baseURL, "")
 	if err != nil {
@@ -218,7 +231,7 @@ func createCatalogFromCommunityRegistry(ctx context.Context, registryClient regi
 
 	catalogServers := make([]Server, 0)
 	skippedByType := make(map[string]int)
-	var ociCount, remoteCount, pypiCount int
+	var ociCount, remoteCount, pypiCount, npmCount int
 
 	for _, serverResp := range servers {
 		if slices.Contains(excludeServers, serverResp.Server.Name) {
@@ -226,7 +239,12 @@ func createCatalogFromCommunityRegistry(ctx context.Context, registryClient regi
 			continue
 		}
 
-		catalogServer, transformSource, err := legacycatalog.TransformToDocker(ctx, serverResp.Server, legacycatalog.WithAllowPyPI(includePyPI), legacycatalog.WithPyPIResolver(legacycatalog.DefaultPyPIVersionResolver()))
+		catalogServer, transformSource, err := legacycatalog.TransformToDocker(ctx, serverResp.Server,
+			legacycatalog.WithAllowPyPI(includePyPI),
+			legacycatalog.WithPyPIResolver(legacycatalog.DefaultPyPIVersionResolver()),
+			legacycatalog.WithAllowNPM(includeNPM),
+			legacycatalog.WithNPMResolver(legacycatalog.DefaultNPMVersionResolver()),
+		)
 		if err != nil {
 			if !errors.Is(err, legacycatalog.ErrIncompatibleServer) {
 				fmt.Fprintf(os.Stderr, "Warning: failed to transform server %q: %v\n", serverResp.Server.Name, err)
@@ -251,6 +269,8 @@ func createCatalogFromCommunityRegistry(ctx context.Context, registryClient regi
 			switch transformSource {
 			case legacycatalog.TransformSourcePyPI:
 				pypiCount++
+			case legacycatalog.TransformSourceNPM:
+				npmCount++
 			default:
 				ociCount++
 			}
@@ -284,12 +304,13 @@ func createCatalogFromCommunityRegistry(ctx context.Context, registryClient regi
 		serversAdded:   len(catalogServers),
 		serversOCI:     ociCount,
 		serversPyPI:    pypiCount,
+		serversNPM:     npmCount,
 		serversRemote:  remoteCount,
 		serversSkipped: totalSkipped(skippedByType),
 		totalServers:   len(servers),
 		skippedByType:  skippedByType,
 	}
-	printCommunityRegistryResult(registryRef, result, includePyPI)
+	printCommunityRegistryResult(registryRef, result, includePyPI, includeNPM)
 
 	return Catalog{
 		CatalogArtifact: CatalogArtifact{
@@ -308,13 +329,16 @@ func totalSkipped(skippedByType map[string]int) int {
 	return total
 }
 
-func printCommunityRegistryResult(refStr string, result communityRegistryResult, includePyPI bool) {
+func printCommunityRegistryResult(refStr string, result communityRegistryResult, includePyPI bool, includeNPM bool) {
 	fmt.Fprintf(os.Stderr, "Fetched %d servers from %s\n", result.serversAdded, refStr)
 	fmt.Fprintf(os.Stderr, "  Total in registry: %d\n", result.totalServers)
 	fmt.Fprintf(os.Stderr, "  Imported:          %d\n", result.serversAdded)
 	fmt.Fprintf(os.Stderr, "    OCI (stdio):     %d\n", result.serversOCI)
 	if includePyPI {
 		fmt.Fprintf(os.Stderr, "    PyPI (stdio):    %d\n", result.serversPyPI)
+	}
+	if includeNPM {
+		fmt.Fprintf(os.Stderr, "    npm (stdio):     %d\n", result.serversNPM)
 	}
 	fmt.Fprintf(os.Stderr, "    Remote:          %d\n", result.serversRemote)
 	fmt.Fprintf(os.Stderr, "  Skipped:           %d\n", result.serversSkipped)

--- a/pkg/catalog_next/create.go
+++ b/pkg/catalog_next/create.go
@@ -9,9 +9,11 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"golang.org/x/sync/errgroup"
 
 	legacycatalog "github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/db"
@@ -229,71 +231,111 @@ func createCatalogFromCommunityRegistry(ctx context.Context, registryClient regi
 		return Catalog{}, fmt.Errorf("failed to fetch servers from community registry: %w", err)
 	}
 
-	catalogServers := make([]Server, 0)
+	// Create resolvers once (they share an HTTP client internally).
+	pypiResolver := legacycatalog.DefaultPyPIVersionResolver()
+	npmResolver := legacycatalog.DefaultNPMVersionResolver()
+
+	transformOpts := []legacycatalog.TransformOption{
+		legacycatalog.WithAllowPyPI(includePyPI),
+		legacycatalog.WithPyPIResolver(pypiResolver),
+		legacycatalog.WithAllowNPM(includeNPM),
+		legacycatalog.WithNPMResolver(npmResolver),
+	}
+
+	type transformResult struct {
+		server Server
+		source legacycatalog.TransformSource
+	}
+
+	results := make([]transformResult, len(servers))
+	resultValid := make([]bool, len(servers))
+
+	var mu sync.Mutex
 	skippedByType := make(map[string]int)
 	var ociCount, remoteCount, pypiCount, npmCount int
 
-	for _, serverResp := range servers {
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(12)
+
+	for i, serverResp := range servers {
 		if slices.Contains(excludeServers, serverResp.Server.Name) {
+			mu.Lock()
 			skippedByType["excluded"]++
+			mu.Unlock()
 			continue
 		}
 
-		catalogServer, transformSource, err := legacycatalog.TransformToDocker(ctx, serverResp.Server,
-			legacycatalog.WithAllowPyPI(includePyPI),
-			legacycatalog.WithPyPIResolver(legacycatalog.DefaultPyPIVersionResolver()),
-			legacycatalog.WithAllowNPM(includeNPM),
-			legacycatalog.WithNPMResolver(legacycatalog.DefaultNPMVersionResolver()),
-		)
-		if err != nil {
-			if !errors.Is(err, legacycatalog.ErrIncompatibleServer) {
-				fmt.Fprintf(os.Stderr, "Warning: failed to transform server %q: %v\n", serverResp.Server.Name, err)
+		g.Go(func() error {
+			catalogServer, transformSource, err := legacycatalog.TransformToDocker(gctx, serverResp.Server, transformOpts...)
+			if err != nil {
+				mu.Lock()
+				if !errors.Is(err, legacycatalog.ErrIncompatibleServer) {
+					fmt.Fprintf(os.Stderr, "Warning: failed to transform server %q: %v\n", serverResp.Server.Name, err)
+				}
+				if len(serverResp.Server.Packages) > 0 {
+					skippedByType[serverResp.Server.Packages[0].RegistryType]++
+				} else {
+					skippedByType["none"]++
+				}
+				mu.Unlock()
+				return nil
 			}
-			if len(serverResp.Server.Packages) > 0 {
-				skippedByType[serverResp.Server.Packages[0].RegistryType]++
-			} else {
-				skippedByType["none"]++
+
+			if catalogServer.Metadata == nil {
+				catalogServer.Metadata = &legacycatalog.Metadata{}
 			}
-			continue
-		}
+			catalogServer.Metadata.Tags = appendIfMissing(catalogServer.Metadata.Tags, "community")
 
-		// Tag with "community" for source identification
-		if catalogServer.Metadata == nil {
-			catalogServer.Metadata = &legacycatalog.Metadata{}
-		}
-		catalogServer.Metadata.Tags = appendIfMissing(catalogServer.Metadata.Tags, "community")
-
-		var s Server
-		switch catalogServer.Type {
-		case "server":
-			switch transformSource {
-			case legacycatalog.TransformSourcePyPI:
-				pypiCount++
-			case legacycatalog.TransformSourceNPM:
-				npmCount++
+			var s Server
+			switch catalogServer.Type {
+			case "server":
+				mu.Lock()
+				switch transformSource {
+				case legacycatalog.TransformSourcePyPI:
+					pypiCount++
+				case legacycatalog.TransformSourceNPM:
+					npmCount++
+				default:
+					ociCount++
+				}
+				mu.Unlock()
+				s = Server{
+					Type:  workingset.ServerTypeImage,
+					Image: catalogServer.Image,
+					Snapshot: &workingset.ServerSnapshot{
+						Server: *catalogServer,
+					},
+				}
+			case "remote":
+				mu.Lock()
+				remoteCount++
+				mu.Unlock()
+				s = Server{
+					Type:     workingset.ServerTypeRemote,
+					Endpoint: catalogServer.Remote.URL,
+					Snapshot: &workingset.ServerSnapshot{
+						Server: *catalogServer,
+					},
+				}
 			default:
-				ociCount++
+				return nil
 			}
-			s = Server{
-				Type:  workingset.ServerTypeImage,
-				Image: catalogServer.Image,
-				Snapshot: &workingset.ServerSnapshot{
-					Server: *catalogServer,
-				},
-			}
-		case "remote":
-			remoteCount++
-			s = Server{
-				Type:     workingset.ServerTypeRemote,
-				Endpoint: catalogServer.Remote.URL,
-				Snapshot: &workingset.ServerSnapshot{
-					Server: *catalogServer,
-				},
-			}
-		default:
-			continue
+
+			results[i] = transformResult{server: s, source: transformSource}
+			resultValid[i] = true
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return Catalog{}, fmt.Errorf("failed to transform servers: %w", err)
+	}
+
+	catalogServers := make([]Server, 0, len(servers))
+	for i := range results {
+		if resultValid[i] {
+			catalogServers = append(catalogServers, results[i].server)
 		}
-		catalogServers = append(catalogServers, s)
 	}
 
 	slices.SortStableFunc(catalogServers, func(a, b Server) int {

--- a/pkg/catalog_next/create_test.go
+++ b/pkg/catalog_next/create_test.go
@@ -45,7 +45,10 @@ func TestCreateFromWorkingSet(t *testing.T) {
 
 	// Capture stdout to verify the output message
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog:latest", []string{}, "test-ws", "", "", "My Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog:latest", CreateOptions{
+			WorkingSetID: "test-ws",
+			Title:        "My Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -88,7 +91,10 @@ func TestCreateFromWorkingSetNormalizedRef(t *testing.T) {
 
 	// Capture stdout to verify the output message
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "docker.io/test/catalog:latest", []string{}, "test-ws", "", "", "My Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "docker.io/test/catalog:latest", CreateOptions{
+			WorkingSetID: "test-ws",
+			Title:        "My Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -119,7 +125,10 @@ func TestCreateFromWorkingSetRejectsDigestReference(t *testing.T) {
 	require.NoError(t, err)
 
 	digestRef := "test/catalog@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-	err = Create(ctx, dao, getMockRegistryClient(), getMockOciService(), digestRef, []string{}, "test-ws", "", "", "My Catalog", false, nil)
+	err = Create(ctx, dao, getMockRegistryClient(), getMockOciService(), digestRef, CreateOptions{
+		WorkingSetID: "test-ws",
+		Title:        "My Catalog",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reference must be a valid OCI reference without a digest")
 }
@@ -146,7 +155,9 @@ func TestCreateFromWorkingSetWithEmptyName(t *testing.T) {
 
 	// Create catalog without providing a title (should use working set name)
 	captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog2:latest", []string{}, "test-ws", "", "", "", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog2:latest", CreateOptions{
+			WorkingSetID: "test-ws",
+		})
 		require.NoError(t, err)
 	})
 
@@ -163,7 +174,10 @@ func TestCreateFromWorkingSetNotFound(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog3:latest", []string{}, "nonexistent-ws", "", "", "Test", false, nil)
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog3:latest", CreateOptions{
+		WorkingSetID: "nonexistent-ws",
+		Title:        "Test",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "profile nonexistent-ws not found")
 }
@@ -190,12 +204,18 @@ func TestCreateFromWorkingSetDuplicate(t *testing.T) {
 
 	// Create catalog from working set
 	captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog4:latest", []string{}, "test-ws", "", "", "Test", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog4:latest", CreateOptions{
+			WorkingSetID: "test-ws",
+			Title:        "Test",
+		})
 		require.NoError(t, err)
 	})
 
 	// Create with same ref again - should succeed and replace (upsert behavior)
-	err = Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog4:latest", []string{}, "test-ws", "", "", "Test Updated", false, nil)
+	err = Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog4:latest", CreateOptions{
+		WorkingSetID: "test-ws",
+		Title:        "Test Updated",
+	})
 	require.NoError(t, err)
 
 	// Verify it was updated
@@ -238,7 +258,10 @@ func TestCreateFromWorkingSetWithSnapshot(t *testing.T) {
 
 	// Create catalog from working set
 	captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog5:latest", []string{}, "test-ws", "", "", "Test", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog5:latest", CreateOptions{
+			WorkingSetID: "test-ws",
+			Title:        "Test",
+		})
 		require.NoError(t, err)
 	})
 
@@ -270,7 +293,10 @@ func TestCreateFromWorkingSetEmptyServers(t *testing.T) {
 
 	// Create catalog from empty working set
 	captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog7:latest", []string{}, "empty-ws", "", "", "Empty Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog7:latest", CreateOptions{
+			WorkingSetID: "empty-ws",
+			Title:        "Empty Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -320,7 +346,10 @@ func TestCreateFromWorkingSetPreservesAllServerFields(t *testing.T) {
 
 	// Create catalog
 	captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog8:latest", []string{}, "detailed-ws", "", "", "Detailed Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog8:latest", CreateOptions{
+			WorkingSetID: "detailed-ws",
+			Title:        "Detailed Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -375,7 +404,10 @@ registry:
 
 	// Create catalog from legacy catalog
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/imported:latest", []string{}, "", catalogFile, "", "Imported Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/imported:latest", CreateOptions{
+			LegacyCatalogURL: catalogFile,
+			Title:            "Imported Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -426,7 +458,10 @@ registry:
 
 	// Create catalog from legacy catalog (first time)
 	output1 := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy3:latest", []string{}, "", catalogFile, "", "Test Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy3:latest", CreateOptions{
+			LegacyCatalogURL: catalogFile,
+			Title:            "Test Catalog",
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output1, "test/legacy3:latest created")
@@ -439,7 +474,10 @@ registry:
 
 	// Create with same ref again (upsert) - should replace
 	output2 := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy3:latest", []string{}, "", catalogFile, "", "Test Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy3:latest", CreateOptions{
+			LegacyCatalogURL: catalogFile,
+			Title:            "Test Catalog",
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output2, "test/legacy3:latest created")
@@ -477,7 +515,10 @@ registry:
 
 	// Create catalog from legacy catalog (first time)
 	output1 := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy4:latest", []string{}, "", catalogFile, "", "Test Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy4:latest", CreateOptions{
+			LegacyCatalogURL: catalogFile,
+			Title:            "Test Catalog",
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output1, "test/legacy4:latest created")
@@ -501,7 +542,10 @@ registry:
 
 	// Create with same ref again (upsert) - should replace with new content
 	output2 := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy4:latest", []string{}, "", catalogFile, "", "Test Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy4:latest", CreateOptions{
+			LegacyCatalogURL: catalogFile,
+			Title:            "Test Catalog",
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output2, "test/legacy4:latest created")
@@ -523,10 +567,13 @@ func TestCreateFromServersWithDockerImages(t *testing.T) {
 	ctx := t.Context()
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/docker-images:latest", []string{
-			"docker://myimage:latest",
-			"docker://anotherimage:v1.0",
-		}, "", "", "", "Docker Images Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/docker-images:latest", CreateOptions{
+			Servers: []string{
+				"docker://myimage:latest",
+				"docker://anotherimage:v1.0",
+			},
+			Title: "Docker Images Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -553,15 +600,21 @@ func TestCreateFromCatalogEntries(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a catalog to pull from
-	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "source-catalog", []string{
-		"docker://myimage:latest",
-	}, "", "", "", "Source Catalog", false, nil)
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "source-catalog", CreateOptions{
+		Servers: []string{
+			"docker://myimage:latest",
+		},
+		Title: "Source Catalog",
+	})
 	require.NoError(t, err)
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "target-catalog", []string{
-			"catalog://source-catalog/My Image",
-		}, "", "", "", "Target Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "target-catalog", CreateOptions{
+			Servers: []string{
+				"catalog://source-catalog/My Image",
+			},
+			Title: "Target Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -584,10 +637,13 @@ func TestCreateFromServersWithRegistryServers(t *testing.T) {
 	ctx := t.Context()
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/registry-servers:latest", []string{
-			"https://example.com/v0/servers/server1",
-			"https://example.com/v0/servers/server2",
-		}, "", "", "", "Registry Servers Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/registry-servers:latest", CreateOptions{
+			Servers: []string{
+				"https://example.com/v0/servers/server1",
+				"https://example.com/v0/servers/server2",
+			},
+			Title: "Registry Servers Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -613,10 +669,13 @@ func TestCreateFromServersWithMixedServers(t *testing.T) {
 	ctx := t.Context()
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/mixed-servers:latest", []string{
-			"docker://myimage:latest",
-			"https://example.com/v0/servers/server1",
-		}, "", "", "", "Mixed Servers Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/mixed-servers:latest", CreateOptions{
+			Servers: []string{
+				"docker://myimage:latest",
+				"https://example.com/v0/servers/server1",
+			},
+			Title: "Mixed Servers Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -638,9 +697,12 @@ func TestCreateFromServersWithInvalidFormat(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/invalid:latest", []string{
-		"invalid-format",
-	}, "", "", "", "Invalid Catalog", false, nil)
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/invalid:latest", CreateOptions{
+		Servers: []string{
+			"invalid-format",
+		},
+		Title: "Invalid Catalog",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid server value")
 }
@@ -650,7 +712,9 @@ func TestCreateFromServersWithEmptyServers(t *testing.T) {
 	ctx := t.Context()
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/empty-servers:latest", []string{}, "", "", "", "Empty Servers Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/empty-servers:latest", CreateOptions{
+			Title: "Empty Servers Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -669,9 +733,11 @@ func TestCreateFromServersRequiresTitle(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/no-title:latest", []string{
-		"docker://myimage:latest",
-	}, "", "", "", "", false, nil)
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/no-title:latest", CreateOptions{
+		Servers: []string{
+			"docker://myimage:latest",
+		},
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "title is required")
 }
@@ -698,9 +764,13 @@ func TestCreateFromServersAddsToExistingWorkingSet(t *testing.T) {
 
 	// Create catalog from working set AND add additional servers
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/combined:latest", []string{
-			"docker://myimage:latest",
-		}, "test-ws", "", "", "Combined Catalog", false, nil)
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/combined:latest", CreateOptions{
+			Servers: []string{
+				"docker://myimage:latest",
+			},
+			WorkingSetID: "test-ws",
+			Title:        "Combined Catalog",
+		})
 		require.NoError(t, err)
 	})
 
@@ -903,7 +973,10 @@ func TestCreateFromLegacyCatalogWithRemotes(t *testing.T) {
 
 			// Create catalog from legacy catalog
 			output := captureStdout(t, func() {
-				err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/imported:latest", []string{}, "", catalogFile, "", "Imported Catalog", false, nil)
+				err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/imported:latest", CreateOptions{
+					LegacyCatalogURL: catalogFile,
+					Title:            "Imported Catalog",
+				})
 				require.NoError(t, err)
 			})
 
@@ -969,7 +1042,7 @@ func TestCreateFromCommunityRegistry(t *testing.T) {
 	npmServer := v0.ServerResponse{
 		Server: v0.ServerJSON{
 			Name:        "io.example/npm-server",
-			Description: "An npm server (incompatible)",
+			Description: "An npm server (excluded because includeNPM=false)",
 			Version:     "1.0.0",
 			Packages: []model.Package{
 				{
@@ -985,7 +1058,10 @@ func TestCreateFromCommunityRegistry(t *testing.T) {
 	)
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, mockClient, getMockOciService(), "test/community:latest", []string{}, "", "", "registry.modelcontextprotocol.io", "MCP Community Registry", false, nil)
+		err := Create(ctx, dao, mockClient, getMockOciService(), "test/community:latest", CreateOptions{
+			CommunityRegistryRef: "registry.modelcontextprotocol.io",
+			Title:                "MCP Community Registry",
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output, "Catalog test/community:latest created")
@@ -998,7 +1074,7 @@ func TestCreateFromCommunityRegistry(t *testing.T) {
 	cat := NewFromDb(&catalogs[0])
 	assert.Equal(t, "MCP Community Registry", cat.Title)
 	assert.Equal(t, "registry:registry.modelcontextprotocol.io", cat.Source)
-	// Should have 2 servers (OCI + remote), npm server should be skipped
+	// Should have 2 servers (OCI + remote), npm server excluded because includeNPM=false
 	require.Len(t, cat.Servers, 2)
 
 	// Servers should be sorted by name
@@ -1064,7 +1140,11 @@ func TestCreateFromCommunityRegistryWithExclusions(t *testing.T) {
 	)
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, mockClient, getMockOciService(), "test/community-excluded:latest", []string{}, "", "", "registry.modelcontextprotocol.io", "MCP Community Registry", false, []string{"io.example/blocked-server"})
+		err := Create(ctx, dao, mockClient, getMockOciService(), "test/community-excluded:latest", CreateOptions{
+			CommunityRegistryRef: "registry.modelcontextprotocol.io",
+			Title:                "MCP Community Registry",
+			ExcludeServers:       []string{"io.example/blocked-server"},
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output, "Catalog test/community-excluded:latest created")
@@ -1157,7 +1237,11 @@ func TestCreateFromCommunityRegistryWithMultipleExclusions(t *testing.T) {
 	excludeList := []string{"io.example/blocked-one", "io.example/blocked-two", "io.example/does-not-exist"}
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, mockClient, getMockOciService(), "test/multi-exclude:latest", []string{}, "", "", "registry.modelcontextprotocol.io", "MCP Community Registry", false, excludeList)
+		err := Create(ctx, dao, mockClient, getMockOciService(), "test/multi-exclude:latest", CreateOptions{
+			CommunityRegistryRef: "registry.modelcontextprotocol.io",
+			Title:                "MCP Community Registry",
+			ExcludeServers:       excludeList,
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output, "Catalog test/multi-exclude:latest created")
@@ -1194,7 +1278,10 @@ func TestCreateFromCommunityRegistryError(t *testing.T) {
 		mocks.WithListServersError(fmt.Errorf("connection refused")),
 	)
 
-	err := Create(ctx, dao, mockClient, getMockOciService(), "test/community:latest", []string{}, "", "", "registry.example.com", "Test", false, nil)
+	err := Create(ctx, dao, mockClient, getMockOciService(), "test/community:latest", CreateOptions{
+		CommunityRegistryRef: "registry.example.com",
+		Title:                "Test",
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create catalog from community registry")
 }
@@ -1222,7 +1309,10 @@ func TestCreateFromCommunityRegistryAllIncompatible(t *testing.T) {
 	)
 
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, mockClient, getMockOciService(), "test/all-skipped:latest", []string{}, "", "", "registry.example.com", "All Skipped", false, nil)
+		err := Create(ctx, dao, mockClient, getMockOciService(), "test/all-skipped:latest", CreateOptions{
+			CommunityRegistryRef: "registry.example.com",
+			Title:                "All Skipped",
+		})
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output, "Catalog test/all-skipped:latest created")

--- a/pkg/workingset/registry_conversion_test.go
+++ b/pkg/workingset/registry_conversion_test.go
@@ -30,7 +30,7 @@ func TestConvertRegistryServerToCatalog_BasicOCI(t *testing.T) {
 		},
 	}
 
-	catalogServer, source, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, source, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	assert.Equal(t, catalog.TransformSourceOCI, source)
@@ -67,7 +67,7 @@ func TestConvertRegistryServerToCatalog_WithIcon(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://example.com/icon.png", catalogServer.Icon)
@@ -110,7 +110,7 @@ func TestConvertRegistryServerToCatalog_WithVolumesAndUser(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	assert.Len(t, catalogServer.Volumes, 1)
@@ -156,7 +156,7 @@ func TestConvertRegistryServerToCatalog_WithVolumeVariables(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	// Volume should be extracted with placeholder converted to {{serverName.var}} format
@@ -214,7 +214,7 @@ func TestConvertRegistryServerToCatalog_WithCommand(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	assert.Len(t, catalogServer.Command, 2)
@@ -261,7 +261,7 @@ func TestConvertRegistryServerToCatalog_WithSecrets(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	assert.Len(t, catalogServer.Secrets, 2)
@@ -309,7 +309,7 @@ func TestConvertRegistryServerToCatalog_WithEnvironmentVariables(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	assert.Len(t, catalogServer.Env, 1)
@@ -364,7 +364,7 @@ func TestConvertRegistryServerToCatalog_WithConfigVariables(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	// Verify Env entry is created with converted placeholders
@@ -451,7 +451,7 @@ func TestConvertRegistryServerToCatalog_MultipleSimpleEnvVars(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	// Should have 1 config item named after server with all properties merged
@@ -487,7 +487,7 @@ func TestConvertRegistryServerToCatalog_MultipleSimpleEnvVars(t *testing.T) {
 	assert.Contains(t, required, "API_URLS")
 }
 
-func TestConvertRegistryServerToCatalog_NoOCIPackages(t *testing.T) {
+func TestConvertRegistryServerToCatalog_NPMWithoutStdioTransport(t *testing.T) {
 	serverResp := &v0.ServerResponse{
 		Server: v0.ServerJSON{
 			Name:        "io.github.user/test",
@@ -502,7 +502,7 @@ func TestConvertRegistryServerToCatalog_NoOCIPackages(t *testing.T) {
 		},
 	}
 
-	_, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	_, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, catalog.ErrIncompatibleServer)
 }
@@ -531,7 +531,7 @@ func TestConvertRegistryServerToCatalog_MultipleOCIPackages(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	// Should return the first OCI package
@@ -560,7 +560,7 @@ func TestConvertRegistryServerToCatalog_MixedPackageTypes(t *testing.T) {
 		},
 	}
 
-	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp, nil)
+	catalogServer, _, err := ConvertRegistryServerToCatalog(t.Context(), serverResp)
 	require.NoError(t, err)
 
 	// Should return the OCI package, ignoring npm

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -464,7 +464,7 @@ func ResolveFile(ctx context.Context, value string) ([]Server, error) {
 				var serverResp v0.ServerResponse
 				if err := json.Unmarshal(buf, &serverResp); err == nil && serverResp.Server.Name != "" {
 					// Successfully parsed as v0.ServerResponse
-					catalogServer, _, err := ConvertRegistryServerToCatalog(ctx, &serverResp, catalog.DefaultPyPIVersionResolver())
+					catalogServer, _, err := ConvertRegistryServerToCatalog(ctx, &serverResp, catalog.WithPyPIResolver(catalog.DefaultPyPIVersionResolver()), catalog.WithNPMResolver(catalog.DefaultNPMVersionResolver()))
 					if err != nil {
 						return nil, fmt.Errorf("failed to convert v0.ServerResponse to catalog.Server: %w", err)
 					}
@@ -477,7 +477,7 @@ func ResolveFile(ctx context.Context, value string) ([]Server, error) {
 						serverResp := &v0.ServerResponse{
 							Server: serverJSON,
 						}
-						catalogServer, _, err := ConvertRegistryServerToCatalog(ctx, serverResp, catalog.DefaultPyPIVersionResolver())
+						catalogServer, _, err := ConvertRegistryServerToCatalog(ctx, serverResp, catalog.WithPyPIResolver(catalog.DefaultPyPIVersionResolver()), catalog.WithNPMResolver(catalog.DefaultNPMVersionResolver()))
 						if err != nil {
 							return nil, fmt.Errorf("failed to convert v0.ServerJSON to catalog.Server: %w", err)
 						}
@@ -626,8 +626,8 @@ func ResolveImageRef(ctx context.Context, ociService oci.Service, value string) 
 	return fullRef, nil
 }
 
-func ConvertRegistryServerToCatalog(ctx context.Context, serverResp *v0.ServerResponse, pypiResolver catalog.PyPIVersionResolver) (catalog.Server, catalog.TransformSource, error) {
-	result, source, err := catalog.TransformToDocker(ctx, serverResp.Server, catalog.WithPyPIResolver(pypiResolver))
+func ConvertRegistryServerToCatalog(ctx context.Context, serverResp *v0.ServerResponse, opts ...catalog.TransformOption) (catalog.Server, catalog.TransformSource, error) {
+	result, source, err := catalog.TransformToDocker(ctx, serverResp.Server, opts...)
 	if err != nil {
 		return catalog.Server{}, "", err
 	}
@@ -669,7 +669,7 @@ func ResolveRegistry(ctx context.Context, registryClient registryapi.Client, val
 	}
 
 	// Check for OCI packages and convert to catalog format
-	catalogServer, _, err := ConvertRegistryServerToCatalog(ctx, serverResp, catalog.DefaultPyPIVersionResolver())
+	catalogServer, _, err := ConvertRegistryServerToCatalog(ctx, serverResp, catalog.WithPyPIResolver(catalog.DefaultPyPIVersionResolver()), catalog.WithNPMResolver(catalog.DefaultNPMVersionResolver()))
 	if err != nil {
 		return Server{}, fmt.Errorf("failed to convert registry server: %w", err)
 	}


### PR DESCRIPTION
**What I did**                                                                                                                                                
- Add npm/npx package support to the MCP catalog transformation pipeline, following the same pattern as the existing PyPI support (PR #392)            
- npm is the largest package type in the MCP community registry (~49% of all servers). This change adds 2,493 new importable servers to the catalog, roughly doubling the number of usable community servers.                                                                                               
- 71 npm servers are correctly skipped (no stdio transport available)                                                                                
                                                                                                                                                         
## How it works                                                                                                                                      
npm servers from the community registry are transformed into Docker catalog entries that run via `npx` inside a `node:{version}-bookworm-slim` container. The transformation:
                                                                                                                                                         
1. Resolves the Node.js version by querying the npm registry for the package's `engines.node` field (e.g., `>=18` resolves to Node 18). Defaults to Node 22 when unspecified.
2. Builds the npx command: `npx --yes [--registry URL] pkg[@version] [args...]`                                                                    
3. Mounts an npm cache volume: `docker-mcp-npm-cache-{serverName}:/root/.npm`                                                                      
4. Preserves secrets and env vars from the registry metadata                                                                                       
                                                                                                                                                         
Package priority order: OCI > PyPI > npm > Remote (unchanged, npm slots in after PyPI).                                                                
                                                                                                                                                                                                                                                                                                           
**Testing** 
Unit tests (13 transform tests + 20 parser tests, all passing)                                                                                                                 
```                                                                                                                                                                                                                                  
  === RUN   TestParseNodeVersion                                                                                                                         
      --- PASS: TestParseNodeVersion/empty_string                                                                                                      
      --- PASS: TestParseNodeVersion/greater_than_or_equal
      --- PASS: TestParseNodeVersion/greater_than_or_equal_with_patch                                                                                    
      --- PASS: TestParseNodeVersion/caret_constraint
      --- PASS: TestParseNodeVersion/tilde_constraint                                                                                                    
      --- PASS: TestParseNodeVersion/range_with_upper_bound                                                                                            
      --- PASS: TestParseNodeVersion/or_range                                                                                                            
      --- PASS: TestParseNodeVersion/garbage_input
      --- PASS: TestParseNodeVersion/just_a_number                                                                                                       
      ... (15 cases total)                                                                                                                             
  --- PASS: TestNodeVersionToImageTag (5 cases)                                                                                                          
  --- PASS: TestTransformNPM
  --- PASS: TestTransformNPMScopedPackage                                                                                                                
  --- PASS: TestTransformNPMWithCustomRegistry                                                                                                         
  --- PASS: TestTransformNPMWithPackageArgs                                                                                                              
  --- PASS: TestTransformNPMWithoutVersion                                                                                                               
  --- PASS: TestTransformNPMWithEnvVariables
  --- PASS: TestTransformNPMDisallowed                                                                                                                   
  --- PASS: TestTransformNPMAllowedByDefault                                                                                                           
  --- PASS: TestTransformNPMPackageNotFound                                                                                                              
  --- PASS: TestTransformNPMPackageNotFoundWithRemoteFallback
  --- PASS: TestTransformNPMPreferOCIOverNPM                                                                                                             
  --- PASS: TestTransformNPMPreferPyPIOverNPM                                                                                                          
  --- PASS: TestTransformNPMNilResolver                                                                                                                  
 ```    
Integration test: batch validation against live MCP community registry                                                                             
`TestIntegrationNPMTransformBatch` fetches 500 real npm-only servers from the MCP community registry and validates that `TransformToDocker` produces correct output for each one. Result: 450 passed, 0 failed, 50 skipped (remote transport took precedence), 100% success rate.                       
```                                                                                                                                                  
  === RUN   TestIntegrationNPMTransformBatch                                                                                                           
      Fetched 500 npm-only stdio servers across 18 pages of registry results
      === NPM Transform Batch Results ===                                                                                                                
      Total servers fetched: 500                                                                                                                         
      Passed:                450                                                                                                                         
      Failed:                0                                                                                                                           
      Skipped (remote/err):  50                                                                                                                          
      Success rate:          100.0% (450/450 of transformable servers)
  --- PASS: TestIntegrationNPMTransformBatch (4.51s)                                                                                                     
```                                                                                                                                             
Integration test: npm version resolver against live npm registry                                                                                   
`TestIntegrationNPMVersionResolver` validates Node.js version resolution against real npm packages:                                                    
```
  === RUN   TestIntegrationNPMVersionResolver                                                                                                            
      --- PASS: @anthropic-ai/claude-code@: engines.node resolved to ">=18" (will use image node:18-bookworm-slim)                                     
      --- PASS: @agenttrust/mcp-server@1.1.1: engines.node resolved to ">=18" (will use image node:18-bookworm-slim)                                     
      --- PASS: @contextlayer/mcp@0.0.3: engines.node resolved to "" (will use image node:22-bookworm-slim)                                              
      --- PASS: @nonexistent-scope/definitely-not-a-real-package@99.99.99: correctly returned not-found                                                  
```                                                                                                                                 
End-to-end: community registry import with `--include-npm`                                                                                         
```                                                                                                                                    
  $ docker mcp catalog create test-npm                                                                                                                   
      --from-community-registry registry.modelcontextprotocol.io                                                                                         
      --include-npm --exclude "docker/*"                                                                                                                 
                                                                                                                                                         
  Fetched 4881 servers from registry.modelcontextprotocol.io                                                                                             
    Total in registry: 6114                                                                                                                              
    Imported:          4881                                                                                                                              
      OCI (stdio):     192                                                                                                                               
      npm (stdio):     2493
      Remote:          2196                                                                                                                              
    Skipped:           1233                                                                                                                            
      pypi:            906                                                                                                                               
      no packages:     122                                                                                                                               
      mcpb:            94
      npm:             71                                                                                                                                
      nuget:           24                                                                                                                              
      oci:             16                                                                                                                                
```                                                                                                                                                     
End-to-end: single npm server profile creation and inspection
```                                                                                                                                                 
  $ docker mcp profile create --name test-npm-server                                                                                                     
      --server "https://registry.modelcontextprotocol.io/v0/servers/ai.agenttrust%2Fmcp-server/versions/1.1.1"                                           
                                                                                                                                                         
  $ docker mcp profile show test_npm_server --format yaml                                                                                                
servers:
    - type: registry
      secrets: default
      source: https://registry.modelcontextprotocol.io/v0/servers/ai.agenttrust%2Fmcp-server/versions/1.1.1
      snapshot:
        server:
            name: ai-agenttrust-mcp-server
            type: server
            image: node:18-bookworm-slim
            description: Identity, trust, and A2A orchestration for autonomous AI agents. Official A2A partner.
            title: AgentTrust — Identity & Trust for A2A Agents
            icon: https://agenttrust.ai/icon.png
            longLived: true
            remote: {}
            secrets:
                - name: ai-agenttrust-mcp-server.AGENTTRUST_API_KEY
                  env: AGENTTRUST_API_KEY
            command:
                - npx
                - --yes
                - '@agenttrust/mcp-server@1.1.1'
            volumes:
                - docker-mcp-npm-cache-ai-agenttrust-mcp-server:/root/.npm
            metadata:
                registryUrl: https://registry.modelcontextprotocol.io/v0/servers/ai.agenttrust%2Fmcp-server/versions/1.1.1
secrets:
    default:
        provider: docker-desktop-store
```                         
Note: Node 18 was correctly resolved from the package's `engines.node: ">=18"` field rather than using the default Node 22.                                                              
                                                                                                                                                         
🤖 Code and PR description generated in part with [Claude Code](https://claude.com/claude-code) with human input, creation, and review