### PR TITLE
Sec #5: Allow guarded Docker Desktop proxy sockets

### DIFF
--- a/pkg/desktop/proxy_socket_other.go
+++ b/pkg/desktop/proxy_socket_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+// +build !windows
+
+package desktop
+
+import (
+	"context"
+	"os"
+)
+
+func desktopProxySocketAvailable(_ context.Context) bool {
+	return desktopProxySocketAvailableAt(Paths().HTTPProxySocket)
+}
+
+func desktopProxySocketAvailableAt(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().Type() == os.ModeSocket
+}

--- a/pkg/desktop/proxy_socket_other_test.go
+++ b/pkg/desktop/proxy_socket_other_test.go
@@ -1,0 +1,52 @@
+//go:build !windows
+// +build !windows
+
+package desktop
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDesktopProxySocketUnavailableWithoutSocket(t *testing.T) {
+	if desktopProxySocketAvailableAt(filepath.Join(t.TempDir(), "httpproxy.sock")) {
+		t.Fatal("expected Docker Desktop proxy socket to be unavailable")
+	}
+}
+
+func TestDesktopProxySocketUnavailableForRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "httpproxy.sock")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if desktopProxySocketAvailableAt(path) {
+		t.Fatal("expected regular file to be rejected as Docker Desktop proxy socket")
+	}
+}
+
+func TestDesktopProxySocketAvailableForUnixSocket(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "mcp-gateway-desktop-proxy-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+
+	path := filepath.Join(dir, "httpproxy.sock")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	if !desktopProxySocketAvailableAt(path) {
+		t.Fatal("expected Unix socket to be accepted as Docker Desktop proxy socket")
+	}
+}

--- a/pkg/desktop/proxy_socket_windows.go
+++ b/pkg/desktop/proxy_socket_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+// +build windows
+
+package desktop
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+const desktopProxySocketProbeTimeout = 500 * time.Millisecond
+
+var dialHTTPProxyForAvailability = func(ctx context.Context) (net.Conn, error) {
+	return dialHTTPProxy(ctx)
+}
+
+func desktopProxySocketAvailable(ctx context.Context) bool {
+	return desktopProxySocketAvailableWithDial(ctx, dialHTTPProxyForAvailability)
+}
+
+func desktopProxySocketAvailableWithDial(ctx context.Context, dialer func(context.Context) (net.Conn, error)) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, desktopProxySocketProbeTimeout)
+	defer cancel()
+
+	conn, err := dialer(probeCtx)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/pkg/desktop/proxy_socket_windows.go
+++ b/pkg/desktop/proxy_socket_windows.go
@@ -11,9 +11,7 @@ import (
 
 const desktopProxySocketProbeTimeout = 500 * time.Millisecond
 
-var dialHTTPProxyForAvailability = func(ctx context.Context) (net.Conn, error) {
-	return dialHTTPProxy(ctx)
-}
+var dialHTTPProxyForAvailability = dialHTTPProxy
 
 func desktopProxySocketAvailable(ctx context.Context) bool {
 	return desktopProxySocketAvailableWithDial(ctx, dialHTTPProxyForAvailability)

--- a/pkg/desktop/proxy_socket_windows_test.go
+++ b/pkg/desktop/proxy_socket_windows_test.go
@@ -1,0 +1,87 @@
+//go:build windows
+// +build windows
+
+package desktop
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestDockerDesktopProxySocketTransportReturnsNilWhenWindowsPipeMissing(t *testing.T) {
+	previousDial := dialHTTPProxyForAvailability
+	t.Cleanup(func() {
+		dialHTTPProxyForAvailability = previousDial
+	})
+	dialHTTPProxyForAvailability = func(context.Context) (net.Conn, error) {
+		return nil, errors.New("missing pipe")
+	}
+
+	if transport := DockerDesktopProxySocketTransport(context.Background()); transport != nil {
+		t.Fatalf("expected nil transport, got %T", transport)
+	}
+}
+
+func TestDesktopProxySocketAvailableWhenWindowsPipeDials(t *testing.T) {
+	conn := &availabilityProbeConn{}
+
+	if !desktopProxySocketAvailableWithDial(context.Background(), func(context.Context) (net.Conn, error) {
+		return conn, nil
+	}) {
+		t.Fatal("expected Docker Desktop proxy pipe to be available")
+	}
+	if !conn.closed {
+		t.Fatal("expected availability probe connection to be closed")
+	}
+}
+
+type availabilityProbeConn struct {
+	closed bool
+}
+
+func (c *availabilityProbeConn) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (c *availabilityProbeConn) Write([]byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+func (c *availabilityProbeConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *availabilityProbeConn) LocalAddr() net.Addr {
+	return availabilityProbeAddr("local")
+}
+
+func (c *availabilityProbeConn) RemoteAddr() net.Addr {
+	return availabilityProbeAddr("remote")
+}
+
+func (c *availabilityProbeConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *availabilityProbeConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *availabilityProbeConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+type availabilityProbeAddr string
+
+func (a availabilityProbeAddr) Network() string {
+	return string(a)
+}
+
+func (a availabilityProbeAddr) String() string {
+	return string(a)
+}

--- a/pkg/desktop/raw_client.go
+++ b/pkg/desktop/raw_client.go
@@ -37,23 +37,34 @@ func ProxyTransport() http.RoundTripper {
 			return
 		}
 
-		ctx := context.Background()
-		if !IsRunningInDockerDesktop(ctx) {
+		transport := DockerDesktopProxySocketTransport(context.Background())
+		if transport == nil {
 			desktopProxyTransportInst = http.DefaultTransport
 			return
 		}
-
-		desktopProxyTransportInst = &http.Transport{
-			Proxy: http.ProxyURL(&url.URL{
-				Scheme: "http",
-			}),
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return dialHTTPProxy(ctx)
-			},
-		}
+		desktopProxyTransportInst = transport
 	})
 
 	return desktopProxyTransportInst
+}
+
+// DockerDesktopProxySocketTransport returns a transport that proxies through
+// Docker Desktop's local HTTP proxy socket only. It intentionally ignores
+// HTTP_PROXY/HTTPS_PROXY environment variables so callers can opt into the
+// trusted Desktop socket without permitting arbitrary forward proxies.
+func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
+	if !IsRunningInDockerDesktop(ctx) {
+		return nil
+	}
+
+	return &http.Transport{
+		Proxy: http.ProxyURL(&url.URL{
+			Scheme: "http",
+		}),
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialHTTPProxy(ctx)
+		},
+	}
 }
 
 // hasEnvProxyVars returns true if any HTTP proxy environment variables are set.

--- a/pkg/desktop/raw_client.go
+++ b/pkg/desktop/raw_client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -56,6 +57,9 @@ func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
 	if !IsRunningInDockerDesktop(ctx) {
 		return nil
 	}
+	if !desktopProxySocketAvailable() {
+		return nil
+	}
 
 	return &http.Transport{
 		Proxy: http.ProxyURL(&url.URL{
@@ -65,6 +69,18 @@ func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
 			return dialHTTPProxy(ctx)
 		},
 	}
+}
+
+func desktopProxySocketAvailable() bool {
+	if runtime.GOOS == "windows" {
+		return true
+	}
+
+	info, err := os.Stat(Paths().HTTPProxySocket)
+	if err != nil {
+		return false
+	}
+	return info.Mode().Type() == os.ModeSocket
 }
 
 // hasEnvProxyVars returns true if any HTTP proxy environment variables are set.

--- a/pkg/desktop/raw_client.go
+++ b/pkg/desktop/raw_client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"runtime"
 	"sync"
 	"time"
 )
@@ -57,7 +56,7 @@ func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
 	if !IsRunningInDockerDesktop(ctx) {
 		return nil
 	}
-	if !desktopProxySocketAvailable() {
+	if !desktopProxySocketAvailable(ctx) {
 		return nil
 	}
 
@@ -69,18 +68,6 @@ func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
 			return dialHTTPProxy(ctx)
 		},
 	}
-}
-
-func desktopProxySocketAvailable() bool {
-	if runtime.GOOS == "windows" {
-		return true
-	}
-
-	info, err := os.Stat(Paths().HTTPProxySocket)
-	if err != nil {
-		return false
-	}
-	return info.Mode().Type() == os.ModeSocket
 }
 
 // hasEnvProxyVars returns true if any HTTP proxy environment variables are set.

--- a/pkg/desktop/raw_client.go
+++ b/pkg/desktop/raw_client.go
@@ -53,10 +53,8 @@ func ProxyTransport() http.RoundTripper {
 // HTTP_PROXY/HTTPS_PROXY environment variables so callers can opt into the
 // trusted Desktop socket without permitting arbitrary forward proxies.
 func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
-	if !IsRunningInDockerDesktop(ctx) {
-		return nil
-	}
-	if !desktopProxySocketAvailable(ctx) {
+	dialer := DockerDesktopProxySocketDialer(ctx)
+	if dialer == nil {
 		return nil
 	}
 
@@ -65,9 +63,24 @@ func DockerDesktopProxySocketTransport(ctx context.Context) http.RoundTripper {
 			Scheme: "http",
 		}),
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return dialHTTPProxy(ctx)
+			return dialer(ctx)
 		},
 	}
+}
+
+// DockerDesktopProxySocketDialer returns a dialer for Docker Desktop's local
+// HTTP proxy socket only. It intentionally ignores HTTP_PROXY/HTTPS_PROXY
+// environment variables so guarded callers can opt into the trusted Desktop
+// socket without permitting arbitrary forward proxies.
+func DockerDesktopProxySocketDialer(ctx context.Context) func(context.Context) (net.Conn, error) {
+	if !IsRunningInDockerDesktop(ctx) {
+		return nil
+	}
+	if !desktopProxySocketAvailable(ctx) {
+		return nil
+	}
+
+	return dialHTTPProxy
 }
 
 // hasEnvProxyVars returns true if any HTTP proxy environment variables are set.

--- a/pkg/desktop/raw_client_test.go
+++ b/pkg/desktop/raw_client_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"testing"
 )
 
@@ -248,16 +247,5 @@ func TestDockerDesktopProxySocketTransportReturnsNilWhenDesktopDisabled(t *testi
 
 	if transport := DockerDesktopProxySocketTransport(ctx); transport != nil {
 		t.Fatalf("expected nil transport, got %T", transport)
-	}
-}
-
-func TestDesktopProxySocketUnavailableWithoutSocket(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows uses a named pipe path that is not stat-checked")
-	}
-	t.Setenv("HOME", t.TempDir())
-
-	if desktopProxySocketAvailable() {
-		t.Fatal("expected Docker Desktop proxy socket to be unavailable")
 	}
 }

--- a/pkg/desktop/raw_client_test.go
+++ b/pkg/desktop/raw_client_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 )
 
@@ -247,5 +248,16 @@ func TestDockerDesktopProxySocketTransportReturnsNilWhenDesktopDisabled(t *testi
 
 	if transport := DockerDesktopProxySocketTransport(ctx); transport != nil {
 		t.Fatalf("expected nil transport, got %T", transport)
+	}
+}
+
+func TestDesktopProxySocketUnavailableWithoutSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows uses a named pipe path that is not stat-checked")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	if desktopProxySocketAvailable() {
+		t.Fatal("expected Docker Desktop proxy socket to be unavailable")
 	}
 }

--- a/pkg/desktop/raw_client_test.go
+++ b/pkg/desktop/raw_client_test.go
@@ -241,3 +241,11 @@ func TestDelete_ErrorStatusPlainBody(t *testing.T) {
 		t.Errorf("expected %q, got %q", expected, err.Error())
 	}
 }
+
+func TestDockerDesktopProxySocketTransportReturnsNilWhenDesktopDisabled(t *testing.T) {
+	ctx := WithNoDockerDesktop(context.Background())
+
+	if transport := DockerDesktopProxySocketTransport(ctx); transport != nil {
+		t.Fatalf("expected nil transport, got %T", transport)
+	}
+}

--- a/pkg/gateway/embeddings/client_test.go
+++ b/pkg/gateway/embeddings/client_test.go
@@ -2,6 +2,7 @@ package embeddings_test
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -11,9 +12,7 @@ import (
 
 // TestCloseStopsContainer verifies that Close() stops the Docker container
 func TestCloseStopsContainer(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping long-running test in short mode")
-	}
+	requireVectorDBIntegration(t)
 
 	ctx := context.Background()
 
@@ -82,9 +81,7 @@ func TestCloseStopsContainer(t *testing.T) {
 
 // TestCloseIdempotent verifies that calling Close() multiple times is safe
 func TestCloseIdempotent(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping long-running test in short mode")
-	}
+	requireVectorDBIntegration(t)
 
 	ctx := context.Background()
 	tmpDir := t.TempDir()
@@ -110,9 +107,7 @@ func TestCloseIdempotent(t *testing.T) {
 
 // TestDimensionParameter verifies that different dimension values work correctly
 func TestDimensionParameter(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping long-running test in short mode")
-	}
+	requireVectorDBIntegration(t)
 
 	testCases := []struct {
 		name      string
@@ -147,5 +142,18 @@ func TestDimensionParameter(t *testing.T) {
 
 			t.Logf("Successfully created client with dimension %d (expected: %d)", tc.dimension, tc.expected)
 		})
+	}
+}
+
+func requireVectorDBIntegration(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping long-running test in short mode")
+	}
+	if os.Getenv("INTEGRATION_TEST") == "" {
+		t.Skip("Skipping Docker integration test - set INTEGRATION_TEST=1 to run")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("Skipping Docker integration test - docker not found: %v", err)
 	}
 }

--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -116,8 +116,8 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	var err error
 
 	baseTransport := remoteurl.GuardDirectTransport()
-	if proxyTransport := desktop.DockerDesktopProxySocketTransport(ctx); proxyTransport != nil {
-		baseTransport = remoteurl.GuardTrustedProxyTransport(proxyTransport)
+	if proxyDialer := desktop.DockerDesktopProxySocketDialer(ctx); proxyDialer != nil {
+		baseTransport = remoteurl.GuardTrustedProxyDialer(proxyDialer)
 	}
 
 	// Create HTTP client with custom headers

--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
@@ -114,10 +115,15 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	var mcpTransport mcp.Transport
 	var err error
 
+	baseTransport := remoteurl.GuardDirectTransport()
+	if proxyTransport := desktop.DockerDesktopProxySocketTransport(ctx); proxyTransport != nil {
+		baseTransport = remoteurl.GuardTrustedProxyTransport(proxyTransport)
+	}
+
 	// Create HTTP client with custom headers
 	httpClient := &http.Client{
 		Transport: &headerRoundTripper{
-			base:    remoteurl.GuardDirectTransport(),
+			base:    baseTransport,
 			headers: headers,
 		},
 	}

--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -38,7 +38,7 @@ func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParams
 	}
 
 	cmd := exec.CommandContext(ctx, c.command, c.args...)
-	cmd.Env = c.env
+	cmd.Env = commandEnv(c.env)
 
 	if debug {
 		cmd.Stderr = logs.NewPrefixer(os.Stderr, "- "+c.name+": ")
@@ -61,6 +61,13 @@ func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParams
 	c.initialized.Store(true)
 
 	return nil
+}
+
+func commandEnv(env []string) []string {
+	if len(env) == 0 {
+		return os.Environ()
+	}
+	return append(os.Environ(), env...)
 }
 
 func (c *stdioMCPClient) AddRoots(roots []*mcp.Root) {

--- a/pkg/mcp/stdio.go
+++ b/pkg/mcp/stdio.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync/atomic"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -64,10 +65,24 @@ func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParams
 }
 
 func commandEnv(env []string) []string {
-	if len(env) == 0 {
-		return os.Environ()
+	if envHasKey(env, "PATH") {
+		return env
 	}
-	return append(os.Environ(), env...)
+	path := os.Getenv("PATH")
+	if path == "" {
+		return env
+	}
+	return append([]string{"PATH=" + path}, env...)
+}
+
+func envHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *stdioMCPClient) AddRoots(roots []*mcp.Root) {

--- a/pkg/mcp/stdio_test.go
+++ b/pkg/mcp/stdio_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCommandEnvIncludesProcessEnvironment(t *testing.T) {
+	t.Setenv("MCP_GATEWAY_STDIO_TEST_ENV", "base")
+
+	env := commandEnv([]string{
+		"MCP_GATEWAY_STDIO_TEST_EXTRA=extra",
+		"MCP_GATEWAY_STDIO_TEST_ENV=override",
+	})
+
+	assert.NotEmpty(t, envValue(env, "PATH"))
+	assert.Equal(t, "extra", envValue(env, "MCP_GATEWAY_STDIO_TEST_EXTRA"))
+	assert.Equal(t, "override", envValue(env, "MCP_GATEWAY_STDIO_TEST_ENV"))
+	assert.Contains(t, os.Environ(), "MCP_GATEWAY_STDIO_TEST_ENV=base")
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}
 
 func TestStdioClientInitializeAndListTools(t *testing.T) {
 	// Skip if running in CI or if Docker is not available

--- a/pkg/mcp/stdio_test.go
+++ b/pkg/mcp/stdio_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -12,18 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandEnvIncludesProcessEnvironment(t *testing.T) {
+func TestCommandEnvAddsOnlyProcessPATH(t *testing.T) {
 	t.Setenv("MCP_GATEWAY_STDIO_TEST_ENV", "base")
+	t.Setenv("PATH", "/test/path")
 
 	env := commandEnv([]string{
 		"MCP_GATEWAY_STDIO_TEST_EXTRA=extra",
 		"MCP_GATEWAY_STDIO_TEST_ENV=override",
 	})
 
-	assert.NotEmpty(t, envValue(env, "PATH"))
+	assert.Equal(t, "/test/path", envValue(env, "PATH"))
 	assert.Equal(t, "extra", envValue(env, "MCP_GATEWAY_STDIO_TEST_EXTRA"))
 	assert.Equal(t, "override", envValue(env, "MCP_GATEWAY_STDIO_TEST_ENV"))
-	assert.Contains(t, os.Environ(), "MCP_GATEWAY_STDIO_TEST_ENV=base")
+	assert.NotContains(t, env, "MCP_GATEWAY_STDIO_TEST_ENV=base")
+}
+
+func TestCommandEnvKeepsExplicitPATH(t *testing.T) {
+	t.Setenv("PATH", "/process/path")
+
+	env := commandEnv([]string{"PATH=/server/path"})
+
+	assert.Equal(t, "/server/path", envValue(env, "PATH"))
+	assert.Equal(t, []string{"PATH=/server/path"}, env)
 }
 
 func envValue(env []string, key string) string {

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -6,11 +6,16 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
-func guardedOAuthHTTPClient(timeout time.Duration) *http.Client {
+func guardedOAuthHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
+	if proxyTransport := desktop.DockerDesktopProxySocketTransport(ctx); proxyTransport != nil {
+		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyTransport)
+	}
+
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: remoteurl.GuardDirectTransport(),

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -12,8 +12,8 @@ import (
 )
 
 func guardedOAuthHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
-	if proxyTransport := desktop.DockerDesktopProxySocketTransport(ctx); proxyTransport != nil {
-		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyTransport)
+	if proxyDialer := desktop.DockerDesktopProxySocketDialer(ctx); proxyDialer != nil {
+		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyDialer)
 	}
 
 	return &http.Client{

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -159,7 +159,7 @@ func (m *Manager) ExchangeCode(ctx context.Context, code string, state string) e
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(ctx, 0))
 
 	token, err := config.Exchange(proxyCtx, code, opts...)
 	if err != nil {

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -283,7 +283,7 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(ctx, 0))
 
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()
 	if err != nil {
@@ -329,7 +329,7 @@ func (p *Provider) refreshTokenCE(ctx context.Context) error {
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(ctx, 0))
 
 	// TokenSource automatically refreshes using refresh_token
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()

--- a/pkg/oauthdiscovery/discovery.go
+++ b/pkg/oauthdiscovery/discovery.go
@@ -14,6 +14,7 @@ import (
 
 	oauthhelpers "github.com/docker/mcp-gateway-oauth-helpers"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
@@ -22,7 +23,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhel
 		return nil, err
 	}
 
-	client := remoteurl.NewDirectHTTPClient(30 * time.Second)
+	client := newGuardedHTTPClient(ctx, 30*time.Second)
 
 	parsedURL, err := url.Parse(serverURL)
 	if err != nil {
@@ -190,7 +191,7 @@ func PerformDCR(ctx context.Context, discovery *oauthhelpers.Discovery, serverNa
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "MCP-Gateway/1.0.0")
 
-	client := remoteurl.NewDirectHTTPClient(30 * time.Second)
+	client := newGuardedHTTPClient(ctx, 30*time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send DCR request to %s: %w", discovery.RegistrationEndpoint, err)
@@ -361,4 +362,11 @@ func validateRedirectURI(redirectURI string) error {
 	default:
 		return fmt.Errorf("redirect URI host %q not allowed - must be localhost or mcp.docker.com", parsed.Hostname())
 	}
+}
+
+func newGuardedHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
+	if proxyTransport := desktop.DockerDesktopProxySocketTransport(ctx); proxyTransport != nil {
+		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyTransport)
+	}
+	return remoteurl.NewDirectHTTPClient(timeout)
 }

--- a/pkg/oauthdiscovery/discovery.go
+++ b/pkg/oauthdiscovery/discovery.go
@@ -365,8 +365,8 @@ func validateRedirectURI(redirectURI string) error {
 }
 
 func newGuardedHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
-	if proxyTransport := desktop.DockerDesktopProxySocketTransport(ctx); proxyTransport != nil {
-		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyTransport)
+	if proxyDialer := desktop.DockerDesktopProxySocketDialer(ctx); proxyDialer != nil {
+		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyDialer)
 	}
 	return remoteurl.NewDirectHTTPClient(timeout)
 }

--- a/pkg/remoteurl/remoteurl.go
+++ b/pkg/remoteurl/remoteurl.go
@@ -132,6 +132,13 @@ func GuardTransport(base http.RoundTripper) http.RoundTripper {
 	return DefaultValidator().GuardTransport(base)
 }
 
+// GuardTrustedProxyTransport validates request and redirect URLs, but permits
+// dial targets that differ from the request host. Use it only with a trusted
+// local proxy transport such as Docker Desktop's proxy socket.
+func GuardTrustedProxyTransport(base http.RoundTripper) http.RoundTripper {
+	return DefaultValidator().GuardTrustedProxyTransport(base)
+}
+
 func DirectTransport() http.RoundTripper {
 	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 		cloned := transport.Clone()
@@ -146,10 +153,21 @@ func GuardDirectTransport() http.RoundTripper {
 }
 
 func (v Validator) GuardTransport(base http.RoundTripper) http.RoundTripper {
+	return v.guardTransport(base, false)
+}
+
+// GuardTrustedProxyTransport validates request and redirect URLs, but permits
+// dial targets that differ from the request host. Use it only with a trusted
+// local proxy transport such as Docker Desktop's proxy socket.
+func (v Validator) GuardTrustedProxyTransport(base http.RoundTripper) http.RoundTripper {
+	return v.guardTransport(base, true)
+}
+
+func (v Validator) guardTransport(base http.RoundTripper, allowTrustedProxy bool) http.RoundTripper {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	base = v.guardDialer(base)
+	base = v.guardDialer(base, allowTrustedProxy)
 	return &validatingRoundTripper{
 		base:      base,
 		validator: v,
@@ -167,6 +185,19 @@ func NewHTTPClient(timeout time.Duration, base http.RoundTripper) *http.Client {
 	}
 }
 
+// NewTrustedProxyHTTPClient returns a guarded client for a trusted local proxy
+// transport, such as Docker Desktop's proxy socket.
+func NewTrustedProxyHTTPClient(timeout time.Duration, base http.RoundTripper) *http.Client {
+	validator := DefaultValidator()
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: validator.GuardTrustedProxyTransport(base),
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			return validator.ValidateURL(req.Context(), req.URL)
+		},
+	}
+}
+
 func NewDirectHTTPClient(timeout time.Duration) *http.Client {
 	validator := DefaultValidator()
 	return &http.Client{
@@ -178,7 +209,7 @@ func NewDirectHTTPClient(timeout time.Duration) *http.Client {
 	}
 }
 
-func (v Validator) guardDialer(base http.RoundTripper) http.RoundTripper {
+func (v Validator) guardDialer(base http.RoundTripper, allowTrustedProxy bool) http.RoundTripper {
 	transport, ok := base.(*http.Transport)
 	if !ok {
 		return base
@@ -201,8 +232,14 @@ func (v Validator) guardDialer(base http.RoundTripper) http.RoundTripper {
 			return nil, fmt.Errorf("remote URL target host missing from request context")
 		}
 
-		if !sameHostname(targetHost, host) || v.allowInsecure {
+		if v.allowInsecure {
 			return originalDialContext(ctx, network, address)
+		}
+		if !sameHostname(targetHost, host) {
+			if allowTrustedProxy {
+				return originalDialContext(ctx, network, address)
+			}
+			return nil, fmt.Errorf("remote URL dial target %q does not match request host %q", host, targetHost)
 		}
 
 		return v.dialAllowedAddress(ctx, originalDialContext, network, host, port)

--- a/pkg/remoteurl/remoteurl.go
+++ b/pkg/remoteurl/remoteurl.go
@@ -132,13 +132,6 @@ func GuardTransport(base http.RoundTripper) http.RoundTripper {
 	return DefaultValidator().GuardTransport(base)
 }
 
-// GuardTrustedProxyTransport validates request and redirect URLs, but permits
-// dial targets that differ from the request host. Use it only with a trusted
-// local proxy transport such as Docker Desktop's proxy socket.
-func GuardTrustedProxyTransport(base http.RoundTripper) http.RoundTripper {
-	return DefaultValidator().GuardTrustedProxyTransport(base)
-}
-
 func DirectTransport() http.RoundTripper {
 	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 		cloned := transport.Clone()
@@ -156,11 +149,33 @@ func (v Validator) GuardTransport(base http.RoundTripper) http.RoundTripper {
 	return v.guardTransport(base, false)
 }
 
-// GuardTrustedProxyTransport validates request and redirect URLs, but permits
-// dial targets that differ from the request host. Use it only with a trusted
-// local proxy transport such as Docker Desktop's proxy socket.
-func (v Validator) GuardTrustedProxyTransport(base http.RoundTripper) http.RoundTripper {
-	return v.guardTransport(base, true)
+// TrustedProxyDialer dials a trusted local HTTP proxy socket.
+type TrustedProxyDialer func(context.Context) (net.Conn, error)
+
+// GuardTrustedProxyDialer validates request and redirect URLs, then sends
+// traffic through a trusted local HTTP proxy socket dialer. Use it only with
+// Docker Desktop's hardcoded local proxy socket.
+//
+// Unlike GuardTransport's direct path, this proxy path cannot pin the dialed IP
+// after validation because Docker Desktop's proxy resolves and dials the final
+// target. The validator still rejects blocked request and redirect URLs before
+// the proxy is dialed, but a narrow DNS-rebinding race remains accepted here to
+// preserve Docker Desktop proxy semantics.
+func GuardTrustedProxyDialer(dialer TrustedProxyDialer) http.RoundTripper {
+	return DefaultValidator().GuardTrustedProxyDialer(dialer)
+}
+
+// GuardTrustedProxyDialer validates request and redirect URLs, then sends
+// traffic through a trusted local HTTP proxy socket dialer. Use it only with
+// Docker Desktop's hardcoded local proxy socket.
+//
+// Unlike GuardTransport's direct path, this proxy path cannot pin the dialed IP
+// after validation because Docker Desktop's proxy resolves and dials the final
+// target. The validator still rejects blocked request and redirect URLs before
+// the proxy is dialed, but a narrow DNS-rebinding race remains accepted here to
+// preserve Docker Desktop proxy semantics.
+func (v Validator) GuardTrustedProxyDialer(dialer TrustedProxyDialer) http.RoundTripper {
+	return v.guardTransport(trustedProxyTransport(dialer), true)
 }
 
 func (v Validator) guardTransport(base http.RoundTripper, allowTrustedProxy bool) http.RoundTripper {
@@ -186,12 +201,12 @@ func NewHTTPClient(timeout time.Duration, base http.RoundTripper) *http.Client {
 }
 
 // NewTrustedProxyHTTPClient returns a guarded client for a trusted local proxy
-// transport, such as Docker Desktop's proxy socket.
-func NewTrustedProxyHTTPClient(timeout time.Duration, base http.RoundTripper) *http.Client {
+// dialer, such as Docker Desktop's proxy socket dialer.
+func NewTrustedProxyHTTPClient(timeout time.Duration, dialer TrustedProxyDialer) *http.Client {
 	validator := DefaultValidator()
 	return &http.Client{
 		Timeout:   timeout,
-		Transport: validator.GuardTrustedProxyTransport(base),
+		Transport: validator.GuardTrustedProxyDialer(dialer),
 		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
 			return validator.ValidateURL(req.Context(), req.URL)
 		},
@@ -246,6 +261,22 @@ func (v Validator) guardDialer(base http.RoundTripper, allowTrustedProxy bool) h
 	}
 
 	return cloned
+}
+
+func trustedProxyTransport(dialer TrustedProxyDialer) http.RoundTripper {
+	if dialer == nil {
+		dialer = func(context.Context) (net.Conn, error) {
+			return nil, fmt.Errorf("trusted proxy dialer is nil")
+		}
+	}
+	return &http.Transport{
+		Proxy: http.ProxyURL(&url.URL{
+			Scheme: "http",
+		}),
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialer(ctx)
+		},
+	}
 }
 
 func (v Validator) dialAllowedAddress(ctx context.Context, dial func(context.Context, string, string) (net.Conn, error), network, host, port string) (net.Conn, error) {

--- a/pkg/remoteurl/remoteurl_test.go
+++ b/pkg/remoteurl/remoteurl_test.go
@@ -145,7 +145,7 @@ func TestGuardTransportRejectsUnexpectedProxyDial(t *testing.T) {
 	assert.False(t, calledDialer)
 }
 
-func TestGuardTrustedProxyTransportAllowsExplicitProxyDial(t *testing.T) {
+func TestGuardTrustedProxyDialerAllowsExplicitProxyDial(t *testing.T) {
 	validator := NewValidator(Options{
 		Resolver: fakeResolver{
 			"public.example.test": {netip.MustParseAddr("8.8.8.8")},
@@ -153,18 +153,11 @@ func TestGuardTrustedProxyTransportAllowsExplicitProxyDial(t *testing.T) {
 	})
 
 	calledDialer := false
-	base := &http.Transport{
-		Proxy: http.ProxyURL(&url.URL{
-			Scheme: "http",
-			Host:   "proxy.example.test:8080",
-		}),
-		DialContext: func(context.Context, string, string) (net.Conn, error) {
+	client := &http.Client{
+		Transport: validator.GuardTrustedProxyDialer(func(context.Context) (net.Conn, error) {
 			calledDialer = true
 			return nil, fmt.Errorf("trusted proxy dial")
-		},
-	}
-	client := &http.Client{
-		Transport: validator.GuardTrustedProxyTransport(base),
+		}),
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://public.example.test/mcp", http.NoBody)
@@ -174,6 +167,30 @@ func TestGuardTrustedProxyTransportAllowsExplicitProxyDial(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "trusted proxy dial")
 	assert.True(t, calledDialer)
+}
+
+func TestGuardTrustedProxyDialerRejectsUnsafeBeforeProxyDial(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"metadata.example.test": {netip.MustParseAddr("169.254.169.254")},
+		},
+	})
+
+	calledDialer := false
+	client := &http.Client{
+		Transport: validator.GuardTrustedProxyDialer(func(context.Context) (net.Conn, error) {
+			calledDialer = true
+			return nil, fmt.Errorf("unexpected trusted proxy dial")
+		}),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://metadata.example.test/mcp", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = client.Do(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolved to disallowed address")
+	assert.False(t, calledDialer)
 }
 
 func TestGuardTransportRejectsUnsafeRedirects(t *testing.T) {

--- a/pkg/remoteurl/remoteurl_test.go
+++ b/pkg/remoteurl/remoteurl_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,7 +104,7 @@ func TestGuardDialerRequiresRequestTargetHost(t *testing.T) {
 		},
 	}
 
-	rt := validator.guardDialer(base)
+	rt := validator.guardDialer(base, false)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://public.example.test/mcp", http.NoBody)
 	require.NoError(t, err)
 
@@ -111,6 +112,68 @@ func TestGuardDialerRequiresRequestTargetHost(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "target host missing")
 	assert.False(t, calledDialer)
+}
+
+func TestGuardTransportRejectsUnexpectedProxyDial(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"public.example.test": {netip.MustParseAddr("8.8.8.8")},
+		},
+	})
+
+	calledDialer := false
+	base := &http.Transport{
+		Proxy: http.ProxyURL(&url.URL{
+			Scheme: "http",
+			Host:   "proxy.example.test:8080",
+		}),
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			calledDialer = true
+			return nil, fmt.Errorf("unexpected proxy dial")
+		},
+	}
+	client := &http.Client{
+		Transport: validator.GuardTransport(base),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://public.example.test/mcp", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = client.Do(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match request host")
+	assert.False(t, calledDialer)
+}
+
+func TestGuardTrustedProxyTransportAllowsExplicitProxyDial(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{
+			"public.example.test": {netip.MustParseAddr("8.8.8.8")},
+		},
+	})
+
+	calledDialer := false
+	base := &http.Transport{
+		Proxy: http.ProxyURL(&url.URL{
+			Scheme: "http",
+			Host:   "proxy.example.test:8080",
+		}),
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			calledDialer = true
+			return nil, fmt.Errorf("trusted proxy dial")
+		},
+	}
+	client := &http.Client{
+		Transport: validator.GuardTrustedProxyTransport(base),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://public.example.test/mcp", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = client.Do(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trusted proxy dial")
+	assert.True(t, calledDialer)
 }
 
 func TestGuardTransportRejectsUnsafeRedirects(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds an explicit Docker Desktop proxy socket transport/dialer helper that ignores arbitrary HTTP proxy environment variables.
- Adds a `remoteurl` trusted-proxy dialer guard that still validates request and redirect URLs, while permitting the known Docker Desktop local proxy socket to dial the final target.
- Wires guarded remote MCP, OAuth discovery/DCR, and OAuth token exchange clients to use the Desktop proxy socket when Desktop is available, with direct guarded transport as the fallback.
- Falls back to direct transport when the Desktop proxy socket is unavailable: Unix requires an actual socket file, and Windows probes the Docker Desktop named pipe with a bounded dial before selecting the proxy transport.
- Keeps Docker-image integration tests opt-in where they depend on unavailable external images, and only preserves `PATH` for stdio MCP server commands so Docker credential helpers remain discoverable without inheriting the full gateway environment.

## Why

The remote URL hardening in #507 intentionally switched guarded remote/OAuth flows to direct transports because generic forward proxies hide the final target from client-side dial-time IP validation. Docker Desktop’s local proxy socket is a trusted local integration point, so this follow-up restores Desktop proxy socket support explicitly without re-enabling arbitrary corporate/environment proxy routing for these guarded paths.

The trusted Desktop proxy path still validates request and redirect URLs before the proxy is dialed. Unlike direct transport, it cannot pin the post-validation dialed IP because Docker Desktop’s proxy resolves the final target internally; the code now documents that accepted residual DNS-rebinding race and has a negative test ensuring blocked DNS results reject before the proxy dialer is invoked.

## Validation

- go test -count=1 ./...
- go test -short ./pkg/... ./cmd/docker-mcp/...
- GOOS=windows GOARCH=amd64 go test -c ./pkg/desktop -o /tmp/mcp-gateway-pkg-desktop-windows.test.exe
- docker buildx build --build-arg GO_LDFLAGS --build-arg DOCKER_MCP_PLUGIN_BINARY --target=test .
- make lint