### PR TITLE
Fix OAuth token exchange and refresh not using proxy transport 

### DIFF
--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -3,11 +3,13 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker-credential-helpers/credentials"
 	"golang.org/x/oauth2"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
@@ -153,7 +155,13 @@ func (m *Manager) ExchangeCode(ctx context.Context, code string, state string) e
 		opts = append(opts, oauth2.SetAuthURLParam("resource", provider.ResourceURL()))
 	}
 
-	token, err := config.Exchange(ctx, code, opts...)
+	// Inject proxy transport so the token endpoint is reachable through
+	// Docker Desktop's HTTP proxy when applicable.
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: desktop.ProxyTransport(),
+	})
+
+	token, err := config.Exchange(proxyCtx, code, opts...)
 	if err != nil {
 		return fmt.Errorf("token exchange failed for %s: %w", serverName, err)
 	}

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -165,7 +166,7 @@ func (p *Provider) Run(ctx context.Context) {
 			case ModeCE:
 				// CE mode: Refresh token directly, then reload server connection
 				go func() {
-					if err := p.refreshTokenCE(); err != nil {
+					if err := p.refreshTokenCE(ctx); err != nil {
 						log.Logf("! Token refresh failed for %s: %v", p.name, err)
 						return
 					}
@@ -277,7 +278,13 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 	provider := NewDCRProvider(dcrClient, DefaultRedirectURI)
 	config := provider.Config()
 
-	refreshedToken, err := config.TokenSource(ctx, token).Token()
+	// Inject proxy transport so the token endpoint is reachable through
+	// Docker Desktop's HTTP proxy when applicable.
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: desktop.ProxyTransport(),
+	})
+
+	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()
 	if err != nil {
 		return fmt.Errorf("token refresh failed: %w", err)
 	}
@@ -293,7 +300,7 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 
 // refreshTokenCE refreshes an OAuth token in CE mode
 // Uses the same oauth2 library refresh mechanism as Desktop
-func (p *Provider) refreshTokenCE() error {
+func (p *Provider) refreshTokenCE(ctx context.Context) error {
 	// Create read-write credential helper for save operations
 	rwHelper := NewReadWriteCredentialHelper()
 
@@ -315,8 +322,14 @@ func (p *Provider) refreshTokenCE() error {
 	provider := NewDCRProvider(dcrClient, DefaultRedirectURI)
 	config := provider.Config()
 
+	// Inject proxy transport so the token endpoint is reachable through
+	// Docker Desktop's HTTP proxy when applicable.
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: desktop.ProxyTransport(),
+	})
+
 	// TokenSource automatically refreshes using refresh_token
-	refreshedToken, err := config.TokenSource(context.Background(), token).Token()
+	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()
 	if err != nil {
 		return fmt.Errorf("token refresh failed: %w", err)
 	}


### PR DESCRIPTION
**Problem**
OAuth token exchange and token refresh requests were using Go's default HTTP transport instead of desktop.ProxyTransport(). This meant that in environments where the OAuth token endpoint is only reachable through Docker Desktop's HTTP proxy (corporate networks, VPNs, etc.), these requests would silently fail.                                                                                     
                                                                                                                                     
 Regular MCP traffic (post-auth) was unaffected, `pkg/mcp/remote.go` correctly wraps all requests in a `headerRoundTripper` using `desktop.ProxyTransport()`. The gap was only in the OAuth token lifecycle.
                                                                                                                                       
Additionally, `refreshTokenCE` used `context.Background()` instead of the caller's context, silently dropping cancellation signals and deadlines. The community refresh path (`refreshTokenCommunity`) did not have this issue, it already accepted and forwarded ctx.
                                                                                                                                       
The golang.org/x/oauth2 library uses Go's `http.DefaultTransport` unless you inject a custom HTTP client via `context.WithValue(ctx,oauth2.HTTPClient, client)`. None of the three OAuth HTTP call sites (`ExchangeCode`, `refreshTokenCommunity`, `refreshTokenCE`) were doing this:                                               
                                                                                                                                                                                                                                                                                       
**Fix**                                                                                                                             
                                                                                                                                     
All three call sites now inject `desktop.ProxyTransport()` into the context before calling the oauth2 library:                         
```
  proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{                                                                  
      Transport: desktop.ProxyTransport(),                                                                                           
  })
```                                                                                                                                     

`refreshTokenCE` was also updated to accept a ctx `context.Context` parameter (matching `refreshTokenCommunity`), and its call site in Run() now passes the caller's context.                                                                                               
                                                                                                                                       
**What this does NOT change**                                                                                                          
- Custom Remote.Headers are still only sent to the MCP resource server, not to the OAuth token endpoint. Those headers typically contain resource-server-specific credentials (API keys, etc.) and sending them to the auth server would be a potential secret leak.

If auth-server-specific headers are needed in the future, that should be a separate config key.   