### PR TITLE
fix(db): batch catalog_server inserts to avoid SQLite variable limit

### DIFF
--- a/pkg/db/catalog.go
+++ b/pkg/db/catalog.go
@@ -126,9 +126,19 @@ func (d *dao) UpsertCatalog(ctx context.Context, catalog Catalog) error {
 		server_type, tools, source, image, endpoint, catalog_ref, snapshot
 	) VALUES (:server_type, :tools, :source, :image, :endpoint, :catalog_ref, :snapshot)`
 
-		_, err = tx.NamedExecContext(ctx, serverQuery, catalog.Servers)
-		if err != nil {
-			return err
+		// Insert in batches. A slice passed to NamedExecContext expands into a
+		// single multi-row INSERT with one bound parameter per column per row,
+		// and SQLite caps the number of variables per statement at 32766
+		// (SQLITE_MAX_VARIABLE_NUMBER). With 7 columns per server, large
+		// catalogs (e.g. the community registry's thousands of servers) exceed
+		// that limit and fail with "too many SQL variables".
+		const columnsPerServer = 7
+		const batchSize = 32766 / columnsPerServer // 4680 servers per statement
+		for start := 0; start < len(catalog.Servers); start += batchSize {
+			end := min(start+batchSize, len(catalog.Servers))
+			if _, err = tx.NamedExecContext(ctx, serverQuery, catalog.Servers[start:end]); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/db/catalog_test.go
+++ b/pkg/db/catalog_test.go
@@ -45,6 +45,40 @@ func TestCreateCatalogAndGetCatalog(t *testing.T) {
 	assert.WithinDuration(t, time.Now().UTC(), *retrieved.LastUpdated, 60*time.Second)
 }
 
+func TestCreateCatalogWithManyServers(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	// More servers than fit in a single SQLite statement: with 7 bound
+	// parameters per server, anything over 32766/7 = 4680 servers would
+	// overflow SQLITE_MAX_VARIABLE_NUMBER if inserted in one statement.
+	const serverCount = 10000
+	servers := make([]CatalogServer, serverCount)
+	for i := range servers {
+		servers[i] = CatalogServer{
+			ServerType: "registry",
+			Tools:      ToolList{"tool1"},
+			Source:     "https://example.com/server",
+			Image:      "docker/test:latest",
+		}
+	}
+
+	catalog := Catalog{
+		Ref:     "docker.io/test/large:latest",
+		Digest:  "large123",
+		Title:   "large-catalog",
+		Source:  "https://example.com/large",
+		Servers: servers,
+	}
+
+	err := dao.UpsertCatalog(ctx, catalog)
+	require.NoError(t, err)
+
+	retrieved, err := dao.GetCatalog(ctx, "docker.io/test/large:latest")
+	require.NoError(t, err)
+	assert.Len(t, retrieved.Servers, serverCount)
+}
+
 func TestCreateCatalogWithEmptyServers(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()


### PR DESCRIPTION
**What I did**

`UpsertCatalog` inserted every catalog server in a single multi-row `INSERT` via `NamedExecContext`. When a slice is passed, `sqlx` expands it into one statement with **one bound parameter per column per row**. SQLite caps bound parameters per statement at **32766** (`SQLITE_MAX_VARIABLE_NUMBER`). With 7 columns per server, any catalog with more than `32766 / 7 ≈ 4680` servers overflows the limit and fails with:

```
failed to create catalog: SQL logic error: too many SQL variables (1)
```

This now reproduces in CI when building the community-registry catalog (`docker mcp catalog-next create --from-community-registry`), which imports 5500+ servers (`7 × 5597 = 39179 > 32766`). It will affect any sufficiently large catalog.

**Fix:** insert servers in batches of `32766 / 7` rows so each statement stays under the limit. The inserts already run inside the existing transaction, so all-or-nothing semantics are preserved.

Added `TestCreateCatalogWithManyServers` (inserts 10000 servers) as a regression test. It fails with `too many SQL variables (1)` on the old code and passes with the batched insert.

**Related issue**

N/A — surfaced via the `docker/ai-mcp` CI build-and-push job.

**(not mandatory) A picture of a cute animal**

🦫 (a beaver, because it batches its work)