### PR TITLE
Sec #7: Constrain local file inputs

### DIFF
--- a/cmd/docker-mcp/commands/catalog_next.go
+++ b/cmd/docker-mcp/commands/catalog_next.go
@@ -121,7 +121,7 @@ When using --server without --from-profile, --from-legacy-catalog, or --from-com
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path). Can be specified multiple times.")
+	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 	flags.StringVar(&opts.FromWorkingSet, "from-profile", "", "Profile ID to create the catalog from")
 	flags.StringVar(&opts.FromLegacyCatalog, "from-legacy-catalog", "", "Legacy catalog URL to create the catalog from")
 	flags.StringVar(&opts.FromCommunityRegistry, "from-community-registry", "", "Community registry hostname to fetch servers from (e.g. registry.modelcontextprotocol.io)")
@@ -415,7 +415,7 @@ func addCatalogNextServersCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path). Can be specified multiple times.")
+	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 
 	return cmd
 }

--- a/cmd/docker-mcp/commands/catalog_next.go
+++ b/cmd/docker-mcp/commands/catalog_next.go
@@ -121,7 +121,7 @@ When using --server without --from-profile, --from-legacy-catalog, or --from-com
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
+	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path that resolves under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 	flags.StringVar(&opts.FromWorkingSet, "from-profile", "", "Profile ID to create the catalog from")
 	flags.StringVar(&opts.FromLegacyCatalog, "from-legacy-catalog", "", "Legacy catalog URL to create the catalog from")
 	flags.StringVar(&opts.FromCommunityRegistry, "from-community-registry", "", "Community registry hostname to fetch servers from (e.g. registry.modelcontextprotocol.io)")
@@ -415,7 +415,7 @@ func addCatalogNextServersCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
+	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path that resolves under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 
 	return cmd
 }

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -189,8 +189,8 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 		runCmd.Flags().StringVar(&options.WorkingSet, "profile", "", "Profile ID to use (mutually exclusive with --servers and --enable-all-servers)")
 	}
 	runCmd.Flags().BoolVar(&enableAllServers, "enable-all-servers", false, "Enable all servers in the catalog (instead of using individual --servers options)")
-	runCmd.Flags().StringSliceVar(&options.CatalogPath, "catalog", options.CatalogPath, "Paths to docker catalogs (absolute or relative to ~/.docker/mcp/catalogs/)")
-	runCmd.Flags().StringSliceVar(&additionalCatalogs, "additional-catalog", nil, "Additional catalog paths to append to the default catalogs")
+	runCmd.Flags().StringSliceVar(&options.CatalogPath, "catalog", options.CatalogPath, "Paths to docker catalogs under ~/.docker/mcp/catalogs/")
+	runCmd.Flags().StringSliceVar(&additionalCatalogs, "additional-catalog", nil, "Additional catalog paths under ~/.docker/mcp/catalogs/ to append to the default catalogs")
 	runCmd.Flags().StringSliceVar(&options.RegistryPath, "registry", options.RegistryPath, "Paths to the registry files (absolute or relative to ~/.docker/mcp/)")
 	runCmd.Flags().StringSliceVar(&additionalRegistries, "additional-registry", nil, "Additional registry paths to merge with the default registry.yaml")
 	runCmd.Flags().StringSliceVar(&options.ConfigPath, "config", options.ConfigPath, "Paths to the config files (absolute or relative to ~/.docker/mcp/)")

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -189,8 +189,8 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 		runCmd.Flags().StringVar(&options.WorkingSet, "profile", "", "Profile ID to use (mutually exclusive with --servers and --enable-all-servers)")
 	}
 	runCmd.Flags().BoolVar(&enableAllServers, "enable-all-servers", false, "Enable all servers in the catalog (instead of using individual --servers options)")
-	runCmd.Flags().StringSliceVar(&options.CatalogPath, "catalog", options.CatalogPath, "Paths to docker catalogs under ~/.docker/mcp/catalogs/")
-	runCmd.Flags().StringSliceVar(&additionalCatalogs, "additional-catalog", nil, "Additional catalog paths under ~/.docker/mcp/catalogs/ to append to the default catalogs")
+	runCmd.Flags().StringSliceVar(&options.CatalogPath, "catalog", options.CatalogPath, "Catalog paths must resolve under ~/.docker/mcp/catalogs/")
+	runCmd.Flags().StringSliceVar(&additionalCatalogs, "additional-catalog", nil, "Additional catalog paths must resolve under ~/.docker/mcp/catalogs/")
 	runCmd.Flags().StringSliceVar(&options.RegistryPath, "registry", options.RegistryPath, "Paths to the registry files (absolute or relative to ~/.docker/mcp/)")
 	runCmd.Flags().StringSliceVar(&additionalRegistries, "additional-registry", nil, "Additional registry paths to merge with the default registry.yaml")
 	runCmd.Flags().StringSliceVar(&options.ConfigPath, "config", options.ConfigPath, "Paths to the config files (absolute or relative to ~/.docker/mcp/)")

--- a/cmd/docker-mcp/commands/workingset.go
+++ b/cmd/docker-mcp/commands/workingset.go
@@ -220,7 +220,7 @@ Use 'docker mcp template list' to see available templates.`,
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Name, "name", "", "Name of the profile (required unless --from-template is used)")
 	flags.StringVar(&opts.ID, "id", "", "ID of the profile (defaults to a slugified version of the name)")
-	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path). Can be specified multiple times.")
+	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 	flags.StringArrayVar(&opts.Connect, "connect", []string{}, fmt.Sprintf("Clients to connect to: mcp-client (can be specified multiple times). Supported clients: %s", client.GetSupportedMCPClients(*cfg)))
 	flags.StringVar(&opts.FromTemplate, "from-template", "", "Create profile from a starter template (use `docker mcp template list` to see options)")
 
@@ -466,7 +466,7 @@ func addServerCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path). Can be specified multiple times.")
+	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 
 	return cmd
 }

--- a/cmd/docker-mcp/commands/workingset.go
+++ b/cmd/docker-mcp/commands/workingset.go
@@ -220,7 +220,7 @@ Use 'docker mcp template list' to see available templates.`,
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Name, "name", "", "Name of the profile (required unless --from-template is used)")
 	flags.StringVar(&opts.ID, "id", "", "ID of the profile (defaults to a slugified version of the name)")
-	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
+	flags.StringArrayVar(&opts.Servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path that resolves under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 	flags.StringArrayVar(&opts.Connect, "connect", []string{}, fmt.Sprintf("Clients to connect to: mcp-client (can be specified multiple times). Supported clients: %s", client.GetSupportedMCPClients(*cfg)))
 	flags.StringVar(&opts.FromTemplate, "from-template", "", "Create profile from a starter template (use `docker mcp template list` to see options)")
 
@@ -466,7 +466,7 @@ func addServerCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path under ~/.docker/mcp/catalogs). Can be specified multiple times.")
+	flags.StringArrayVar(&servers, "server", []string{}, "Server to include specified with a URI: https:// (MCP Registry reference) or docker:// (Docker Image reference) or catalog:// (Catalog reference) or file:// (Local file path that resolves under ~/.docker/mcp/catalogs). Can be specified multiple times.")
 
 	return cmd
 }

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -8,7 +8,8 @@ options:
     - option: additional-catalog
       value_type: stringSlice
       default_value: '[]'
-      description: Additional catalog paths to append to the default catalogs
+      description: |
+        Additional catalog paths under ~/.docker/mcp/catalogs/ to append to the default catalogs
       deprecated: false
       hidden: false
       experimental: false
@@ -68,8 +69,7 @@ options:
     - option: catalog
       value_type: stringSlice
       default_value: '[docker-mcp.yaml]'
-      description: |
-        Paths to docker catalogs (absolute or relative to ~/.docker/mcp/catalogs/)
+      description: Paths to docker catalogs under ~/.docker/mcp/catalogs/
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -9,7 +9,7 @@ options:
       value_type: stringSlice
       default_value: '[]'
       description: |
-        Additional catalog paths under ~/.docker/mcp/catalogs/ to append to the default catalogs
+        Additional catalog paths must resolve under ~/.docker/mcp/catalogs/
       deprecated: false
       hidden: false
       experimental: false
@@ -69,7 +69,7 @@ options:
     - option: catalog
       value_type: stringSlice
       default_value: '[docker-mcp.yaml]'
-      description: Paths to docker catalogs under ~/.docker/mcp/catalogs/
+      description: Catalog paths must resolve under ~/.docker/mcp/catalogs/
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/generator/reference/mcp_gateway_run.md
+++ b/docs/generator/reference/mcp_gateway_run.md
@@ -7,13 +7,13 @@ Run the gateway
 
 | Name                        | Type          | Default             | Description                                                                                                                                   |
 |:----------------------------|:--------------|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
-| `--additional-catalog`      | `stringSlice` |                     | Additional catalog paths to append to the default catalogs                                                                                    |
+| `--additional-catalog`      | `stringSlice` |                     | Additional catalog paths under ~/.docker/mcp/catalogs/ to append to the default catalogs                                                      |
 | `--additional-config`       | `stringSlice` |                     | Additional config paths to merge with the default config.yaml                                                                                 |
 | `--additional-registry`     | `stringSlice` |                     | Additional registry paths to merge with the default registry.yaml                                                                             |
 | `--additional-tools-config` | `stringSlice` |                     | Additional tools paths to merge with the default tools.yaml                                                                                   |
 | `--block-network`           | `bool`        |                     | Block tools from accessing forbidden network resources                                                                                        |
 | `--block-secrets`           | `bool`        | `true`              | Block secrets from being/received sent to/from tools                                                                                          |
-| `--catalog`                 | `stringSlice` | `[docker-mcp.yaml]` | Paths to docker catalogs (absolute or relative to ~/.docker/mcp/catalogs/)                                                                    |
+| `--catalog`                 | `stringSlice` | `[docker-mcp.yaml]` | Paths to docker catalogs under ~/.docker/mcp/catalogs/                                                                                        |
 | `--config`                  | `stringSlice` | `[config.yaml]`     | Paths to the config files (absolute or relative to ~/.docker/mcp/)                                                                            |
 | `--cpus`                    | `int`         | `1`                 | CPUs allocated to each MCP Server (default is 1)                                                                                              |
 | `--debug-dns`               | `bool`        |                     | Debug DNS resolution                                                                                                                          |

--- a/docs/generator/reference/mcp_gateway_run.md
+++ b/docs/generator/reference/mcp_gateway_run.md
@@ -7,13 +7,13 @@ Run the gateway
 
 | Name                        | Type          | Default             | Description                                                                                                                                   |
 |:----------------------------|:--------------|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
-| `--additional-catalog`      | `stringSlice` |                     | Additional catalog paths under ~/.docker/mcp/catalogs/ to append to the default catalogs                                                      |
+| `--additional-catalog`      | `stringSlice` |                     | Additional catalog paths must resolve under ~/.docker/mcp/catalogs/                                                                           |
 | `--additional-config`       | `stringSlice` |                     | Additional config paths to merge with the default config.yaml                                                                                 |
 | `--additional-registry`     | `stringSlice` |                     | Additional registry paths to merge with the default registry.yaml                                                                             |
 | `--additional-tools-config` | `stringSlice` |                     | Additional tools paths to merge with the default tools.yaml                                                                                   |
 | `--block-network`           | `bool`        |                     | Block tools from accessing forbidden network resources                                                                                        |
 | `--block-secrets`           | `bool`        | `true`              | Block secrets from being/received sent to/from tools                                                                                          |
-| `--catalog`                 | `stringSlice` | `[docker-mcp.yaml]` | Paths to docker catalogs under ~/.docker/mcp/catalogs/                                                                                        |
+| `--catalog`                 | `stringSlice` | `[docker-mcp.yaml]` | Catalog paths must resolve under ~/.docker/mcp/catalogs/                                                                                      |
 | `--config`                  | `stringSlice` | `[config.yaml]`     | Paths to the config files (absolute or relative to ~/.docker/mcp/)                                                                            |
 | `--cpus`                    | `int`         | `1`                 | CPUs allocated to each MCP Server (default is 1)                                                                                              |
 | `--debug-dns`               | `bool`        |                     | Debug DNS resolution                                                                                                                          |

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -102,16 +102,6 @@ func readFileOrURL(ctx context.Context, fileOrURL string) ([]byte, error) {
 
 		return io.ReadAll(resp.Body)
 
-	case filepath.IsAbs(fileOrURL) || strings.HasPrefix(fileOrURL, "./"):
-		buf, err := os.ReadFile(fileOrURL)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		return buf, nil
-
 	default:
 		path, err := ResolveLocalCatalogPath(fileOrURL)
 		if err != nil {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -20,6 +21,8 @@ import (
 const (
 	DockerCatalogFilename = "docker-mcp.yaml"
 )
+
+var errUntrustedLocalPath = errors.New("local file path must resolve within Docker MCP catalogs directory")
 
 func Get(ctx context.Context) (Catalog, error) {
 	return ReadFrom(ctx, []string{DockerCatalogFilename})
@@ -110,12 +113,10 @@ func readFileOrURL(ctx context.Context, fileOrURL string) ([]byte, error) {
 		return buf, nil
 
 	default:
-		homeDir, err := user.HomeDir()
+		path, err := ResolveLocalCatalogPath(fileOrURL)
 		if err != nil {
 			return nil, err
 		}
-
-		path := filepath.Join(homeDir, ".docker", "mcp", "catalogs", fileOrURL)
 
 		buf, err := os.ReadFile(path)
 		if err != nil {
@@ -126,6 +127,67 @@ func readFileOrURL(ctx context.Context, fileOrURL string) ([]byte, error) {
 		}
 		return buf, nil
 	}
+}
+
+func ResolveLocalCatalogPath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("local file path is required")
+	}
+
+	homeDir, err := user.HomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	catalogsDir := filepath.Join(homeDir, ".docker", "mcp", "catalogs")
+	root, err := filepath.Abs(catalogsDir)
+	if err != nil {
+		return "", err
+	}
+
+	var candidate string
+	if filepath.IsAbs(path) || strings.HasPrefix(path, "."+string(filepath.Separator)) || path == "." {
+		candidate, err = filepath.Abs(path)
+	} else {
+		candidate, err = filepath.Abs(filepath.Join(root, path))
+	}
+	if err != nil {
+		return "", err
+	}
+
+	root, err = evalPathIfExists(root)
+	if err != nil {
+		return "", err
+	}
+	candidateForCheck, err := evalPathIfExists(candidate)
+	if err != nil {
+		return "", err
+	}
+
+	if !pathWithin(root, candidateForCheck) {
+		return "", errUntrustedLocalPath
+	}
+
+	return candidate, nil
+}
+
+func evalPathIfExists(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+	if os.IsNotExist(err) {
+		return path, nil
+	}
+	return "", err
+}
+
+func pathWithin(root, candidate string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func isURL(fileOrURL string) bool {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -158,7 +158,7 @@ func ResolveLocalCatalogPath(path string) (string, error) {
 		return "", errUntrustedLocalPath
 	}
 
-	return candidate, nil
+	return candidateForCheck, nil
 }
 
 func evalPathIfExists(path string) (string, error) {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -131,7 +131,7 @@ func TestCatalogPrecedenceOrder(t *testing.T) {
 	ctx := context.Background()
 
 	// Test precedence order: Docker → Configured → CLI-specified
-	additionalCatalogs := []string{filepath.Join(tempHome, "cli-catalog.yaml")}
+	additionalCatalogs := []string{filepath.Join(tempHome, ".docker", "mcp", "catalogs", "cli-catalog.yaml")}
 	catalog, err := GetWithOptions(ctx, true, additionalCatalogs)
 	require.NoError(t, err)
 
@@ -151,6 +151,49 @@ func TestCatalogPrecedenceOrder(t *testing.T) {
 	require.Len(t, overlappingServer.Tools, 1, "should have exactly the tools from winning server")
 	assert.Equal(t, "overlapping-tool", overlappingServer.Tools[0].Name, "tool name should be preserved")
 	assert.Equal(t, "CLI Catalog Server", overlappingServer.Tools[0].Description, "should use entire server from highest precedence catalog")
+}
+
+func TestReadOneRejectsCatalogPathTraversal(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "relative traversal outside catalogs dir",
+			path: "../outside.yaml",
+		},
+		{
+			name: "nested relative traversal outside catalogs dir",
+			path: "nested/../../outside.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := ReadOne(t.Context(), tt.path)
+			require.ErrorIs(t, err, errUntrustedLocalPath)
+		})
+	}
+}
+
+func TestReadOneRejectsSymlinkEscape(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	catalogsDir := filepath.Join(tempHome, ".docker", "mcp", "catalogs")
+	require.NoError(t, os.MkdirAll(catalogsDir, 0o755))
+
+	outsideCatalog := filepath.Join(t.TempDir(), "outside.yaml")
+	require.NoError(t, os.WriteFile(outsideCatalog, []byte("registry: {}\n"), 0o644))
+	if err := os.Symlink(outsideCatalog, filepath.Join(catalogsDir, "escape.yaml")); err != nil {
+		t.Skipf("symlink creation is not available: %v", err)
+	}
+
+	_, _, _, err := ReadOne(t.Context(), "escape.yaml")
+	require.ErrorIs(t, err, errUntrustedLocalPath)
 }
 
 // Helper functions
@@ -305,6 +348,6 @@ func setupOverlappingCatalogs(t *testing.T, homeDir string) {
         container:
           image: cli/overlapping-server
           command: []`
-	err = os.WriteFile(filepath.Join(homeDir, "cli-catalog.yaml"), []byte(cliCatalog), 0o644)
+	err = os.WriteFile(filepath.Join(catalogsDir, "cli-catalog.yaml"), []byte(cliCatalog), 0o644)
 	require.NoError(t, err)
 }

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -212,6 +212,27 @@ func TestReadOneRejectsSymlinkEscape(t *testing.T) {
 	require.ErrorIs(t, err, errUntrustedLocalPath)
 }
 
+func TestResolveLocalCatalogPathReturnsResolvedPath(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	catalogsDir := filepath.Join(tempHome, ".docker", "mcp", "catalogs")
+	require.NoError(t, os.MkdirAll(catalogsDir, 0o755))
+
+	targetCatalog := filepath.Join(catalogsDir, "target.yaml")
+	require.NoError(t, os.WriteFile(targetCatalog, []byte("registry: {}\n"), 0o644))
+	if err := os.Symlink(targetCatalog, filepath.Join(catalogsDir, "link.yaml")); err != nil {
+		t.Skipf("symlink creation is not available: %v", err)
+	}
+
+	resolvedTarget, err := filepath.EvalSymlinks(targetCatalog)
+	require.NoError(t, err)
+
+	path, err := ResolveLocalCatalogPath("link.yaml")
+	require.NoError(t, err)
+	require.Equal(t, resolvedTarget, path)
+}
+
 // Helper functions
 
 func setupTestCatalogs(t *testing.T, homeDir string) {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -157,10 +157,26 @@ func TestReadOneRejectsCatalogPathTraversal(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
 
+	cwd := t.TempDir()
+	originalCwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(originalCwd)
+	})
+	require.NoError(t, os.Chdir(cwd))
+
 	tests := []struct {
 		name string
 		path string
 	}{
+		{
+			name: "absolute path outside catalogs dir",
+			path: filepath.Join(t.TempDir(), "outside.yaml"),
+		},
+		{
+			name: "dot-relative path outside catalogs dir",
+			path: "./outside.yaml",
+		},
 		{
 			name: "relative traversal outside catalogs dir",
 			path: "../outside.yaml",

--- a/pkg/catalog_next/create_test.go
+++ b/pkg/catalog_next/create_test.go
@@ -17,6 +17,18 @@ import (
 	"github.com/docker/mcp-gateway/test/mocks"
 )
 
+func trustedLegacyCatalogPath(t *testing.T, name string) string {
+	t.Helper()
+
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	catalogFile := filepath.Join(tempHome, ".docker", "mcp", "catalogs", name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(catalogFile), 0o755))
+
+	return catalogFile
+}
+
 func TestCreateFromWorkingSet(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
@@ -381,9 +393,7 @@ func TestCreateFromLegacyCatalog(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	// Create a temporary legacy catalog file
-	tempDir := t.TempDir()
-	catalogFile := filepath.Join(tempDir, "test-catalog.yaml")
+	catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
 
 	legacyCatalogYAML := `name: test-catalog
 registry:
@@ -441,9 +451,7 @@ func TestCreateFromLegacyCatalogWithRemoveExistingWithSameContent(t *testing.T) 
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	// Create a temporary legacy catalog file
-	tempDir := t.TempDir()
-	catalogFile := filepath.Join(tempDir, "test-catalog.yaml")
+	catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
 
 	legacyCatalogYAML := `name: test-catalog
 registry:
@@ -498,9 +506,7 @@ func TestCreateFromLegacyCatalogWithRemoveExistingWithDifferentContent(t *testin
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	// Create a temporary legacy catalog file
-	tempDir := t.TempDir()
-	catalogFile := filepath.Join(tempDir, "test-catalog.yaml")
+	catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
 
 	legacyCatalogYAML := `name: test-catalog
 registry:
@@ -962,9 +968,7 @@ func TestCreateFromLegacyCatalogWithRemotes(t *testing.T) {
 			dao := setupTestDB(t)
 			ctx := t.Context()
 
-			// Create a temporary legacy catalog file
-			tempDir := t.TempDir()
-			catalogFile := filepath.Join(tempDir, "test-catalog.yaml")
+			catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
 
 			legacyCatalogYAML := "name: test-catalog\nregistry:\n  test-server:\n" + tt.serverYAML + "\n"
 

--- a/pkg/catalog_next/create_test.go
+++ b/pkg/catalog_next/create_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/docker/mcp-gateway/test/mocks"
 )
 
-func trustedLegacyCatalogPath(t *testing.T, name string) string {
+func trustedLegacyCatalogPath(t *testing.T) string {
 	t.Helper()
 
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
 
-	catalogFile := filepath.Join(tempHome, ".docker", "mcp", "catalogs", name)
+	catalogFile := filepath.Join(tempHome, ".docker", "mcp", "catalogs", "test-catalog.yaml")
 	require.NoError(t, os.MkdirAll(filepath.Dir(catalogFile), 0o755))
 
 	return catalogFile
@@ -393,7 +393,7 @@ func TestCreateFromLegacyCatalog(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
+	catalogFile := trustedLegacyCatalogPath(t)
 
 	legacyCatalogYAML := `name: test-catalog
 registry:
@@ -451,7 +451,7 @@ func TestCreateFromLegacyCatalogWithRemoveExistingWithSameContent(t *testing.T) 
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
+	catalogFile := trustedLegacyCatalogPath(t)
 
 	legacyCatalogYAML := `name: test-catalog
 registry:
@@ -506,7 +506,7 @@ func TestCreateFromLegacyCatalogWithRemoveExistingWithDifferentContent(t *testin
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
+	catalogFile := trustedLegacyCatalogPath(t)
 
 	legacyCatalogYAML := `name: test-catalog
 registry:
@@ -968,7 +968,7 @@ func TestCreateFromLegacyCatalogWithRemotes(t *testing.T) {
 			dao := setupTestDB(t)
 			ctx := t.Context()
 
-			catalogFile := trustedLegacyCatalogPath(t, "test-catalog.yaml")
+			catalogFile := trustedLegacyCatalogPath(t)
 
 			legacyCatalogYAML := "name: test-catalog\nregistry:\n  test-server:\n" + tt.serverYAML + "\n"
 

--- a/pkg/elicitation_integration_test.go
+++ b/pkg/elicitation_integration_test.go
@@ -86,14 +86,13 @@ func TestIntegrationWithElicitation(t *testing.T) {
 	buildElicitImage(t)
 
 	dockerClient := createDockerClientForElicitation(t)
-	tmp := t.TempDir()
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  elicit:\n    longLived: true\n    image: elicit:latest")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  elicit:\n    longLived: true\n    image: elicit:latest")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=elicit",
 		"--long-lived",
 		"--verbose",

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -47,8 +47,21 @@ func writeFile(t *testing.T, parent, name string, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
+func writeTrustedCatalogFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := filepath.Join(home, ".docker", "mcp", "catalogs", name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return path
+}
+
 // createClickhouseCatalogFile creates a temporary catalog file containing only the clickhouse server entry
-func createClickhouseCatalogFile(t *testing.T, tempDir string) string {
+func createClickhouseCatalogFile(t *testing.T) string {
 	t.Helper()
 
 	// Create a minimal catalog using raw YAML content
@@ -121,11 +134,7 @@ func createClickhouseCatalogFile(t *testing.T, tempDir string) string {
       owner: ClickHouse
 `
 
-	// Write to temporary file
-	catalogFile := filepath.Join(tempDir, "clickhouse-catalog.yaml")
-	require.NoError(t, os.WriteFile(catalogFile, []byte(catalogYAML), 0o644))
-
-	return catalogFile
+	return writeTrustedCatalogFile(t, "clickhouse-catalog.yaml", catalogYAML)
 }
 
 func TestIntegrationVersion(t *testing.T) {
@@ -172,7 +181,7 @@ func TestIntegrationCallToolClickhouse(t *testing.T) {
 	writeFile(t, tmp, "config.yaml", "clickhouse:\n  host: sql-clickhouse.clickhouse.com\n  user: demo\n")
 
 	// Create temporary catalog file with only the clickhouse entry
-	catalogFile := createClickhouseCatalogFile(t, tmp)
+	catalogFile := createClickhouseCatalogFile(t)
 
 	gatewayArgs := []string{
 		"--servers=clickhouse",

--- a/pkg/long_lived_integration_test.go
+++ b/pkg/long_lived_integration_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -77,14 +76,13 @@ func TestIntegrationShortLivedContainerCloses(t *testing.T) {
 	thisIsAnIntegrationTest(t)
 
 	dockerClient := createDockerClient(t)
-	tmp := t.TempDir()
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=time",
 	}
 
@@ -113,14 +111,13 @@ func TestIntegrationLongLivedServerStaysRunning(t *testing.T) {
 	thisIsAnIntegrationTest(t)
 
 	dockerClient := createDockerClient(t)
-	tmp := t.TempDir()
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    longLived: true\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    longLived: true\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=time",
 	}
 
@@ -147,14 +144,13 @@ func TestIntegrationLongLivedServerWithFlagStaysRunning(t *testing.T) {
 	thisIsAnIntegrationTest(t)
 
 	dockerClient := createDockerClient(t)
-	tmp := t.TempDir()
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=time",
 		"--long-lived",
 	}
@@ -182,14 +178,13 @@ func TestIntegrationLongLivedShouldCleanupContainerBeforeShutdown(t *testing.T) 
 	thisIsAnIntegrationTest(t)
 
 	dockerClient := createDockerClient(t)
-	tmp := t.TempDir()
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  time:\n    image: mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=time",
 		"--long-lived",
 	}

--- a/pkg/remote_headers_integration_test.go
+++ b/pkg/remote_headers_integration_test.go
@@ -46,7 +46,7 @@ registry:
         env: AUTH_TOKEN
 `, server.url)
 
-	writeFile(t, tmp, "catalog.yaml", catalogContent)
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", catalogContent)
 
 	// Optional: uncomment for debugging
 	// fmt.Printf("DEBUG: Catalog content:\n%s\n", catalogContent)
@@ -56,7 +56,7 @@ registry:
 	gatewayArgs := []string{
 		"--servers=test-server",
 		"--secrets=" + filepath.Join(tmp, ".env"),
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 	}
 
 	out := runDockerMCP(t, "tools", "call", "--gateway-arg="+strings.Join(gatewayArgs, ","), "get_auth_header")

--- a/pkg/toollist_notifications_integration_test.go
+++ b/pkg/toollist_notifications_integration_test.go
@@ -87,17 +87,16 @@ func TestIntegrationToolListChangeNotifications(t *testing.T) {
 	buildElicitImageForToolNotifications(t)
 
 	dockerClient := createDockerClientForToolNotifications(t)
-	tmp := t.TempDir()
 
 	// Test that the gateway properly handles tool list change notifications and refreshes capabilities
 	// This verifies that dynamic tools added by MCP servers become visible and callable
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  elicit:\n    longLived: true\n    image: elicit:latest")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  elicit:\n    longLived: true\n    image: elicit:latest")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=elicit",
 		"--long-lived",
 		"--verbose",
@@ -232,16 +231,15 @@ func TestIntegrationToolListNotificationRouting(t *testing.T) {
 	buildElicitImageForToolNotifications(t)
 
 	dockerClient := createDockerClientForToolNotifications(t)
-	tmp := t.TempDir()
 
 	// Set up a test scenario with multiple clients to verify notification routing
-	writeFile(t, tmp, "catalog.yaml", "name: docker-test\nregistry:\n  elicit:\n    longLived: true\n    image: elicit:latest")
+	catalogFile := writeTrustedCatalogFile(t, "catalog.yaml", "name: docker-test\nregistry:\n  elicit:\n    longLived: true\n    image: elicit:latest")
 
 	args := []string{
 		"mcp",
 		"gateway",
 		"run",
-		"--catalog=" + filepath.Join(tmp, "catalog.yaml"),
+		"--catalog=" + catalogFile,
 		"--servers=elicit",
 		"--long-lived",
 		"--verbose",

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -395,10 +396,25 @@ func ResolveServersFromString(ctx context.Context, registryClient registryapi.Cl
 			return nil, fmt.Errorf("failed to resolve registry: %w", err)
 		}
 		return []Server{server}, nil
-	} else if v, ok := strings.CutPrefix(value, "file://"); ok {
-		return ResolveFile(ctx, v)
+	} else if path, ok := strings.CutPrefix(value, "file://"); ok {
+		path, err := parseLocalFileReference(path, value)
+		if err != nil {
+			return nil, err
+		}
+		return ResolveFile(ctx, path)
 	}
 	return nil, fmt.Errorf("invalid server value: %s", value)
+}
+
+func parseLocalFileReference(path, value string) (string, error) {
+	// Docker MCP treats file:// as a catalog-root-relative local file reference,
+	// not as an RFC file URI with a host component. Decode escapes before the
+	// catalog resolver applies the trusted-root boundary.
+	decodedPath, err := url.PathUnescape(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid local file reference %q: %w", value, err)
+	}
+	return decodedPath, nil
 }
 
 // isV0ServerJSON checks if the JSON data represents a v0.ServerJSON/v0.ServerResponse

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -428,7 +428,12 @@ func isV0ServerJSON(buf []byte) bool {
 }
 
 func ResolveFile(ctx context.Context, value string) ([]Server, error) {
-	buf, err := os.ReadFile(value)
+	path, err := catalog.ResolveLocalCatalogPath(value)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
@@ -440,7 +445,7 @@ func ResolveFile(ctx context.Context, value string) ([]Server, error) {
 	}
 
 	var servers []catalog.Server
-	switch filepath.Ext(strings.ToLower(value)) {
+	switch filepath.Ext(strings.ToLower(path)) {
 	case ".yaml", ".yml":
 		if err := yaml.Unmarshal(buf, &probe); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal server: %w", err)
@@ -496,7 +501,7 @@ func ResolveFile(ctx context.Context, value string) ([]Server, error) {
 			}
 		}
 	default:
-		return nil, fmt.Errorf("unsupported file extension: %s, must be .yaml or .json", value)
+		return nil, fmt.Errorf("unsupported file extension: must be .yaml, .yml, or .json")
 	}
 
 	if probe.Registry != nil {

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -1321,6 +1321,29 @@ func TestResolveFile(t *testing.T) {
 	}
 }
 
+func TestResolveFileDecodesEscapedLocalReference(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	content, err := testData.ReadFile("testdata/server.yaml")
+	require.NoError(t, err)
+
+	tempFile := filepath.Join(tempHome, ".docker", "mcp", "catalogs", "testdata", "server copy.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(tempFile), 0o755))
+	require.NoError(t, os.WriteFile(tempFile, content, 0o644))
+
+	servers, err := ResolveServersFromString(t.Context(), mocks.NewMockRegistryAPIClient(), mocks.NewMockOCIService(), setupTestDB(t), "file://testdata/server%20copy.yaml")
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, "myimage:latest", servers[0].Image)
+}
+
+func TestResolveFileRejectsInvalidEscapedLocalReference(t *testing.T) {
+	_, err := ResolveServersFromString(t.Context(), mocks.NewMockRegistryAPIClient(), mocks.NewMockOCIService(), setupTestDB(t), "file://testdata/%zz.yaml")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid local file reference")
+}
+
 func TestResolveFileRejectsUntrustedPaths(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -1297,23 +1297,17 @@ func TestResolveFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// write temp file to disk
-			tempDir := t.TempDir()
+			tempHome := t.TempDir()
+			t.Setenv("HOME", tempHome)
+
 			if tt.file != "" {
 				content, err := testData.ReadFile("testdata/" + tt.file)
 				require.NoError(t, err)
-				tempFile := filepath.Join(tempDir, "testdata", tt.file)
+				tempFile := filepath.Join(tempHome, ".docker", "mcp", "catalogs", "testdata", tt.file)
 				_ = os.MkdirAll(filepath.Dir(tempFile), 0o755)
 				err = os.WriteFile(tempFile, content, 0o644)
 				require.NoError(t, err)
-				defer os.Remove(tempFile)
 			}
-
-			cwd, err := os.Getwd()
-			require.NoError(t, err)
-			defer os.Chdir(cwd) //nolint:errcheck
-			err = os.Chdir(tempDir)
-			require.NoError(t, err)
 
 			server, err := ResolveServersFromString(t.Context(), mocks.NewMockRegistryAPIClient(), mocks.NewMockOCIService(), setupTestDB(t), tt.input)
 			if tt.expectedErr != "" {
@@ -1323,6 +1317,51 @@ func TestResolveFile(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, server)
 			}
+		})
+	}
+}
+
+func TestResolveFileRejectsUntrustedPaths(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	outsideDir := t.TempDir()
+	outsideServer := filepath.Join(outsideDir, "server.yaml")
+	content, err := testData.ReadFile("testdata/server.yaml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(outsideServer, content, 0o644))
+
+	cwd := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "server.yaml"), content, 0o644))
+	originalCwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(originalCwd)
+	})
+	require.NoError(t, os.Chdir(cwd))
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "absolute path outside catalogs dir",
+			input: "file://" + outsideServer,
+		},
+		{
+			name:  "relative traversal outside catalogs dir",
+			input: "file://../server.yaml",
+		},
+		{
+			name:  "dot-relative path outside catalogs dir",
+			input: "file://./server.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveServersFromString(t.Context(), mocks.NewMockRegistryAPIClient(), mocks.NewMockOCIService(), setupTestDB(t), tt.input)
+			require.ErrorContains(t, err, "local file path must resolve within Docker MCP catalogs directory")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Route `file://` server-definition reads and legacy catalog reads through the trusted Docker MCP catalog-directory resolver before opening files.
- Constrain local catalog names and local file references to paths that resolve under `~/.docker/mcp/catalogs`, including symlink-resolved containment checks.
- Return the validated real path from the resolver to avoid validating one path and opening another.
- Decode escaped `file://` path components before applying the trusted-root boundary, while documenting Docker MCP's catalog-root-relative `file://` behavior.
- Update CLI help/generated docs and add regression coverage for traversal, symlink escape, untrusted absolute/dot-relative paths, resolved-path returns, and escaped local file references.

## Breaking change
- Local catalog paths supplied via `--catalog` or `--additional-catalog` must now resolve under `~/.docker/mcp/catalogs`. Absolute or `./` catalog paths outside that directory are rejected instead of being read directly.
- `file://` server-definition paths are likewise constrained to the same trusted catalog directory.

## Validation
- `go test ./pkg/catalog ./pkg/workingset ./pkg/catalog_next ./pkg/gateway`
- `go test ./pkg -run '^$'`
- `go test ./cmd/docker-mcp/commands -run '^$'`
- `make lint-darwin`
- `make docs`