### PR TITLE
Reduce insecurity of secret setting command in documentation

### DIFF
--- a/docs/generator/reference/docker_mcp_secret_set.yaml
+++ b/docs/generator/reference/docker_mcp_secret_set.yaml
@@ -18,8 +18,7 @@ examples: |-
     ### Pass the secret via STDIN
 
     ```console
-    echo my-secret-password > pwd.txt
-    cat pwd.txt | docker mcp secret set postgres_password
+    echo my-secret-password | docker mcp secret set postgres_password
     ```
 deprecated: false
 hidden: false

--- a/docs/generator/reference/mcp_secret_set.md
+++ b/docs/generator/reference/mcp_secret_set.md
@@ -11,6 +11,5 @@ Set a secret in the local OS Keychain
 ### Pass the secret via STDIN
 
 ```console
-echo my-secret-password > pwd.txt
-cat pwd.txt | docker mcp secret set postgres_password
+echo my-secret-password | docker mcp secret set postgres_password
 ```


### PR DESCRIPTION
The existing example encourages an unsafe pattern where the a secret value is written to disk in clear text - for no reason at all. Given the purpose of the feature is secure storage of secrets, this seems worth avoiding. 

