### PR TITLE
Update bake-action to v7.2.0 to fix SHA pinning policy violation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04
     outputs:
-      targets: ${{ steps.generate.outputs.targets }}
+      matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       -
         name: Checkout
@@ -28,7 +28,7 @@ jobs:
       -
         name: List targets
         id: generate
-        uses: docker/bake-action/subaction/list-targets@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4  # v6.10.0
+        uses: docker/bake-action/subaction/matrix@6614cfa25eff9a0b2b2697efb0b6159e7680d584  # v7.2.0
         with:
           target: validate-docs
 
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJson(needs.prepare.outputs.targets) }}
+        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       -
         name: Set up Docker Buildx
@@ -48,6 +48,6 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Validate
-        uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4  # v6.10.0
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584  # v7.2.0
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- Upgrades `docker/bake-action` from v6.10.0 to v7.2.0 in the `validate` workflow
- Migrates from deprecated `subaction/list-targets` to `subaction/matrix`
- Fixes org policy violation: `list-targets` internally used `actions/github-script@v7` (tag, not SHA), which is blocked by the requirement that all actions must be pinned to a full-length commit SHA

This is blocking CI on external contributor PRs (#489, #493).

## Test plan

- [ ] Verify `validate` workflow passes on this PR
- [ ] Re-trigger CI on #489 and #493 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)