### PR TITLE
Sec #2: Harden container gateway auth

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -39,6 +39,7 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 				Cpus:         1,
 				Memory:       "2Gb",
 				Transport:    "stdio",
+				Host:         gateway.DefaultContainerGatewayHost,
 				LogCalls:     true,
 				BlockSecrets: true,
 				Verbose:      true,
@@ -203,7 +204,9 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 	runCmd.Flags().StringArrayVar(&options.OciRef, "oci-ref", options.OciRef, "OCI image references to use")
 	runCmd.Flags().StringSliceVar(&mcpRegistryUrls, "mcp-registry", nil, "MCP registry URLs to fetch servers from (can be repeated)")
 	runCmd.Flags().IntVar(&options.Port, "port", options.Port, "TCP port to listen on (default is to listen on stdio)")
+	runCmd.Flags().StringVar(&options.Host, "host", options.Host, "Host or IP address to bind TCP transports to")
 	runCmd.Flags().StringVar(&options.Transport, "transport", options.Transport, "stdio, sse or streaming. Uses MCP_GATEWAY_AUTH_TOKEN environment variable for localhost authentication to prevent dns rebinding attacks.")
+	runCmd.Flags().BoolVar(&options.AllowUnauthenticated, "allow-unauthenticated", options.AllowUnauthenticated, "Allow unauthenticated HTTP/SSE gateway requests")
 	runCmd.Flags().BoolVar(&options.LogCalls, "log-calls", options.LogCalls, "Log calls to the tools")
 	runCmd.Flags().BoolVar(&options.BlockSecrets, "block-secrets", options.BlockSecrets, "Block secrets from being/received sent to/from tools")
 	runCmd.Flags().BoolVar(&options.BlockNetwork, "block-network", options.BlockNetwork, "Block tools from accessing forbidden network resources")

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -39,7 +39,6 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 				Cpus:         1,
 				Memory:       "2Gb",
 				Transport:    "stdio",
-				Host:         gateway.DefaultContainerGatewayHost,
 				LogCalls:     true,
 				BlockSecrets: true,
 				Verbose:      true,

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/mcp-gateway/pkg/features"
-	gatewaypkg "github.com/docker/mcp-gateway/pkg/gateway"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGatewayRunCommandContainerNetworkDefaults(t *testing.T) {
+func TestGatewayRunCommandContainerAuthDefaults(t *testing.T) {
 	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
 
 	cmd := gatewayCommand(nil, nil, features.AllDisabled())
@@ -18,7 +17,7 @@ func TestGatewayRunCommandContainerNetworkDefaults(t *testing.T) {
 
 	hostFlag := runCmd.Flags().Lookup("host")
 	assert.NotNil(t, hostFlag)
-	assert.Equal(t, gatewaypkg.DefaultContainerGatewayHost, hostFlag.DefValue)
+	assert.Empty(t, hostFlag.DefValue)
 
 	allowUnauthenticatedFlag := runCmd.Flags().Lookup("allow-unauthenticated")
 	assert.NotNil(t, allowUnauthenticatedFlag)

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -4,8 +4,26 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/mcp-gateway/pkg/features"
+	gatewaypkg "github.com/docker/mcp-gateway/pkg/gateway"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGatewayRunCommandContainerNetworkDefaults(t *testing.T) {
+	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
+
+	cmd := gatewayCommand(nil, nil, features.AllDisabled())
+	runCmd, _, err := cmd.Find([]string{"run"})
+	assert.NoError(t, err)
+
+	hostFlag := runCmd.Flags().Lookup("host")
+	assert.NotNil(t, hostFlag)
+	assert.Equal(t, gatewaypkg.DefaultContainerGatewayHost, hostFlag.DefValue)
+
+	allowUnauthenticatedFlag := runCmd.Flags().Lookup("allow-unauthenticated")
+	assert.NotNil(t, allowUnauthenticatedFlag)
+	assert.Equal(t, "false", allowUnauthenticatedFlag.DefValue)
+}
 
 func TestIsOAuthInterceptorFeatureEnabled(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
-	"github.com/docker/mcp-gateway/pkg/features"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/features"
 )
 
 func TestGatewayRunCommandContainerAuthDefaults(t *testing.T) {
@@ -13,7 +15,7 @@ func TestGatewayRunCommandContainerAuthDefaults(t *testing.T) {
 
 	cmd := gatewayCommand(nil, nil, features.AllDisabled())
 	runCmd, _, err := cmd.Find([]string{"run"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	hostFlag := runCmd.Flags().Lookup("host")
 	assert.NotNil(t, hostFlag)

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -45,6 +45,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: allow-unauthenticated
+      value_type: bool
+      default_value: "false"
+      description: Allow unauthenticated HTTP/SSE gateway requests
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: block-network
       value_type: bool
       default_value: "false"
@@ -122,6 +132,15 @@ options:
       default_value: "false"
       description: |
         Enable all servers in the catalog (instead of using individual --servers options)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: host
+      value_type: string
+      description: Host or IP address to bind TCP transports to
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/generator/reference/mcp_gateway_run.md
+++ b/docs/generator/reference/mcp_gateway_run.md
@@ -11,6 +11,7 @@ Run the gateway
 | `--additional-config`       | `stringSlice` |                     | Additional config paths to merge with the default config.yaml                                                                                 |
 | `--additional-registry`     | `stringSlice` |                     | Additional registry paths to merge with the default registry.yaml                                                                             |
 | `--additional-tools-config` | `stringSlice` |                     | Additional tools paths to merge with the default tools.yaml                                                                                   |
+| `--allow-unauthenticated`   | `bool`        |                     | Allow unauthenticated HTTP/SSE gateway requests                                                                                               |
 | `--block-network`           | `bool`        |                     | Block tools from accessing forbidden network resources                                                                                        |
 | `--block-secrets`           | `bool`        | `true`              | Block secrets from being/received sent to/from tools                                                                                          |
 | `--catalog`                 | `stringSlice` | `[docker-mcp.yaml]` | Paths to docker catalogs (absolute or relative to ~/.docker/mcp/catalogs/)                                                                    |
@@ -19,6 +20,7 @@ Run the gateway
 | `--debug-dns`               | `bool`        |                     | Debug DNS resolution                                                                                                                          |
 | `--dry-run`                 | `bool`        |                     | Start the gateway but do not listen for connections (useful for testing the configuration)                                                    |
 | `--enable-all-servers`      | `bool`        |                     | Enable all servers in the catalog (instead of using individual --servers options)                                                             |
+| `--host`                    | `string`      |                     | Host or IP address to bind TCP transports to                                                                                                  |
 | `--interceptor`             | `stringArray` |                     | List of interceptors to use (format: when:type:path, e.g. 'before:exec:/bin/path')                                                            |
 | `--log-calls`               | `bool`        | `true`              | Log calls to the tools                                                                                                                        |
 | `--long-lived`              | `bool`        |                     | Containers are long-lived and will not be removed until the gateway is stopped, useful for stateful servers                                   |

--- a/pkg/gateway/auth_test.go
+++ b/pkg/gateway/auth_test.go
@@ -1,11 +1,14 @@
 package gateway
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/docker/mcp-gateway/pkg/log"
 )
 
 func TestGenerateAuthToken(t *testing.T) {
@@ -104,10 +107,13 @@ func TestInitializeHTTPAuth_ContainerModeRequiresAuth(t *testing.T) {
 func TestInitializeHTTPAuth_AllowUnauthenticatedSkipsAuth(t *testing.T) {
 	t.Setenv("MCP_GATEWAY_AUTH_TOKEN", "ignored-token")
 
+	var logs bytes.Buffer
+	log.SetLogWriter(&logs)
+	defer log.SetLogWriter(os.Stderr)
+
 	g := &Gateway{
 		Options: Options{
 			Transport:            "streaming",
-			Host:                 "0.0.0.0",
 			AllowUnauthenticated: true,
 		},
 	}
@@ -117,6 +123,17 @@ func TestInitializeHTTPAuth_AllowUnauthenticatedSkipsAuth(t *testing.T) {
 	}
 	if g.authToken != "" {
 		t.Errorf("expected auth token to stay empty when unauthenticated access is explicit, got %q", g.authToken)
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "ignoring MCP_GATEWAY_AUTH_TOKEN because --allow-unauthenticated is set") {
+		t.Errorf("expected log output to mention ignored auth token, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "without authentication on all interfaces") {
+		t.Errorf("expected log output to mention unauthenticated all-interfaces listener, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "execute configured MCP tools") {
+		t.Errorf("expected log output to mention tool execution risk, got %q", logOutput)
 	}
 }
 

--- a/pkg/gateway/auth_test.go
+++ b/pkg/gateway/auth_test.go
@@ -120,32 +120,6 @@ func TestInitializeHTTPAuth_AllowUnauthenticatedSkipsAuth(t *testing.T) {
 	}
 }
 
-func TestApplyRuntimeDefaults_ContainerBindsLoopback(t *testing.T) {
-	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
-
-	g := &Gateway{}
-	g.applyRuntimeDefaults()
-
-	if g.Host != DefaultContainerGatewayHost {
-		t.Errorf("expected container default host %q, got %q", DefaultContainerGatewayHost, g.Host)
-	}
-}
-
-func TestApplyRuntimeDefaults_ExplicitHostWins(t *testing.T) {
-	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
-
-	g := &Gateway{
-		Options: Options{
-			Host: "0.0.0.0",
-		},
-	}
-	g.applyRuntimeDefaults()
-
-	if g.Host != "0.0.0.0" {
-		t.Errorf("expected explicit host to be preserved, got %q", g.Host)
-	}
-}
-
 func TestAuthenticationMiddleware_HealthEndpoint(t *testing.T) {
 	authToken := "test-token-123"
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/gateway/auth_test.go
+++ b/pkg/gateway/auth_test.go
@@ -80,6 +80,72 @@ func TestGetOrGenerateAuthToken_EmptyEnvironment(t *testing.T) {
 	}
 }
 
+func TestInitializeHTTPAuth_ContainerModeRequiresAuth(t *testing.T) {
+	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
+	t.Setenv("MCP_GATEWAY_AUTH_TOKEN", "container-token")
+
+	g := &Gateway{
+		Options: Options{
+			Transport: "sse",
+		},
+	}
+
+	if err := g.initializeHTTPAuth(); err != nil {
+		t.Fatalf("initializeHTTPAuth() failed: %v", err)
+	}
+	if g.authToken != "container-token" {
+		t.Errorf("expected auth token from environment, got %q", g.authToken)
+	}
+	if g.authTokenWasGenerated {
+		t.Error("expected authTokenWasGenerated to be false")
+	}
+}
+
+func TestInitializeHTTPAuth_AllowUnauthenticatedSkipsAuth(t *testing.T) {
+	t.Setenv("MCP_GATEWAY_AUTH_TOKEN", "ignored-token")
+
+	g := &Gateway{
+		Options: Options{
+			Transport:            "streaming",
+			Host:                 "0.0.0.0",
+			AllowUnauthenticated: true,
+		},
+	}
+
+	if err := g.initializeHTTPAuth(); err != nil {
+		t.Fatalf("initializeHTTPAuth() failed: %v", err)
+	}
+	if g.authToken != "" {
+		t.Errorf("expected auth token to stay empty when unauthenticated access is explicit, got %q", g.authToken)
+	}
+}
+
+func TestApplyRuntimeDefaults_ContainerBindsLoopback(t *testing.T) {
+	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
+
+	g := &Gateway{}
+	g.applyRuntimeDefaults()
+
+	if g.Host != DefaultContainerGatewayHost {
+		t.Errorf("expected container default host %q, got %q", DefaultContainerGatewayHost, g.Host)
+	}
+}
+
+func TestApplyRuntimeDefaults_ExplicitHostWins(t *testing.T) {
+	t.Setenv("DOCKER_MCP_IN_CONTAINER", "1")
+
+	g := &Gateway{
+		Options: Options{
+			Host: "0.0.0.0",
+		},
+	}
+	g.applyRuntimeDefaults()
+
+	if g.Host != "0.0.0.0" {
+		t.Errorf("expected explicit host to be preserved, got %q", g.Host)
+	}
+}
+
 func TestAuthenticationMiddleware_HealthEndpoint(t *testing.T) {
 	authToken := "test-token-123"
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/gateway/config.go
+++ b/pkg/gateway/config.go
@@ -2,6 +2,8 @@ package gateway
 
 import "github.com/docker/mcp-gateway/pkg/catalog"
 
+const DefaultContainerGatewayHost = "127.0.0.1"
+
 type Config struct {
 	Options
 	WorkingSet         string
@@ -16,6 +18,7 @@ type Config struct {
 
 type Options struct {
 	Port                    int
+	Host                    string
 	Transport               string
 	ToolNames               []string
 	Interceptors            []string
@@ -39,4 +42,5 @@ type Options struct {
 	LogFilePath             string
 	UseEmbeddings           bool
 	UseProfiles             bool
+	AllowUnauthenticated    bool
 }

--- a/pkg/gateway/config.go
+++ b/pkg/gateway/config.go
@@ -2,8 +2,6 @@ package gateway
 
 import "github.com/docker/mcp-gateway/pkg/catalog"
 
-const DefaultContainerGatewayHost = "127.0.0.1"
-
 type Config struct {
 	Options
 	WorkingSet         string

--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -492,8 +492,11 @@ func (g *Gateway) initializeHTTPAuth() error {
 		return nil
 	}
 	if g.AllowUnauthenticated {
+		if os.Getenv("MCP_GATEWAY_AUTH_TOKEN") != "" {
+			log.Log("Warning: ignoring MCP_GATEWAY_AUTH_TOKEN because --allow-unauthenticated is set")
+		}
 		if isExternallyReachableHost(g.Host) {
-			log.Log("Warning: unauthenticated gateway access is enabled on a non-loopback listener")
+			log.Logf("WARNING: --allow-unauthenticated is exposing the MCP gateway without authentication on %s. Any client that can reach this listener can execute configured MCP tools. Remove --allow-unauthenticated or bind with --host 127.0.0.1 unless this is intentional.", gatewayListenerDescription(g.Host))
 		}
 		return nil
 	}
@@ -521,6 +524,14 @@ func isHTTPTransport(transport string) bool {
 
 func gatewayListenAddress(host string, port int) string {
 	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func gatewayListenerDescription(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "all interfaces"
+	}
+	return host
 }
 
 func isExternallyReachableHost(host string) bool {

--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -143,6 +144,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 	if g.policyClient == nil {
 		g.policyClient = newPolicyClient(ctx)
 	}
+	g.applyRuntimeDefaults()
 
 	// Set up log file redirection if specified
 	if g.LogFilePath != "" {
@@ -226,7 +228,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 			lc  net.ListenConfig
 			err error
 		)
-		ln, err = lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
+		ln, err = lc.Listen(ctx, "tcp", gatewayListenAddress(g.Host, port))
 		if err != nil {
 			return err
 		}
@@ -340,7 +342,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 		return fmt.Errorf("loading configuration: %w", err)
 	}
 
-	// When running in Container mode, disable OAuth notification monitoring and authentication
+	// When running in Container mode, disable OAuth notification monitoring.
 	inContainer := os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1"
 
 	if g.McpOAuthDcrEnabled && !inContainer {
@@ -437,16 +439,10 @@ func (g *Gateway) Run(ctx context.Context) error {
 		return nil
 	}
 
-	// Initialize authentication token for SSE and streaming modes
-	// Skip authentication when running in container (DOCKER_MCP_IN_CONTAINER=1)
+	// Initialize authentication token for SSE and streaming modes.
 	transport := strings.ToLower(g.Transport)
-	if (transport == "sse" || transport == "http" || transport == "streamable" || transport == "streaming" || transport == "streamable-http") && !inContainer {
-		token, wasGenerated, err := getOrGenerateAuthToken()
-		if err != nil {
-			return fmt.Errorf("failed to initialize auth token: %w", err)
-		}
-		g.authToken = token
-		g.authTokenWasGenerated = wasGenerated
+	if err := g.initializeHTTPAuth(); err != nil {
+		return err
 	}
 
 	// Start the server
@@ -459,9 +455,9 @@ func (g *Gateway) Run(ctx context.Context) error {
 		log.Log("> Start sse server on port", g.Port)
 		endpoint := "/sse"
 		url := formatGatewayURL(g.Port, endpoint)
-		if inContainer {
+		if g.AllowUnauthenticated {
 			log.Logf("> Gateway URL: %s", url)
-			log.Logf("> Authentication disabled (running in container)")
+			log.Logf("> Authentication disabled by explicit configuration")
 		} else if g.authTokenWasGenerated {
 			log.Logf("> Gateway URL: %s", url)
 			log.Logf("> Use Bearer token: %s", formatBearerToken(g.authToken))
@@ -475,9 +471,9 @@ func (g *Gateway) Run(ctx context.Context) error {
 		log.Log("> Start streaming server on port", g.Port)
 		endpoint := "/mcp"
 		url := formatGatewayURL(g.Port, endpoint)
-		if inContainer {
+		if g.AllowUnauthenticated {
 			log.Logf("> Gateway URL: %s", url)
-			log.Logf("> Authentication disabled (running in container)")
+			log.Logf("> Authentication disabled by explicit configuration")
 		} else if g.authTokenWasGenerated {
 			log.Logf("> Gateway URL: %s", url)
 			log.Logf("> Use Bearer token: %s", formatBearerToken(g.authToken))
@@ -490,6 +486,66 @@ func (g *Gateway) Run(ctx context.Context) error {
 	default:
 		return fmt.Errorf("unknown transport %q, expected 'stdio', 'sse' or 'streaming", g.Transport)
 	}
+}
+
+func (g *Gateway) applyRuntimeDefaults() {
+	if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" && g.Host == "" {
+		g.Host = DefaultContainerGatewayHost
+	}
+}
+
+func (g *Gateway) initializeHTTPAuth() error {
+	if !isHTTPTransport(g.Transport) {
+		return nil
+	}
+	if g.AllowUnauthenticated {
+		if isExternallyReachableHost(g.Host) {
+			log.Log("Warning: unauthenticated gateway access is enabled on a non-loopback listener")
+		}
+		return nil
+	}
+
+	token, wasGenerated, err := getOrGenerateAuthToken()
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth token: %w", err)
+	}
+	if token == "" {
+		return fmt.Errorf("authentication token is empty")
+	}
+	g.authToken = token
+	g.authTokenWasGenerated = wasGenerated
+	return nil
+}
+
+func isHTTPTransport(transport string) bool {
+	switch strings.ToLower(transport) {
+	case "sse", "http", "streamable", "streaming", "streamable-http":
+		return true
+	default:
+		return false
+	}
+}
+
+func gatewayListenAddress(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func isExternallyReachableHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return true
+	}
+	if strings.EqualFold(host, "localhost") {
+		return false
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true
+	}
+	return !ip.IsLoopback()
 }
 
 // RefreshCapabilities implements the CapabilityRefresher interface

--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -144,7 +144,6 @@ func (g *Gateway) Run(ctx context.Context) error {
 	if g.policyClient == nil {
 		g.policyClient = newPolicyClient(ctx)
 	}
-	g.applyRuntimeDefaults()
 
 	// Set up log file redirection if specified
 	if g.LogFilePath != "" {
@@ -485,12 +484,6 @@ func (g *Gateway) Run(ctx context.Context) error {
 
 	default:
 		return fmt.Errorf("unknown transport %q, expected 'stdio', 'sse' or 'streaming", g.Transport)
-	}
-}
-
-func (g *Gateway) applyRuntimeDefaults() {
-	if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" && g.Host == "" {
-		g.Host = DefaultContainerGatewayHost
 	}
 }
 

--- a/pkg/gateway/transport.go
+++ b/pkg/gateway/transport.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -19,6 +20,10 @@ func (g *Gateway) startStdioServer(ctx context.Context, _ io.Reader, _ io.Writer
 }
 
 func (g *Gateway) startSseServer(ctx context.Context, ln net.Listener) error {
+	if g.authToken == "" && !g.AllowUnauthenticated {
+		return errors.New("authentication token is required for SSE transport")
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthHandler(&g.health))
 	mux.Handle("/", redirectHandler("/sse"))
@@ -44,6 +49,10 @@ func (g *Gateway) startSseServer(ctx context.Context, ln net.Listener) error {
 }
 
 func (g *Gateway) startStreamingServer(ctx context.Context, ln net.Listener) error {
+	if g.authToken == "" && !g.AllowUnauthenticated {
+		return errors.New("authentication token is required for streaming transport")
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthHandler(&g.health))
 	mux.Handle("/", redirectHandler("/mcp"))

--- a/pkg/gateway/transport_test.go
+++ b/pkg/gateway/transport_test.go
@@ -61,6 +61,101 @@ func TestIsAllowedOrigin(t *testing.T) {
 	}
 }
 
+func TestGatewayListenAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port int
+		want string
+	}{
+		{
+			name: "all interfaces",
+			host: "",
+			port: 8811,
+			want: ":8811",
+		},
+		{
+			name: "ipv4 loopback",
+			host: "127.0.0.1",
+			port: 8811,
+			want: "127.0.0.1:8811",
+		},
+		{
+			name: "ipv6 loopback",
+			host: "::1",
+			port: 8811,
+			want: "[::1]:8811",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gatewayListenAddress(tt.host, tt.port)
+			if got != tt.want {
+				t.Errorf("gatewayListenAddress(%q, %d) = %q, expected %q", tt.host, tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsExternallyReachableHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{
+			name: "empty host binds all interfaces",
+			host: "",
+			want: true,
+		},
+		{
+			name: "zero ipv4 binds all interfaces",
+			host: "0.0.0.0",
+			want: true,
+		},
+		{
+			name: "zero ipv6 binds all interfaces",
+			host: "::",
+			want: true,
+		},
+		{
+			name: "localhost",
+			host: "localhost",
+			want: false,
+		},
+		{
+			name: "ipv4 loopback",
+			host: "127.0.0.1",
+			want: false,
+		},
+		{
+			name: "ipv6 loopback",
+			host: "::1",
+			want: false,
+		},
+		{
+			name: "external ipv4",
+			host: "192.0.2.1",
+			want: true,
+		},
+		{
+			name: "hostname",
+			host: "gateway.example.com",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isExternallyReachableHost(tt.host)
+			if got != tt.want {
+				t.Errorf("isExternallyReachableHost(%q) = %v, expected %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOriginSecurityHandler(t *testing.T) {
 	// Create a simple handler that always succeeds if reached
 	successHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/gateway/transport_test.go
+++ b/pkg/gateway/transport_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -151,6 +152,42 @@ func TestIsExternallyReachableHost(t *testing.T) {
 			got := isExternallyReachableHost(tt.host)
 			if got != tt.want {
 				t.Errorf("isExternallyReachableHost(%q) = %v, expected %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPTransportsRequireAuthToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   func(*Gateway) error
+		wantErr string
+	}{
+		{
+			name: "sse",
+			start: func(g *Gateway) error {
+				return g.startSseServer(context.Background(), nil)
+			},
+			wantErr: "authentication token is required for SSE transport",
+		},
+		{
+			name: "streaming",
+			start: func(g *Gateway) error {
+				return g.startStreamingServer(context.Background(), nil)
+			},
+			wantErr: "authentication token is required for streaming transport",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Gateway{}
+			err := tt.start(g)
+			if err == nil {
+				t.Fatalf("expected auth token error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error to contain %q, got %q", tt.wantErr, err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- require bearer-token auth for SSE/streaming gateway transports even when running with DOCKER_MCP_IN_CONTAINER=1
- keep container TCP listeners reachable by default for published ports and Compose service-name access, with --host available for explicit bind overrides
- add --allow-unauthenticated as the explicit opt-out and fail closed when HTTP transports start without auth
- add focused tests for container auth setup, listener binding helpers, CLI defaults, and generated CLI reference docs

## Validation

- go test ./pkg/gateway
- go test ./pkg/gateway -run 'Test(InitializeHTTPAuth|GatewayListenAddress|IsExternallyReachableHost)'
- go test ./cmd/docker-mcp/commands -run TestGatewayRunCommandContainerAuthDefaults
- make lint-windows
- make docs

Note: local docker buildx bake validate-docs is blocked in this worktree because Docker sees a .git file pointing at an external worktree path that is not mounted into the build context. The generated docs were refreshed with make docs.