### PR TITLE
test(secretsscan): assemble token-shaped inputs at runtime

### DIFF
--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -1,6 +1,7 @@
 package secretsscan
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,13 @@ func TestDoesntContainsSecrets(t *testing.T) {
 }
 
 func TestContainsSecrets(t *testing.T) {
-	assert.True(t, ContainsSecrets("ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"))
-	assert.True(t, ContainsSecrets("dckr_pat_eJ1VdWgkzcPf34tsua8ZqKJp18w"))
+	// Assemble token-shaped inputs at runtime rather than as source literals,
+	// so secret-scanning tooling doesn't flag this file as containing leaked
+	// credentials. The assembled strings still satisfy the GitHub-PAT regex
+	// (ghp_[0-9a-zA-Z]{36}) and Docker-PAT regex (dckr_pat_[-0-9a-zA-Z]{27}).
+	githubPATShaped := "ghp_" + strings.Repeat("T", 36)
+	dockerPATShaped := "dckr_pat_" + strings.Repeat("T", 27)
+
+	assert.True(t, ContainsSecrets(githubPATShaped))
+	assert.True(t, ContainsSecrets(dockerPATShaped))
 }


### PR DESCRIPTION
## Summary

The two literals in `pkg/secretsscan/secrets_test.go` `TestContainsSecrets` matched the GitHub-PAT and Docker-PAT regex shapes closely enough that GitHub's secret-scanning service flags the file as containing leaked credentials. Push protection also blocks any future push containing a similarly-shaped literal.

This change builds the test inputs at runtime from a literal prefix (`ghp_`, `dckr_pat_`) plus repeated padding via `strings.Repeat`, so the source code no longer contains a complete-shape token. `ContainsSecrets` sees the assembled string and continues to return `true` for both patterns.

## Test

```
$ go test ./pkg/secretsscan/ -count=1 -v
=== RUN   TestDoesntContainsSecrets
--- PASS: TestDoesntContainsSecrets (0.00s)
=== RUN   TestContainsSecrets
--- PASS: TestContainsSecrets (0.00s)
PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)