### PR TITLE
Sec #1: Harden Docker bind mounts

### DIFF
--- a/pkg/gateway/clientpool.go
+++ b/pkg/gateway/clientpool.go
@@ -265,6 +265,14 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 			log.Logf("Warning: tool '%s' has volume value that looks like a flag, skipping: %q", tool.Name, mount)
 			continue
 		}
+		if err := validateDockerVolumeBinds([]string{mount}); err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{
+					Text: fmt.Sprintf("validate volume for %s: %v", tool.Name, err),
+				}},
+				IsError: true,
+			}, nil
+		}
 
 		args = append(args, "-v", mount)
 	}
@@ -340,7 +348,7 @@ func (cp *clientPool) baseArgs(name string) []string {
 	return args
 }
 
-func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, targetConfig proxies.TargetConfig) ([]string, []string) {
+func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, targetConfig proxies.TargetConfig) ([]string, []string, error) {
 	args := cp.baseArgs(serverConfig.Name)
 	var env []string
 
@@ -406,6 +414,9 @@ func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, targetConfi
 			log.Logf("Warning: server '%s' has volume value that looks like a flag, skipping: %q", serverConfig.Name, mount)
 			continue
 		}
+		if err := validateDockerVolumeBinds([]string{mount}); err != nil {
+			return nil, nil, fmt.Errorf("validate volume for %s: %w", serverConfig.Name, err)
+		}
 
 		args = append(args, "-v", mount)
 	}
@@ -437,7 +448,7 @@ func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, targetConfi
 		args = append(args, "--add-host", host)
 	}
 
-	return args, env
+	return args, env, nil
 }
 
 // isSafeFlagValue reports whether v can be safely appended to a docker run
@@ -527,7 +538,10 @@ func (cg *clientGetter) GetClient(ctx context.Context) (mcpclient.Client, error)
 				}
 
 				image := cg.serverConfig.Spec.Image
-				args, env := cg.cp.argsAndEnv(cg.serverConfig, targetConfig)
+				args, env, err := cg.cp.argsAndEnv(cg.serverConfig, targetConfig)
+				if err != nil {
+					return nil, err
+				}
 
 				command := expandEnvList(eval.EvaluateList(cg.serverConfig.Spec.Command, cg.serverConfig.Config), env)
 				if len(command) == 0 {

--- a/pkg/gateway/clientpool.go
+++ b/pkg/gateway/clientpool.go
@@ -265,7 +265,8 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 			log.Logf("Warning: tool '%s' has volume value that looks like a flag, skipping: %q", tool.Name, mount)
 			continue
 		}
-		if err := validateDockerVolumeBinds([]string{mount}); err != nil {
+		mount, err := normalizeDockerVolumeBind(mount)
+		if err != nil {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
 					Text: fmt.Sprintf("validate volume for %s: %v", tool.Name, err),
@@ -414,7 +415,8 @@ func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, targetConfi
 			log.Logf("Warning: server '%s' has volume value that looks like a flag, skipping: %q", serverConfig.Name, mount)
 			continue
 		}
-		if err := validateDockerVolumeBinds([]string{mount}); err != nil {
+		mount, err := normalizeDockerVolumeBind(mount)
+		if err != nil {
 			return nil, nil, fmt.Errorf("validate volume for %s: %w", serverConfig.Name, err)
 		}
 

--- a/pkg/gateway/clientpool_test.go
+++ b/pkg/gateway/clientpool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -119,21 +120,22 @@ secrets:
 }
 
 func TestApplyConfigMountAs(t *testing.T) {
+	hostPath := t.TempDir()
 	catalogYAML := `
 volumes:
   - '{{hub.log_path|mount_as:/logs:ro}}'
   `
-	configYAML := `
+	configYAML := fmt.Sprintf(`
 hub:
-  log_path: /local/logs
-`
+  log_path: %s
+`, hostPath)
 
 	args, env := argsAndEnv(t, "hub", catalogYAML, configYAML, nil)
 
 	assert.Equal(t, []string{
 		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
 		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
-		"-v", "/local/logs:/logs:ro",
+		"-v", hostPath + ":/logs:ro",
 	}, args)
 	assert.Empty(t, env)
 }
@@ -154,21 +156,22 @@ volumes:
 }
 
 func TestApplyConfigMountAsReadOnly(t *testing.T) {
+	hostPath := t.TempDir()
 	catalogYAML := `
 volumes:
   - '{{hub.log_path|mount_as:/logs:ro}}'
   `
-	configYAML := `
+	configYAML := fmt.Sprintf(`
 hub:
-  log_path: /local/logs
-`
+  log_path: %s
+`, hostPath)
 
 	args, env := argsAndEnv(t, "hub", catalogYAML, configYAML, nil)
 
 	assert.Equal(t, []string{
 		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
 		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
-		"-v", "/local/logs:/logs:ro",
+		"-v", hostPath + ":/logs:ro",
 	}, args)
 	assert.Empty(t, env)
 }
@@ -211,39 +214,25 @@ extraHosts:
 	assert.Empty(t, env)
 }
 
-func TestApplyConfigLongLivedIgnoresReadOnly(t *testing.T) {
+func TestApplyConfigLongLivedRejectsWritableHostBind(t *testing.T) {
 	catalogYAML := `
 longLived: true
 volumes:
   - '/local/data:/data'
   `
 
-	args, env := argsAndEnv(t, "longlived", catalogYAML, "", nil)
-
-	// Volumes should NOT have :ro appended regardless of readOnly flag
-	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=longlived", "-l", "docker-mcp-transport=stdio",
-		"-v", "/local/data:/data",
-	}, args)
-	assert.Empty(t, env)
+	_, _, err := argsAndEnvErr(t, "longlived", catalogYAML, "", nil)
+	require.ErrorContains(t, err, "host path bind mounts must be read-only")
 }
 
-func TestApplyConfigShortLivedRespectsReadOnly(t *testing.T) {
+func TestApplyConfigShortLivedRejectsWritableHostBind(t *testing.T) {
 	catalogYAML := `
 volumes:
   - '/local/data:/data'
   `
 
-	args, env := argsAndEnv(t, "shortlived", catalogYAML, "", nil)
-
-	// Short-lived servers no longer apply read-only mounts automatically
-	assert.Equal(t, []string{
-		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
-		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=shortlived", "-l", "docker-mcp-transport=stdio",
-		"-v", "/local/data:/data",
-	}, args)
-	assert.Empty(t, env)
+	_, _, err := argsAndEnvErr(t, "shortlived", catalogYAML, "", nil)
+	require.ErrorContains(t, err, "host path bind mounts must be read-only")
 }
 
 // TestArgsAndEnv_SkipsFlagShapedValues exercises the argv-sink guard:
@@ -260,7 +249,7 @@ func TestArgsAndEnv_SkipsFlagShapedValues(t *testing.T) {
 			catalogYAML: `
 volumes:
   - "--privileged"
-  - "/legit:/data"
+  - "legit-volume:/data"
 `,
 			wantMissing: []string{"--privileged"},
 		},
@@ -308,7 +297,70 @@ func TestIsSafeFlagValue(t *testing.T) {
 	}
 }
 
+func TestValidateDockerVolumeBinds(t *testing.T) {
+	t.Run("allows named volumes", func(t *testing.T) {
+		require.NoError(t, validateDockerVolumeBinds([]string{"mcp-cache:/cache"}))
+	})
+
+	t.Run("allows read-only binds from allowed roots", func(t *testing.T) {
+		require.NoError(t, validateDockerVolumeBinds([]string{t.TempDir() + ":/data:ro"}))
+	})
+
+	t.Run("allows read-only binds from configured roots", func(t *testing.T) {
+		t.Setenv(dockerBindAllowedPathsEnv, "/opt/mcp-data")
+		require.NoError(t, validateDockerVolumeBinds([]string{"/opt/mcp-data/project:/data:ro"}))
+	})
+
+	t.Run("allows home paths from configured roots", func(t *testing.T) {
+		home := t.TempDir()
+		project := filepath.Join(home, "trusted", "project")
+		require.NoError(t, os.MkdirAll(project, 0o755))
+		t.Setenv("HOME", home)
+		t.Setenv(dockerBindAllowedPathsEnv, "~/trusted")
+
+		require.NoError(t, validateDockerVolumeBinds([]string{"~/trusted/project:/data:ro"}))
+	})
+
+	t.Run("rejects host paths outside allowed roots", func(t *testing.T) {
+		err := validateDockerVolumeBinds([]string{"/opt/mcp-data:/data:ro"})
+		require.ErrorContains(t, err, "outside allowed roots")
+	})
+
+	t.Run("rejects writable host path binds", func(t *testing.T) {
+		err := validateDockerVolumeBinds([]string{t.TempDir() + ":/data"})
+		require.ErrorContains(t, err, "host path bind mounts must be read-only")
+	})
+
+	t.Run("rejects docker socket binds", func(t *testing.T) {
+		err := validateDockerVolumeBinds([]string{"/var/run/docker.sock:/var/run/docker.sock:ro"})
+		require.ErrorContains(t, err, "blocked")
+	})
+
+	t.Run("rejects symlink host paths escaping allowed roots", func(t *testing.T) {
+		allowedRoot := t.TempDir()
+		link := filepath.Join(allowedRoot, "etc-link")
+		if err := os.Symlink("/etc", link); err != nil {
+			t.Skipf("cannot create symlink: %v", err)
+		}
+
+		err := validateDockerVolumeBinds([]string{filepath.ToSlash(link) + ":/data:ro"})
+		require.ErrorContains(t, err, "sensitive system path")
+	})
+
+	t.Run("rejects credential paths even under allowed roots", func(t *testing.T) {
+		err := validateDockerVolumeBinds([]string{filepath.Join(t.TempDir(), ".ssh") + ":/ssh:ro"})
+		require.ErrorContains(t, err, "credential path")
+	})
+}
+
 func argsAndEnv(t *testing.T, name, catalogYAML, configYAML string, secrets map[string]string) ([]string, []string) {
+	t.Helper()
+	args, env, err := argsAndEnvErr(t, name, catalogYAML, configYAML, secrets)
+	require.NoError(t, err)
+	return args, env
+}
+
+func argsAndEnvErr(t *testing.T, name, catalogYAML, configYAML string, secrets map[string]string) ([]string, []string, error) {
 	t.Helper()
 
 	clientPool := &clientPool{

--- a/pkg/gateway/clientpool_test.go
+++ b/pkg/gateway/clientpool_test.go
@@ -303,7 +303,7 @@ func TestIsSafeFlagValue(t *testing.T) {
 
 func TestValidateDockerVolumeBinds(t *testing.T) {
 	t.Run("allows named volumes", func(t *testing.T) {
-		require.NoError(t, validateDockerVolumeBinds([]string{"mcp-cache:/cache"}))
+		require.NoError(t, validateDockerVolumeBinds([]string{"mcp-cache_1.cache:/cache"}))
 	})
 
 	t.Run("allows read-only binds from allowed roots", func(t *testing.T) {
@@ -332,6 +332,22 @@ func TestValidateDockerVolumeBinds(t *testing.T) {
 
 	t.Run("rejects host paths outside allowed roots", func(t *testing.T) {
 		err := validateDockerVolumeBinds([]string{"/opt/mcp-data:/data:ro"})
+		require.ErrorContains(t, err, "outside allowed roots")
+	})
+
+	t.Run("rejects relative host paths with slash", func(t *testing.T) {
+		err := validateDockerVolumeBinds([]string{"foo/bar:/data"})
+		require.ErrorContains(t, err, "host path bind mounts must be read-only")
+
+		err = validateDockerVolumeBinds([]string{"foo/bar:/data:ro"})
+		require.ErrorContains(t, err, "outside allowed roots")
+	})
+
+	t.Run("rejects relative host paths escaping upward", func(t *testing.T) {
+		err := validateDockerVolumeBinds([]string{"subdir/../../../etc:/data"})
+		require.ErrorContains(t, err, "host path bind mounts must be read-only")
+
+		err = validateDockerVolumeBinds([]string{"subdir/../../../etc:/data:ro"})
 		require.ErrorContains(t, err, "outside allowed roots")
 	})
 

--- a/pkg/gateway/clientpool_test.go
+++ b/pkg/gateway/clientpool_test.go
@@ -121,6 +121,8 @@ secrets:
 
 func TestApplyConfigMountAs(t *testing.T) {
 	hostPath := t.TempDir()
+	expectedHostPath, err := cleanDockerHostPath(hostPath)
+	require.NoError(t, err)
 	catalogYAML := `
 volumes:
   - '{{hub.log_path|mount_as:/logs:ro}}'
@@ -135,7 +137,7 @@ hub:
 	assert.Equal(t, []string{
 		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
 		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
-		"-v", hostPath + ":/logs:ro",
+		"-v", expectedHostPath + ":/logs:ro",
 	}, args)
 	assert.Empty(t, env)
 }
@@ -157,6 +159,8 @@ volumes:
 
 func TestApplyConfigMountAsReadOnly(t *testing.T) {
 	hostPath := t.TempDir()
+	expectedHostPath, err := cleanDockerHostPath(hostPath)
+	require.NoError(t, err)
 	catalogYAML := `
 volumes:
   - '{{hub.log_path|mount_as:/logs:ro}}'
@@ -171,7 +175,7 @@ hub:
 	assert.Equal(t, []string{
 		"run", "--rm", "-i", "--init", "--security-opt", "no-new-privileges", "--cpus", "1", "--memory", "2Gb", "--pull", "never",
 		"-l", "docker-mcp=true", "-l", "docker-mcp-tool-type=mcp", "-l", "docker-mcp-name=hub", "-l", "docker-mcp-transport=stdio",
-		"-v", hostPath + ":/logs:ro",
+		"-v", expectedHostPath + ":/logs:ro",
 	}, args)
 	assert.Empty(t, env)
 }
@@ -319,6 +323,11 @@ func TestValidateDockerVolumeBinds(t *testing.T) {
 		t.Setenv(dockerBindAllowedPathsEnv, "~/trusted")
 
 		require.NoError(t, validateDockerVolumeBinds([]string{"~/trusted/project:/data:ro"}))
+		expectedSource, err := cleanDockerHostPath("~/trusted/project")
+		require.NoError(t, err)
+		normalized, err := normalizeDockerVolumeBind("~/trusted/project:/data:ro")
+		require.NoError(t, err)
+		require.Equal(t, expectedSource+":/data:ro", normalized)
 	})
 
 	t.Run("rejects host paths outside allowed roots", func(t *testing.T) {

--- a/pkg/gateway/docker_binds.go
+++ b/pkg/gateway/docker_binds.go
@@ -20,6 +20,8 @@ const dockerBindAllowedPathsEnv = "MCP_GATEWAY_DOCKER_BIND_ALLOWED_PATHS"
 type dockerVolumeBind struct {
 	raw        string
 	source     string
+	target     string
+	mode       string
 	hostPath   bool
 	readOnly   bool
 	sourcePath string
@@ -28,25 +30,36 @@ type dockerVolumeBind struct {
 func validateDockerVolumeBinds(volumes []string) error {
 	allowedRoots := dockerBindAllowedRoots()
 	for _, raw := range volumes {
-		bind, err := parseDockerVolumeBind(raw)
-		if err != nil {
+		if _, err := normalizeDockerVolumeBindWithRoots(raw, allowedRoots); err != nil {
 			return err
-		}
-		if !bind.hostPath {
-			continue
-		}
-		if !bind.readOnly {
-			return fmt.Errorf("unsafe docker volume %q: host path bind mounts must be read-only", bind.raw)
-		}
-		if disallowed, reason := disallowedDockerHostPath(bind.sourcePath); disallowed {
-			return fmt.Errorf("unsafe docker volume %q: host path %q is blocked (%s)", bind.raw, bind.source, reason)
-		}
-		if !isPathUnderAnyRoot(bind.sourcePath, allowedRoots) {
-			return fmt.Errorf("unsafe docker volume %q: host path %q is outside allowed roots %s",
-				bind.raw, bind.source, strings.Join(allowedRoots, ", "))
 		}
 	}
 	return nil
+}
+
+func normalizeDockerVolumeBind(raw string) (string, error) {
+	return normalizeDockerVolumeBindWithRoots(raw, dockerBindAllowedRoots())
+}
+
+func normalizeDockerVolumeBindWithRoots(raw string, allowedRoots []string) (string, error) {
+	bind, err := parseDockerVolumeBind(raw)
+	if err != nil {
+		return "", err
+	}
+	if !bind.hostPath {
+		return bind.raw, nil
+	}
+	if !bind.readOnly {
+		return "", fmt.Errorf("unsafe docker volume %q: host path bind mounts must be read-only", bind.raw)
+	}
+	if disallowed, reason := disallowedDockerHostPath(bind.sourcePath); disallowed {
+		return "", fmt.Errorf("unsafe docker volume %q: host path %q is blocked (%s)", bind.raw, bind.source, reason)
+	}
+	if !isPathUnderAnyRoot(bind.sourcePath, allowedRoots) {
+		return "", fmt.Errorf("unsafe docker volume %q: host path %q is outside allowed roots %s",
+			bind.raw, bind.source, strings.Join(allowedRoots, ", "))
+	}
+	return bind.sourcePath + ":" + bind.target + ":" + bind.mode, nil
 }
 
 func parseDockerVolumeBind(raw string) (dockerVolumeBind, error) {
@@ -67,11 +80,13 @@ func parseDockerVolumeBind(raw string) (dockerVolumeBind, error) {
 		return bind, nil
 	case 2, 3:
 		bind.source = strings.TrimSpace(parts[0])
-		if bind.source == "" || strings.TrimSpace(parts[1]) == "" {
+		bind.target = strings.TrimSpace(parts[1])
+		if bind.source == "" || bind.target == "" {
 			return dockerVolumeBind{}, fmt.Errorf("invalid docker volume %q: source and target are required", raw)
 		}
 		if len(parts) == 3 {
-			bind.readOnly = dockerVolumeModeReadOnly(parts[2])
+			bind.mode = strings.TrimSpace(parts[2])
+			bind.readOnly = dockerVolumeModeReadOnly(bind.mode)
 		}
 		bind.hostPath = dockerVolumeSourceIsHostPath(bind.source)
 		if bind.hostPath {

--- a/pkg/gateway/docker_binds.go
+++ b/pkg/gateway/docker_binds.go
@@ -1,0 +1,300 @@
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode"
+
+	"github.com/docker/mcp-gateway/pkg/user"
+)
+
+// MCP_GATEWAY_DOCKER_BIND_ALLOWED_PATHS adds trusted host-path roots to the
+// default temp-only allowlist. Use the OS path-list separator.
+const dockerBindAllowedPathsEnv = "MCP_GATEWAY_DOCKER_BIND_ALLOWED_PATHS"
+
+type dockerVolumeBind struct {
+	raw        string
+	source     string
+	hostPath   bool
+	readOnly   bool
+	sourcePath string
+}
+
+func validateDockerVolumeBinds(volumes []string) error {
+	allowedRoots := dockerBindAllowedRoots()
+	for _, raw := range volumes {
+		bind, err := parseDockerVolumeBind(raw)
+		if err != nil {
+			return err
+		}
+		if !bind.hostPath {
+			continue
+		}
+		if !bind.readOnly {
+			return fmt.Errorf("unsafe docker volume %q: host path bind mounts must be read-only", bind.raw)
+		}
+		if disallowed, reason := disallowedDockerHostPath(bind.sourcePath); disallowed {
+			return fmt.Errorf("unsafe docker volume %q: host path %q is blocked (%s)", bind.raw, bind.source, reason)
+		}
+		if !isPathUnderAnyRoot(bind.sourcePath, allowedRoots) {
+			return fmt.Errorf("unsafe docker volume %q: host path %q is outside allowed roots %s",
+				bind.raw, bind.source, strings.Join(allowedRoots, ", "))
+		}
+	}
+	return nil
+}
+
+func parseDockerVolumeBind(raw string) (dockerVolumeBind, error) {
+	spec := strings.TrimSpace(raw)
+	if spec == "" {
+		return dockerVolumeBind{}, fmt.Errorf("invalid docker volume %q: empty volume spec", raw)
+	}
+
+	parts := splitDockerVolumeSpec(spec)
+	if len(parts) > 3 {
+		return dockerVolumeBind{}, fmt.Errorf("invalid docker volume %q: expected source:target[:mode]", raw)
+	}
+
+	bind := dockerVolumeBind{raw: spec}
+	switch len(parts) {
+	case 1:
+		// A single path is an anonymous Docker volume target, not a host bind.
+		return bind, nil
+	case 2, 3:
+		bind.source = strings.TrimSpace(parts[0])
+		if bind.source == "" || strings.TrimSpace(parts[1]) == "" {
+			return dockerVolumeBind{}, fmt.Errorf("invalid docker volume %q: source and target are required", raw)
+		}
+		if len(parts) == 3 {
+			bind.readOnly = dockerVolumeModeReadOnly(parts[2])
+		}
+		bind.hostPath = dockerVolumeSourceIsHostPath(bind.source)
+		if bind.hostPath {
+			sourcePath, err := cleanDockerHostPath(bind.source)
+			if err != nil {
+				return dockerVolumeBind{}, fmt.Errorf("invalid docker volume %q: resolve host path %q: %w", raw, bind.source, err)
+			}
+			bind.sourcePath = sourcePath
+		}
+	}
+
+	return bind, nil
+}
+
+func splitDockerVolumeSpec(spec string) []string {
+	var parts []string
+	start := 0
+	for i := range spec {
+		if spec[i] != ':' {
+			continue
+		}
+		if isWindowsDriveColon(spec, start, i) {
+			continue
+		}
+		parts = append(parts, spec[start:i])
+		start = i + 1
+	}
+	return append(parts, spec[start:])
+}
+
+func isWindowsDriveColon(spec string, partStart, colon int) bool {
+	return colon == partStart+1 &&
+		colon+1 < len(spec) &&
+		isASCIIAlpha(rune(spec[partStart])) &&
+		(spec[colon+1] == '\\' || spec[colon+1] == '/')
+}
+
+func isASCIIAlpha(r rune) bool {
+	return r <= unicode.MaxASCII && unicode.IsLetter(r)
+}
+
+func dockerVolumeModeReadOnly(mode string) bool {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return false
+	}
+
+	readOnly := false
+	for opt := range strings.SplitSeq(mode, ",") {
+		switch strings.ToLower(strings.TrimSpace(opt)) {
+		case "rw":
+			return false
+		case "ro", "readonly":
+			readOnly = true
+		}
+	}
+	return readOnly
+}
+
+func dockerVolumeSourceIsHostPath(source string) bool {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return false
+	}
+	return strings.HasPrefix(source, "/") ||
+		strings.HasPrefix(source, "\\\\") ||
+		strings.HasPrefix(source, "./") ||
+		strings.HasPrefix(source, "../") ||
+		source == "." ||
+		source == ".." ||
+		strings.HasPrefix(source, "~/") ||
+		isWindowsAbsPath(source)
+}
+
+func isWindowsAbsPath(p string) bool {
+	return len(p) >= 3 &&
+		isASCIIAlpha(rune(p[0])) &&
+		p[1] == ':' &&
+		(p[2] == '\\' || p[2] == '/')
+}
+
+func cleanDockerHostPath(p string) (string, error) {
+	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
+	if isWindowsAbsPath(p) {
+		return strings.ToLower(path.Clean(p)), nil
+	}
+	if strings.HasPrefix(p, "//") {
+		return "//" + path.Clean(strings.TrimPrefix(p, "//")), nil
+	}
+	if strings.HasPrefix(p, "~/") {
+		home, err := user.HomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expand home directory: %w", err)
+		}
+		if home == "" {
+			return "", fmt.Errorf("expand home directory: empty home directory")
+		}
+		p = path.Join(filepath.ToSlash(home), strings.TrimPrefix(p, "~/"))
+	}
+
+	fsPath := filepath.FromSlash(path.Clean(p))
+	if !filepath.IsAbs(fsPath) {
+		absPath, err := filepath.Abs(fsPath)
+		if err != nil {
+			return "", err
+		}
+		fsPath = absPath
+	}
+	resolved, err := resolveDockerHostPath(fsPath)
+	if err != nil {
+		return "", err
+	}
+	return path.Clean(filepath.ToSlash(resolved)), nil
+}
+
+func resolveDockerHostPath(p string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err == nil {
+		return resolved, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	existing := p
+	var missing []string
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			break
+		}
+		missing = append([]string{filepath.Base(existing)}, missing...)
+		existing = parent
+	}
+
+	resolvedExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(append([]string{resolvedExisting}, missing...)...), nil
+}
+
+func dockerBindAllowedRoots() []string {
+	roots := []string{"/tmp", "/private/tmp", "/var/tmp"}
+	if tmp := os.TempDir(); tmp != "" {
+		roots = append(roots, tmp)
+	}
+	if env := os.Getenv(dockerBindAllowedPathsEnv); env != "" {
+		roots = append(roots, filepath.SplitList(env)...)
+	}
+
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		cleaned, err := cleanDockerHostPath(root)
+		if err != nil {
+			continue
+		}
+		if cleaned == "." || cleaned == "/" || slices.Contains(out, cleaned) {
+			continue
+		}
+		out = append(out, cleaned)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func disallowedDockerHostPath(p string) (bool, string) {
+	lower := strings.ToLower(p)
+	for _, blocked := range []string{
+		"/dev",
+		"/etc",
+		"/library",
+		"/proc",
+		"/private/etc",
+		"/private/var/run",
+		"/root",
+		"/run",
+		"/sys",
+		"/system",
+		"/var/lib/containerd",
+		"/var/lib/docker",
+		"/var/root",
+		"/var/run",
+		"c:/windows",
+	} {
+		if pathHasPrefix(lower, blocked) {
+			return true, "sensitive system path"
+		}
+	}
+
+	for _, segment := range strings.Split(lower, "/") {
+		switch segment {
+		case ".aws", ".azure", ".config", ".docker", ".gnupg", ".kube", ".ssh":
+			return true, "credential path"
+		case ".netrc", ".npmrc", "id_dsa", "id_ecdsa", "id_ed25519", "id_rsa":
+			return true, "credential file"
+		}
+	}
+
+	return false, ""
+}
+
+func isPathUnderAnyRoot(p string, roots []string) bool {
+	for _, root := range roots {
+		if pathHasPrefix(p, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathHasPrefix(p, root string) bool {
+	p = strings.TrimRight(p, "/")
+	root = strings.TrimRight(root, "/")
+	return p == root || strings.HasPrefix(p, root+"/")
+}

--- a/pkg/gateway/docker_binds.go
+++ b/pkg/gateway/docker_binds.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MCP_GATEWAY_DOCKER_BIND_ALLOWED_PATHS adds trusted host-path roots to the
-// default temp-only allowlist. Use the OS path-list separator.
+// default read-only temp-root allowlist. Use the OS path-list separator.
 const dockerBindAllowedPathsEnv = "MCP_GATEWAY_DOCKER_BIND_ALLOWED_PATHS"
 
 type dockerVolumeBind struct {
@@ -128,6 +128,10 @@ func isASCIIAlpha(r rune) bool {
 	return r <= unicode.MaxASCII && unicode.IsLetter(r)
 }
 
+func isASCIIDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
 func dockerVolumeModeReadOnly(mode string) bool {
 	mode = strings.TrimSpace(mode)
 	if mode == "" {
@@ -151,14 +155,25 @@ func dockerVolumeSourceIsHostPath(source string) bool {
 	if source == "" {
 		return false
 	}
-	return strings.HasPrefix(source, "/") ||
-		strings.HasPrefix(source, "\\\\") ||
-		strings.HasPrefix(source, "./") ||
-		strings.HasPrefix(source, "../") ||
-		source == "." ||
-		source == ".." ||
-		strings.HasPrefix(source, "~/") ||
-		isWindowsAbsPath(source)
+	return !dockerVolumeSourceIsNamedVolume(source)
+}
+
+func dockerVolumeSourceIsNamedVolume(source string) bool {
+	if source == "" {
+		return false
+	}
+	for i, r := range source {
+		if i == 0 {
+			if !isASCIIAlpha(r) && !isASCIIDigit(r) {
+				return false
+			}
+			continue
+		}
+		if !isASCIIAlpha(r) && !isASCIIDigit(r) && r != '_' && r != '.' && r != '-' {
+			return false
+		}
+	}
+	return true
 }
 
 func isWindowsAbsPath(p string) bool {

--- a/pkg/gateway/embeddings/client.go
+++ b/pkg/gateway/embeddings/client.go
@@ -41,6 +41,8 @@ func NewVectorDBClient(ctx context.Context, dataDir string, dimension int, logFu
 		"docker", "run", "-i", "--rm",
 		"--name", containerName,
 		"--platform", "linux/amd64",
+		// dataDir is gateway-selected state storage, not catalog/server-supplied.
+		// The vector DB container needs this mount writable to persist vectors.db.
 		"-v", fmt.Sprintf("%s:/data", dataDir),
 		"-e", "DB_PATH=/data/vectors.db",
 		"-e", fmt.Sprintf("VECTOR_DIMENSION=%d", dimension),


### PR DESCRIPTION
## Summary
- Validate Docker volume specs before adding `-v` args for server and tool containers.
- Require host bind mounts to be read-only and under trusted roots.
- Resolve symlinks and expand `~/` with the shared home-dir helper to avoid allowlist bypasses.

## Impact
Unsafe host-path binds now fail before Docker is invoked. Named volumes and read-only binds under temp or `MCP_GATEWAY_DOCKER_BIND_ALLOWED_PATHS` continue to work.

## Validation
- `go test -count=1 ./pkg/gateway`
- `go test -count=1 ./pkg/gateway -run 'TestValidateDockerVolumeBinds|TestApplyConfigMountAs|TestApplyConfigLongLivedRejectsWritableHostBind|TestApplyConfigShortLivedRejectsWritableHostBind|TestArgsAndEnv_SkipsFlagShapedValues'`\n\nNote: `go test -count=1 ./pkg/...` was also attempted, but existing Docker-backed tests in `pkg/gateway/embeddings` and `pkg/mcp` fail in this environment because Docker credential helper `docker-credential-osxkeychain` is unavailable.