### PR TITLE
Sec #5: Harden remote MCP URL handling

### DIFF
--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 type remoteMCPClient struct {
@@ -48,6 +49,9 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	} else {
 		url = c.config.Spec.Remote.URL
 		transport = c.config.Spec.Remote.Transport
+	}
+	if err := remoteurl.Validate(ctx, url); err != nil {
+		return fmt.Errorf("unsafe remote MCP URL for %s: %w", c.config.Name, err)
 	}
 
 	// Secrets to env
@@ -114,7 +118,7 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	// Create HTTP client with custom headers
 	httpClient := &http.Client{
 		Transport: &headerRoundTripper{
-			base:    desktop.ProxyTransport(),
+			base:    remoteurl.GuardTransport(desktop.ProxyTransport()),
 			headers: headers,
 		},
 	}

--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	"github.com/docker/mcp-gateway/pkg/catalog"
-	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
@@ -118,7 +117,7 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	// Create HTTP client with custom headers
 	httpClient := &http.Client{
 		Transport: &headerRoundTripper{
-			base:    remoteurl.GuardTransport(desktop.ProxyTransport()),
+			base:    remoteurl.GuardDirectTransport(),
 			headers: headers,
 		},
 	}

--- a/pkg/mcp/remote_test.go
+++ b/pkg/mcp/remote_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
 )
 
 // roundTripFunc is an adapter to use functions as http.RoundTripper.
@@ -141,4 +143,20 @@ func TestHeaderRoundTripper_EmptyHeaders(t *testing.T) {
 	require.NotNil(t, capturedReq)
 	assert.Empty(t, capturedReq.Header.Get("Authorization"),
 		"no Authorization header when headers map is empty")
+}
+
+func TestRemoteMCPClientRejectsUnsafeRemoteURL(t *testing.T) {
+	client := NewRemoteMCPClient(&catalog.ServerConfig{
+		Name: "unsafe-remote",
+		Spec: catalog.Server{
+			Remote: catalog.Remote{
+				URL:       "http://127.0.0.1:8080/mcp",
+				Transport: "streamable-http",
+			},
+		},
+	})
+
+	err := client.Initialize(context.Background(), nil, false, nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe remote MCP URL")
 }

--- a/pkg/oauth/dcr/manager.go
+++ b/pkg/oauth/dcr/manager.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/docker/docker-credential-helpers/credentials"
 
-	oauth "github.com/docker/mcp-gateway-oauth-helpers"
-
 	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/log"
+	"github.com/docker/mcp-gateway/pkg/oauthdiscovery"
 )
 
 // Manager orchestrates Dynamic Client Registration flows
@@ -69,8 +68,7 @@ func DiscoverAndRegister(ctx context.Context, serverName string, scopes string, 
 
 	// Perform OAuth discovery (RFC 9728, RFC 8414)
 	log.Logf("- Starting OAuth discovery for: %s at: %s", serverName, serverURL)
-	ctx = oauth.WithLogger(ctx, &logger{})
-	discovery, err := oauth.DiscoverOAuthRequirements(ctx, serverURL)
+	discovery, err := oauthdiscovery.DiscoverOAuthRequirements(ctx, serverURL)
 	if err != nil {
 		return Client{}, fmt.Errorf("discovering OAuth requirements for %s: %w", serverName, err)
 	}
@@ -84,7 +82,7 @@ func DiscoverAndRegister(ctx context.Context, serverName string, scopes string, 
 	}
 
 	// Perform Dynamic Client Registration (RFC 7591) with our redirect URI
-	creds, err := oauth.PerformDCR(ctx, discovery, serverName, redirectURI)
+	creds, err := oauthdiscovery.PerformDCR(ctx, discovery, serverName, redirectURI)
 	if err != nil {
 		return Client{}, fmt.Errorf("registering DCR client for %s: %w", serverName, err)
 	}
@@ -156,19 +154,4 @@ func mergeScopes(requiredScopes []string, userScopes string) []string {
 	}
 
 	return merged
-}
-
-// logger adapter for oauth-helpers library
-type logger struct{}
-
-func (l *logger) Infof(format string, args ...any) {
-	log.Logf(format, args...)
-}
-
-func (l *logger) Warnf(format string, args ...any) {
-	log.Logf("! "+format, args...)
-}
-
-func (l *logger) Debugf(format string, args ...any) {
-	log.Logf(format, args...)
 }

--- a/pkg/oauth/dcr_registration.go
+++ b/pkg/oauth/dcr_registration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
+	"github.com/docker/mcp-gateway/pkg/oauthdiscovery"
 )
 
 // dcrRegistrationClient is the subset of desktop.Tools used for DCR registration.
@@ -27,7 +28,7 @@ type oauthProber interface {
 type defaultOAuthProber struct{}
 
 func (defaultOAuthProber) DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhelpers.Discovery, error) {
-	return oauthhelpers.DiscoverOAuthRequirements(ctx, serverURL)
+	return oauthdiscovery.DiscoverOAuthRequirements(ctx, serverURL)
 }
 
 // RegisterProviderForLazySetup registers a DCR provider with Docker Desktop

--- a/pkg/oauth/dcr_registration_test.go
+++ b/pkg/oauth/dcr_registration_test.go
@@ -106,3 +106,9 @@ func TestRegisterProviderForDynamicDiscovery_SkipsOnProbeError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, client.registered, "should not register when probe fails")
 }
+
+func TestDefaultOAuthProberRejectsUnsafeRemoteURL(t *testing.T) {
+	_, err := defaultOAuthProber{}.DiscoverOAuthRequirements(t.Context(), "http://127.0.0.1/mcp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
@@ -14,7 +13,7 @@ import (
 func guardedOAuthHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout:   timeout,
-		Transport: remoteurl.GuardTransport(desktop.ProxyTransport()),
+		Transport: remoteurl.GuardDirectTransport(),
 	}
 }
 

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -1,0 +1,37 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
+)
+
+func guardedOAuthHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: remoteurl.GuardTransport(desktop.ProxyTransport()),
+	}
+}
+
+func validateOutboundDCRClientEndpoints(ctx context.Context, client dcr.Client) error {
+	for _, endpoint := range []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "token endpoint", rawURL: client.TokenEndpoint},
+		{name: "resource URL", rawURL: client.ResourceURL},
+	} {
+		if endpoint.rawURL == "" {
+			continue
+		}
+		if err := remoteurl.Validate(ctx, endpoint.rawURL); err != nil {
+			return fmt.Errorf("invalid OAuth %s for %s: %w", endpoint.name, client.ServerName, err)
+		}
+	}
+	return nil
+}

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -3,13 +3,11 @@ package oauth
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/docker-credential-helpers/credentials"
 	"golang.org/x/oauth2"
 
-	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
@@ -140,6 +138,9 @@ func (m *Manager) ExchangeCode(ctx context.Context, code string, state string) e
 	if err != nil {
 		return fmt.Errorf("DCR client not found for %s: %w", serverName, err)
 	}
+	if err := validateOutboundDCRClientEndpoints(ctx, dcrClient); err != nil {
+		return err
+	}
 
 	// Create provider
 	provider := NewDCRProvider(dcrClient, m.redirectURI)
@@ -156,10 +157,9 @@ func (m *Manager) ExchangeCode(ctx context.Context, code string, state string) e
 	}
 
 	// Inject proxy transport so the token endpoint is reachable through
-	// Docker Desktop's HTTP proxy when applicable.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
-		Transport: desktop.ProxyTransport(),
-	})
+	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
+	// derived OAuth endpoints.
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(0))
 
 	token, err := config.Exchange(proxyCtx, code, opts...)
 	if err != nil {

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -3,7 +3,6 @@ package oauth
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
@@ -262,6 +261,9 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get DCR client from docker pass: %w", err)
 	}
+	if err := validateOutboundDCRClientEndpoints(ctx, dcrClient); err != nil {
+		return err
+	}
 
 	// Get current token from docker pass
 	token, err := GetTokenFromDockerPass(ctx, p.name)
@@ -279,10 +281,9 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 	config := provider.Config()
 
 	// Inject proxy transport so the token endpoint is reachable through
-	// Docker Desktop's HTTP proxy when applicable.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
-		Transport: desktop.ProxyTransport(),
-	})
+	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
+	// derived OAuth endpoints.
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(0))
 
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()
 	if err != nil {
@@ -310,6 +311,9 @@ func (p *Provider) refreshTokenCE(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get DCR client: %w", err)
 	}
+	if err := validateOutboundDCRClientEndpoints(ctx, dcrClient); err != nil {
+		return err
+	}
 
 	// Get current token and create token store
 	tokenStore := NewTokenStore(rwHelper)
@@ -323,10 +327,9 @@ func (p *Provider) refreshTokenCE(ctx context.Context) error {
 	config := provider.Config()
 
 	// Inject proxy transport so the token endpoint is reachable through
-	// Docker Desktop's HTTP proxy when applicable.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
-		Transport: desktop.ProxyTransport(),
-	})
+	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
+	// derived OAuth endpoints.
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(0))
 
 	// TokenSource automatically refreshes using refresh_token
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()

--- a/pkg/oauthdiscovery/discovery.go
+++ b/pkg/oauthdiscovery/discovery.go
@@ -14,7 +14,6 @@ import (
 
 	oauthhelpers "github.com/docker/mcp-gateway-oauth-helpers"
 
-	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
@@ -23,7 +22,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhel
 		return nil, err
 	}
 
-	client := remoteurl.NewHTTPClient(30*time.Second, desktop.ProxyTransport())
+	client := remoteurl.NewDirectHTTPClient(30 * time.Second)
 
 	parsedURL, err := url.Parse(serverURL)
 	if err != nil {
@@ -191,7 +190,7 @@ func PerformDCR(ctx context.Context, discovery *oauthhelpers.Discovery, serverNa
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "MCP-Gateway/1.0.0")
 
-	client := remoteurl.NewHTTPClient(30*time.Second, desktop.ProxyTransport())
+	client := remoteurl.NewDirectHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send DCR request to %s: %w", discovery.RegistrationEndpoint, err)
@@ -276,7 +275,7 @@ func fetchOAuthProtectedResourceMetadata(ctx context.Context, client *http.Clien
 }
 
 func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerURL string) (*oauthhelpers.AuthorizationServerMetadata, error) {
-	metadataURL, err := buildRFC8414WellKnownURL(authServerURL)
+	metadataURL, err := buildRFC8414WellKnownURL(ctx, authServerURL)
 	if err != nil {
 		return nil, fmt.Errorf("building well-known URL: %w", err)
 	}
@@ -322,13 +321,13 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 	return &metadata, nil
 }
 
-func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
+func buildRFC8414WellKnownURL(ctx context.Context, issuerURL string) (string, error) {
 	parsed, err := url.Parse(issuerURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid issuer URL: %w", err)
 	}
-	if parsed.Scheme != "https" {
-		return "", fmt.Errorf("issuer URL must use https scheme")
+	if err := remoteurl.Validate(ctx, issuerURL); err != nil {
+		return "", err
 	}
 	if parsed.RawQuery != "" {
 		return "", fmt.Errorf("issuer URL must not contain query parameters")
@@ -343,7 +342,7 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		path = ""
 	}
 
-	return fmt.Sprintf("https://%s/.well-known/oauth-authorization-server%s", host, path), nil
+	return fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s", parsed.Scheme, host, path), nil
 }
 
 func validateRedirectURI(redirectURI string) error {

--- a/pkg/oauthdiscovery/discovery.go
+++ b/pkg/oauthdiscovery/discovery.go
@@ -1,0 +1,365 @@
+package oauthdiscovery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	oauthhelpers "github.com/docker/mcp-gateway-oauth-helpers"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
+)
+
+func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhelpers.Discovery, error) {
+	if err := remoteurl.Validate(ctx, serverURL); err != nil {
+		return nil, err
+	}
+
+	client := remoteurl.NewHTTPClient(30*time.Second, desktop.ProxyTransport())
+
+	parsedURL, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid server URL: %w", err)
+	}
+
+	mcpPayload := `{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-gateway","version":"1.0.0"}},"id":1}`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, strings.NewReader(mcpPayload))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "docker-mcp-gateway/1.0.0")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server %s: %w", serverURL, err)
+	}
+	defer resp.Body.Close()
+
+	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	var challenges []oauthhelpers.WWWAuthenticateChallenge
+	if wwwAuth != "" {
+		challenges, err = oauthhelpers.ParseWWWAuthenticate(wwwAuth)
+		if err != nil {
+			challenges = nil
+		}
+	}
+
+	defaultAuthServerURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+
+	var resourceMetadata *oauthhelpers.ProtectedResourceMetadata
+	authServerURL := defaultAuthServerURL
+
+	resourceMetadataURL := ""
+	if challenges != nil {
+		resourceMetadataURL = oauthhelpers.FindResourceMetadataURL(challenges)
+	}
+
+	if resourceMetadataURL != "" {
+		resourceMetadata, err = fetchOAuthProtectedResourceMetadata(ctx, client, resourceMetadataURL)
+		if err == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
+			authServerURL = resourceMetadata.AuthorizationServer
+		}
+	} else {
+		wellKnownURL := fmt.Sprintf("%s/.well-known/oauth-protected-resource", defaultAuthServerURL)
+		resourceMetadata, err = fetchOAuthProtectedResourceMetadata(ctx, client, wellKnownURL)
+		if err == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
+			authServerURL = resourceMetadata.AuthorizationServer
+		}
+	}
+
+	authServerMetadata, err := fetchAuthorizationServerMetadata(ctx, client, authServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching authorization server metadata from %s: %w", authServerURL, err)
+	}
+
+	discovery := &oauthhelpers.Discovery{
+		RequiresOAuth: true,
+
+		ResourceURL:         defaultAuthServerURL,
+		ResourceServer:      defaultAuthServerURL,
+		AuthorizationServer: authServerURL,
+
+		Issuer:                            authServerMetadata.Issuer,
+		AuthorizationEndpoint:             authServerMetadata.AuthorizationEndpoint,
+		TokenEndpoint:                     authServerMetadata.TokenEndpoint,
+		RegistrationEndpoint:              authServerMetadata.RegistrationEndpoint,
+		JWKSUri:                           authServerMetadata.JWKSUri,
+		ScopesSupported:                   authServerMetadata.ScopesSupported,
+		ResponseTypesSupported:            authServerMetadata.ResponseTypesSupported,
+		ResponseModesSupported:            authServerMetadata.ResponseModesSupported,
+		GrantTypesSupported:               authServerMetadata.GrantTypesSupported,
+		TokenEndpointAuthMethodsSupported: authServerMetadata.TokenEndpointAuthMethodsSupported,
+		SupportsPKCE:                      slices.Contains(authServerMetadata.CodeChallengeMethodsSupported, "S256"),
+		CodeChallengeMethod:               authServerMetadata.CodeChallengeMethodsSupported,
+	}
+
+	if resourceMetadata != nil {
+		if resourceMetadata.Resource != "" {
+			discovery.ResourceURL = resourceMetadata.Resource
+			discovery.ResourceServer = resourceMetadata.Resource
+		}
+		if len(resourceMetadata.Scopes) > 0 {
+			discovery.Scopes = resourceMetadata.Scopes
+		}
+	}
+	if len(discovery.Scopes) == 0 {
+		discovery.Scopes = oauthhelpers.FindRequiredScopes(challenges)
+	}
+	if err := ValidateDiscovery(ctx, discovery); err != nil {
+		return nil, err
+	}
+
+	return discovery, nil
+}
+
+func ValidateDiscovery(ctx context.Context, discovery *oauthhelpers.Discovery) error {
+	if discovery == nil {
+		return fmt.Errorf("OAuth discovery result is empty")
+	}
+
+	for _, endpoint := range []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "resource", rawURL: discovery.ResourceURL},
+		{name: "resource server", rawURL: discovery.ResourceServer},
+		{name: "authorization server", rawURL: discovery.AuthorizationServer},
+		{name: "authorization endpoint", rawURL: discovery.AuthorizationEndpoint},
+		{name: "token endpoint", rawURL: discovery.TokenEndpoint},
+		{name: "registration endpoint", rawURL: discovery.RegistrationEndpoint},
+	} {
+		if endpoint.rawURL == "" {
+			continue
+		}
+		if err := remoteurl.Validate(ctx, endpoint.rawURL); err != nil {
+			return fmt.Errorf("invalid OAuth %s: %w", endpoint.name, err)
+		}
+	}
+
+	return nil
+}
+
+func PerformDCR(ctx context.Context, discovery *oauthhelpers.Discovery, serverName string, redirectURI string) (*oauthhelpers.ClientCredentials, error) {
+	if discovery == nil || discovery.RegistrationEndpoint == "" {
+		return nil, fmt.Errorf("no registration endpoint found for %s", serverName)
+	}
+	if err := ValidateDiscovery(ctx, discovery); err != nil {
+		return nil, err
+	}
+	if err := validateRedirectURI(redirectURI); err != nil {
+		return nil, fmt.Errorf("invalid redirect URI: %w", err)
+	}
+	if redirectURI == "" {
+		redirectURI = oauthhelpers.DefaultRedirectURI
+	}
+
+	registration := oauthhelpers.DCRRequest{
+		ClientName:              fmt.Sprintf("MCP Gateway - %s", serverName),
+		RedirectURIs:            []string{redirectURI},
+		TokenEndpointAuthMethod: "none",
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		ClientURI:               "https://github.com/docker/mcp-gateway",
+		SoftwareID:              "mcp-gateway",
+		SoftwareVersion:         "1.0.0",
+		Contacts:                []string{"support@docker.com"},
+	}
+	if len(discovery.Scopes) > 0 {
+		registration.Scope = strings.Join(discovery.Scopes, " ")
+	}
+
+	body, err := json.Marshal(registration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal DCR request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, discovery.RegistrationEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DCR request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "MCP-Gateway/1.0.0")
+
+	client := remoteurl.NewHTTPClient(30*time.Second, desktop.ProxyTransport())
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send DCR request to %s: %w", discovery.RegistrationEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		errorBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("DCR failed with status %d for %s", resp.StatusCode, serverName)
+		}
+
+		errorMsg := string(errorBody)
+		var errorResp map[string]any
+		if err := json.Unmarshal(errorBody, &errorResp); err == nil {
+			if errDesc, ok := errorResp["error_description"].(string); ok {
+				errorMsg = errDesc
+			} else if errField, ok := errorResp["error"].(string); ok {
+				errorMsg = errField
+			} else if message, ok := errorResp["message"].(string); ok {
+				errorMsg = message
+			}
+		}
+
+		return nil, fmt.Errorf("DCR failed with status %d for %s: %s", resp.StatusCode, serverName, errorMsg)
+	}
+
+	var dcrResponse oauthhelpers.DCRResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dcrResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode DCR response: %w", err)
+	}
+	if dcrResponse.ClientID == "" {
+		return nil, fmt.Errorf("DCR response missing client_id for %s", serverName)
+	}
+
+	return &oauthhelpers.ClientCredentials{
+		ClientID:              dcrResponse.ClientID,
+		ServerURL:             discovery.ResourceURL,
+		IsPublic:              true,
+		AuthorizationEndpoint: discovery.AuthorizationEndpoint,
+		TokenEndpoint:         discovery.TokenEndpoint,
+	}, nil
+}
+
+func fetchOAuthProtectedResourceMetadata(ctx context.Context, client *http.Client, metadataURL string) (*oauthhelpers.ProtectedResourceMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching metadata from %s: %w", metadataURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("metadata endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	var metadata oauthhelpers.ProtectedResourceMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return nil, fmt.Errorf("parsing JSON response: %w", err)
+	}
+	if metadata.Resource == "" {
+		return nil, fmt.Errorf("resource field missing in protected resource metadata")
+	}
+	if metadata.AuthorizationServer == "" {
+		if len(metadata.AuthorizationServers) == 0 {
+			return nil, fmt.Errorf("authorization_server or authorization_servers field missing in protected resource metadata")
+		}
+		metadata.AuthorizationServer = metadata.AuthorizationServers[0]
+	}
+
+	return &metadata, nil
+}
+
+func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerURL string) (*oauthhelpers.AuthorizationServerMetadata, error) {
+	metadataURL, err := buildRFC8414WellKnownURL(authServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("building well-known URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching metadata from %s: %w", metadataURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("authorization server metadata endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	var metadata oauthhelpers.AuthorizationServerMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return nil, fmt.Errorf("parsing JSON response: %w", err)
+	}
+	if metadata.Issuer == "" {
+		return nil, fmt.Errorf("issuer field missing in authorization server metadata")
+	}
+	if metadata.AuthorizationEndpoint == "" {
+		return nil, fmt.Errorf("authorization_endpoint field missing in authorization server metadata")
+	}
+	if metadata.TokenEndpoint == "" {
+		return nil, fmt.Errorf("token_endpoint field missing in authorization server metadata")
+	}
+	if _, err := url.Parse(metadata.Issuer); err != nil {
+		return nil, fmt.Errorf("invalid issuer URL: %w", err)
+	}
+
+	return &metadata, nil
+}
+
+func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
+	parsed, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid issuer URL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("issuer URL must use https scheme")
+	}
+	if parsed.RawQuery != "" {
+		return "", fmt.Errorf("issuer URL must not contain query parameters")
+	}
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("issuer URL must not contain fragment")
+	}
+
+	host := strings.ToLower(parsed.Host)
+	path := parsed.Path
+	if path == "/" {
+		path = ""
+	}
+
+	return fmt.Sprintf("https://%s/.well-known/oauth-authorization-server%s", host, path), nil
+}
+
+func validateRedirectURI(redirectURI string) error {
+	if redirectURI == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(redirectURI)
+	if err != nil {
+		return fmt.Errorf("invalid redirect URI format: %w", err)
+	}
+
+	switch parsed.Hostname() {
+	case "localhost", "127.0.0.1", "::1", "mcp.docker.com":
+		return nil
+	default:
+		return fmt.Errorf("redirect URI host %q not allowed - must be localhost or mcp.docker.com", parsed.Hostname())
+	}
+}

--- a/pkg/oauthdiscovery/discovery_test.go
+++ b/pkg/oauthdiscovery/discovery_test.go
@@ -1,0 +1,33 @@
+package oauthdiscovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
+)
+
+func TestBuildRFC8414WellKnownURLRejectsLocalHTTPByDefault(t *testing.T) {
+	_, err := buildRFC8414WellKnownURL(t.Context(), "http://localhost:8080/oauth")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestBuildRFC8414WellKnownURLHonorsInsecureDevOptIn(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	metadataURL, err := buildRFC8414WellKnownURL(t.Context(), "http://localhost:8080/oauth")
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8080/.well-known/oauth-authorization-server/oauth", metadataURL)
+}
+
+func TestBuildRFC8414WellKnownURLAllowsPublicHTTPSIssuer(t *testing.T) {
+	metadataURL, err := buildRFC8414WellKnownURL(t.Context(), "https://8.8.8.8/oauth")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://8.8.8.8/.well-known/oauth-authorization-server/oauth", metadataURL)
+}

--- a/pkg/remote_headers_integration_test.go
+++ b/pkg/remote_headers_integration_test.go
@@ -15,12 +15,16 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // TestIntegrationRemoteWithCustomHeaders tests that custom headers (including Authorization
 // with Bearer tokens from secrets) are properly transmitted to remote MCP servers.
 func TestIntegrationRemoteWithCustomHeaders(t *testing.T) {
 	thisIsAnIntegrationTest(t)
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	// Start a test MCP server that can validate the Authorization header
 	server := newTestMCPServer(t)
 	defer server.close()

--- a/pkg/remoteurl/remoteurl.go
+++ b/pkg/remoteurl/remoteurl.go
@@ -1,0 +1,314 @@
+package remoteurl
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// AllowInsecureRemoteURLEnv enables local/dev remote MCP endpoints. Production
+// defaults allow only public HTTPS destinations.
+const AllowInsecureRemoteURLEnv = "DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS"
+
+type resolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
+type contextKey struct{}
+
+type Options struct {
+	AllowInsecure bool
+	Resolver      resolver
+}
+
+type Validator struct {
+	allowInsecure bool
+	resolver      resolver
+}
+
+func NewValidator(options Options) Validator {
+	resolver := options.Resolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	return Validator{
+		allowInsecure: options.AllowInsecure,
+		resolver:      resolver,
+	}
+}
+
+func DefaultValidator() Validator {
+	return NewValidator(Options{
+		AllowInsecure: allowInsecureFromEnv(),
+		Resolver:      net.DefaultResolver,
+	})
+}
+
+func Validate(ctx context.Context, rawURL string) error {
+	return DefaultValidator().Validate(ctx, rawURL)
+}
+
+func (v Validator) Validate(ctx context.Context, rawURL string) error {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return fmt.Errorf("remote URL is empty")
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid remote URL: %w", err)
+	}
+	return v.ValidateURL(ctx, u)
+}
+
+func (v Validator) ValidateURL(ctx context.Context, u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("remote URL is empty")
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("remote URL must be absolute")
+	}
+	if u.User != nil {
+		return fmt.Errorf("remote URL must not include userinfo")
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	switch scheme {
+	case "https":
+	case "http":
+		if !v.allowInsecure {
+			return fmt.Errorf("remote URL must use https")
+		}
+	default:
+		return fmt.Errorf("remote URL must use http or https")
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("remote URL host is empty")
+	}
+	if strings.ContainsAny(host, "\x00%") {
+		return fmt.Errorf("remote URL host is malformed")
+	}
+
+	if v.allowInsecure {
+		return nil
+	}
+
+	if isBlockedHostname(host) {
+		return fmt.Errorf("remote URL host %q is not allowed", host)
+	}
+
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validateAddr(ip); err != nil {
+			return fmt.Errorf("remote URL host %q is not allowed: %w", host, err)
+		}
+		return nil
+	}
+
+	ips, err := v.resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return fmt.Errorf("resolving remote URL host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("remote URL host %q did not resolve to any IP addresses", host)
+	}
+	for _, ip := range ips {
+		if err := validateAddr(ip); err != nil {
+			return fmt.Errorf("remote URL host %q resolved to disallowed address %s: %w", host, ip, err)
+		}
+	}
+
+	return nil
+}
+
+func GuardTransport(base http.RoundTripper) http.RoundTripper {
+	return DefaultValidator().GuardTransport(base)
+}
+
+func (v Validator) GuardTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	base = v.guardDialer(base)
+	return &validatingRoundTripper{
+		base:      base,
+		validator: v,
+	}
+}
+
+func NewHTTPClient(timeout time.Duration, base http.RoundTripper) *http.Client {
+	validator := DefaultValidator()
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: validator.GuardTransport(base),
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			return validator.ValidateURL(req.Context(), req.URL)
+		},
+	}
+}
+
+func (v Validator) guardDialer(base http.RoundTripper) http.RoundTripper {
+	transport, ok := base.(*http.Transport)
+	if !ok {
+		return base
+	}
+
+	cloned := transport.Clone()
+	originalDialContext := cloned.DialContext
+	if originalDialContext == nil {
+		originalDialContext = (&net.Dialer{}).DialContext
+	}
+
+	cloned.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return originalDialContext(ctx, network, address)
+		}
+
+		targetHost, _ := ctx.Value(contextKey{}).(string)
+		if !sameHostname(targetHost, host) || v.allowInsecure {
+			return originalDialContext(ctx, network, address)
+		}
+
+		return v.dialAllowedAddress(ctx, originalDialContext, network, host, port)
+	}
+
+	return cloned
+}
+
+func (v Validator) dialAllowedAddress(ctx context.Context, dial func(context.Context, string, string) (net.Conn, error), network, host, port string) (net.Conn, error) {
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validateAddr(ip); err != nil {
+			return nil, err
+		}
+		return dial(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+
+	ips, err := v.resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("%q did not resolve to any IP addresses", host)
+	}
+	for _, ip := range ips {
+		if err := validateAddr(ip); err != nil {
+			return nil, fmt.Errorf("%q resolved to disallowed address %s: %w", host, ip, err)
+		}
+	}
+
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dial(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+type validatingRoundTripper struct {
+	base      http.RoundTripper
+	validator Validator
+}
+
+func (t *validatingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.validator.ValidateURL(req.Context(), req.URL); err != nil {
+		return nil, err
+	}
+
+	ctx := context.WithValue(req.Context(), contextKey{}, req.URL.Hostname())
+	return t.base.RoundTrip(req.Clone(ctx))
+}
+
+func allowInsecureFromEnv() bool {
+	return os.Getenv(AllowInsecureRemoteURLEnv) == "1" ||
+		strings.EqualFold(os.Getenv(AllowInsecureRemoteURLEnv), "true")
+}
+
+func sameHostname(a, b string) bool {
+	return normalizeHostname(a) == normalizeHostname(b)
+}
+
+func normalizeHostname(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	return host
+}
+
+func isBlockedHostname(host string) bool {
+	host = normalizeHostname(host)
+	switch host {
+	case "localhost", "metadata", "metadata.google.internal", "metadata.azure.internal":
+		return true
+	}
+
+	blockedSuffixes := []string{
+		".localhost",
+		".local",
+		".localdomain",
+		".internal",
+		".cluster.local",
+		".svc",
+	}
+	for _, suffix := range blockedSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+var blockedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("255.255.255.255/32"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+	netip.MustParsePrefix("2001:db8::/32"),
+}
+
+func validateAddr(ip netip.Addr) error {
+	if !ip.IsValid() {
+		return fmt.Errorf("invalid IP address")
+	}
+	if ip.Zone() != "" {
+		return fmt.Errorf("scoped IPv6 addresses are not allowed")
+	}
+
+	ip = ip.Unmap()
+	for _, prefix := range blockedPrefixes {
+		if prefix.Contains(ip) {
+			return fmt.Errorf("address is in blocked range %s", prefix)
+		}
+	}
+	if !ip.IsGlobalUnicast() || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("address is not public")
+	}
+
+	return nil
+}

--- a/pkg/remoteurl/remoteurl.go
+++ b/pkg/remoteurl/remoteurl.go
@@ -132,6 +132,19 @@ func GuardTransport(base http.RoundTripper) http.RoundTripper {
 	return DefaultValidator().GuardTransport(base)
 }
 
+func DirectTransport() http.RoundTripper {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		cloned := transport.Clone()
+		cloned.Proxy = nil
+		return cloned
+	}
+	return &http.Transport{}
+}
+
+func GuardDirectTransport() http.RoundTripper {
+	return DefaultValidator().GuardTransport(DirectTransport())
+}
+
 func (v Validator) GuardTransport(base http.RoundTripper) http.RoundTripper {
 	if base == nil {
 		base = http.DefaultTransport
@@ -148,6 +161,17 @@ func NewHTTPClient(timeout time.Duration, base http.RoundTripper) *http.Client {
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: validator.GuardTransport(base),
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			return validator.ValidateURL(req.Context(), req.URL)
+		},
+	}
+}
+
+func NewDirectHTTPClient(timeout time.Duration) *http.Client {
+	validator := DefaultValidator()
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: validator.GuardTransport(DirectTransport()),
 		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
 			return validator.ValidateURL(req.Context(), req.URL)
 		},

--- a/pkg/remoteurl/remoteurl.go
+++ b/pkg/remoteurl/remoteurl.go
@@ -196,7 +196,11 @@ func (v Validator) guardDialer(base http.RoundTripper) http.RoundTripper {
 			return originalDialContext(ctx, network, address)
 		}
 
-		targetHost, _ := ctx.Value(contextKey{}).(string)
+		targetHost, ok := ctx.Value(contextKey{}).(string)
+		if !ok || targetHost == "" {
+			return nil, fmt.Errorf("remote URL target host missing from request context")
+		}
+
 		if !sameHostname(targetHost, host) || v.allowInsecure {
 			return originalDialContext(ctx, network, address)
 		}
@@ -308,6 +312,7 @@ var blockedPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("255.255.255.255/32"),
 	netip.MustParsePrefix("::/128"),
 	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 	netip.MustParsePrefix("ff00::/8"),

--- a/pkg/remoteurl/remoteurl_test.go
+++ b/pkg/remoteurl/remoteurl_test.go
@@ -1,0 +1,109 @@
+package remoteurl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeResolver map[string][]netip.Addr
+
+func (r fakeResolver) LookupNetIP(_ context.Context, _ string, host string) ([]netip.Addr, error) {
+	if ips, ok := r[host]; ok {
+		return ips, nil
+	}
+	return nil, fmt.Errorf("unexpected lookup for %s", host)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestValidateRejectsUnsafeRemoteURLs(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"private.example.test": {netip.MustParseAddr("10.0.0.5")},
+			"mixed.example.test":   {netip.MustParseAddr("8.8.8.8"), netip.MustParseAddr("10.0.0.5")},
+		},
+	})
+
+	tests := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "http scheme", rawURL: "http://example.com/mcp"},
+		{name: "userinfo", rawURL: "https://user:pass@example.com/mcp"},
+		{name: "non-http scheme", rawURL: "ftp://example.com/mcp"},
+		{name: "localhost", rawURL: "https://localhost/mcp"},
+		{name: "loopback IPv4", rawURL: "https://127.0.0.1/mcp"},
+		{name: "loopback IPv6", rawURL: "https://[::1]/mcp"},
+		{name: "IPv4-mapped loopback", rawURL: "https://[::ffff:127.0.0.1]/mcp"},
+		{name: "link local", rawURL: "https://169.254.169.254/latest/meta-data"},
+		{name: "private IP", rawURL: "https://10.0.0.1/mcp"},
+		{name: "cluster suffix", rawURL: "https://api.default.svc.cluster.local/mcp"},
+		{name: "metadata hostname", rawURL: "https://metadata.google.internal/computeMetadata/v1"},
+		{name: "DNS private result", rawURL: "https://private.example.test/mcp"},
+		{name: "DNS mixed result", rawURL: "https://mixed.example.test/mcp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(context.Background(), tt.rawURL)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateAllowsPublicHTTPS(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"public.example.test": {netip.MustParseAddr("8.8.8.8")},
+		},
+	})
+
+	require.NoError(t, validator.Validate(context.Background(), "https://public.example.test/mcp"))
+}
+
+func TestValidateAllowsInsecureDevURLsWhenOptedIn(t *testing.T) {
+	validator := NewValidator(Options{AllowInsecure: true})
+
+	require.NoError(t, validator.Validate(context.Background(), "http://localhost:3000/mcp"))
+	assert.Error(t, validator.Validate(context.Background(), "file://localhost/tmp/socket"))
+	assert.Error(t, validator.Validate(context.Background(), "https://user@example.com/mcp"))
+}
+
+func TestGuardTransportRejectsUnsafeRedirects(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"public.example.test": {netip.MustParseAddr("8.8.8.8")},
+		},
+	})
+
+	calls := 0
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header: http.Header{
+				"Location": []string{"https://127.0.0.1/mcp"},
+			},
+			Body:    http.NoBody,
+			Request: req,
+		}, nil
+	})
+
+	client := &http.Client{
+		Transport: validator.GuardTransport(base),
+	}
+
+	_, err := client.Get("https://public.example.test/mcp")
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "redirect destination should be rejected before the second request reaches the base transport")
+}

--- a/pkg/remoteurl/remoteurl_test.go
+++ b/pkg/remoteurl/remoteurl_test.go
@@ -75,8 +75,15 @@ func TestValidateAllowsInsecureDevURLsWhenOptedIn(t *testing.T) {
 	validator := NewValidator(Options{AllowInsecure: true})
 
 	require.NoError(t, validator.Validate(context.Background(), "http://localhost:3000/mcp"))
-	assert.Error(t, validator.Validate(context.Background(), "file://localhost/tmp/socket"))
-	assert.Error(t, validator.Validate(context.Background(), "https://user@example.com/mcp"))
+	require.Error(t, validator.Validate(context.Background(), "file://localhost/tmp/socket"))
+	require.Error(t, validator.Validate(context.Background(), "https://user@example.com/mcp"))
+}
+
+func TestDirectTransportDisablesProxy(t *testing.T) {
+	transport, ok := DirectTransport().(*http.Transport)
+
+	require.True(t, ok)
+	assert.Nil(t, transport.Proxy)
 }
 
 func TestGuardTransportRejectsUnsafeRedirects(t *testing.T) {
@@ -103,7 +110,10 @@ func TestGuardTransportRejectsUnsafeRedirects(t *testing.T) {
 		Transport: validator.GuardTransport(base),
 	}
 
-	_, err := client.Get("https://public.example.test/mcp")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://public.example.test/mcp", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = client.Do(req)
 	require.Error(t, err)
 	assert.Equal(t, 1, calls, "redirect destination should be rejected before the second request reaches the base transport")
 }

--- a/pkg/remoteurl/remoteurl_test.go
+++ b/pkg/remoteurl/remoteurl_test.go
@@ -3,6 +3,7 @@ package remoteurl
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/netip"
 	"testing"
@@ -45,6 +46,7 @@ func TestValidateRejectsUnsafeRemoteURLs(t *testing.T) {
 		{name: "loopback IPv4", rawURL: "https://127.0.0.1/mcp"},
 		{name: "loopback IPv6", rawURL: "https://[::1]/mcp"},
 		{name: "IPv4-mapped loopback", rawURL: "https://[::ffff:127.0.0.1]/mcp"},
+		{name: "NAT64 well-known prefix", rawURL: "https://[64:ff9b::a9fe:a9fe]/mcp"},
 		{name: "link local", rawURL: "https://169.254.169.254/latest/meta-data"},
 		{name: "private IP", rawURL: "https://10.0.0.1/mcp"},
 		{name: "cluster suffix", rawURL: "https://api.default.svc.cluster.local/mcp"},
@@ -84,6 +86,31 @@ func TestDirectTransportDisablesProxy(t *testing.T) {
 
 	require.True(t, ok)
 	assert.Nil(t, transport.Proxy)
+}
+
+func TestGuardDialerRequiresRequestTargetHost(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"public.example.test": {netip.MustParseAddr("8.8.8.8")},
+		},
+	})
+
+	calledDialer := false
+	base := &http.Transport{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			calledDialer = true
+			return nil, fmt.Errorf("unexpected dial")
+		},
+	}
+
+	rt := validator.guardDialer(base)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://public.example.test/mcp", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target host missing")
+	assert.False(t, calledDialer)
 }
 
 func TestGuardTransportRejectsUnsafeRedirects(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a centralized remote URL guard that requires public HTTPS destinations by default, rejects userinfo and unsafe hostnames/IP ranges, resolves DNS before use, and validates redirect destinations through a guarded transport.
- Applies the guard to remote MCP client connections and dynamic OAuth discovery/DCR/token HTTP paths that derive from remote MCP URLs.
- Adds regression coverage for loopback, link-local, private, metadata, cluster-local, userinfo, DNS resolution, redirect blocking, NAT64, and the remote client rejection path.

## Developer impact

Local or HTTP remote MCP endpoints now require an explicit dev/test opt-in via `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1`.

Guarded remote MCP and OAuth HTTP flows intentionally use direct transports instead of Docker Desktop/corporate proxy transports. A forward proxy hides the final target from the client-side dial-time IP validation, so direct dialing is the current security tradeoff for these guarded paths. Environments that require proxy routing may need a follow-up design that can validate the proxy-resolved destination equivalently; this tradeoff should be reviewed with Desktop proxy owners before merge.

## Validation

- `go test ./pkg/remoteurl ./pkg/oauth ./pkg/oauth/dcr ./pkg/oauthdiscovery`
- `go test -short ./pkg/mcp`
- `go test ./cmd/docker-mcp/server -run 'TestEnable'`
- `go test -short ./pkg/...`
- `docker buildx build --no-cache --build-arg GO_LDFLAGS --build-arg DOCKER_MCP_PLUGIN_BINARY --target=lint --platform=darwin .`

Note: `go test -short ./pkg/... ./cmd/docker-mcp/...` still fails in existing command-package tests that attempt to use Docker Desktop proxy sockets / localhost test servers in this environment; the full `pkg/...` short suite and directly affected command-server tests pass.