### PR TITLE
Sec #4: Harden tool call logging

### DIFF
--- a/pkg/interceptors/helpers.go
+++ b/pkg/interceptors/helpers.go
@@ -3,6 +3,7 @@ package interceptors
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 func argumentsToString(args any) string {
@@ -12,4 +13,56 @@ func argumentsToString(args any) string {
 	}
 
 	return string(buf)
+}
+
+func argumentsSummary(args any) string {
+	if args == nil {
+		return "none"
+	}
+
+	switch v := args.(type) {
+	case json.RawMessage:
+		return rawJSONSummary(v)
+	case []byte:
+		return rawJSONSummary(v)
+	}
+
+	value := reflect.ValueOf(args)
+	if !value.IsValid() {
+		return "none"
+	}
+
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return "none"
+		}
+		value = value.Elem()
+	}
+
+	switch value.Kind() {
+	case reflect.Map:
+		return fmt.Sprintf("object with %d field(s)", value.Len())
+	case reflect.Slice, reflect.Array:
+		return fmt.Sprintf("array with %d item(s)", value.Len())
+	case reflect.Struct:
+		return fmt.Sprintf("object with %d field(s)", value.NumField())
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	default:
+		return value.Kind().String()
+	}
+}
+
+func rawJSONSummary(raw []byte) string {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return "raw JSON"
+	}
+	return argumentsSummary(decoded)
 }

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -35,14 +35,15 @@ func Callbacks(logCalls, blockSecrets bool, oauthInterceptorEnabled bool, interc
 		middleware = append(middleware, interceptor.ToMiddleware())
 	}
 
+	// Add block secrets middleware before logging so request payloads are scanned
+	// before any built-in diagnostic logging observes the call.
+	if blockSecrets {
+		middleware = append(middleware, BlockSecretsMiddleware())
+	}
+
 	// Add log calls middleware
 	if logCalls {
 		middleware = append(middleware, LogCallsMiddleware())
-	}
-
-	// Add block secrets middleware
-	if blockSecrets {
-		middleware = append(middleware, BlockSecretsMiddleware())
 	}
 
 	return middleware

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -1,9 +1,14 @@
 package interceptors
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -202,4 +207,74 @@ func TestCallbacksOAuthInterceptorWithOtherMiddleware(t *testing.T) {
 	// With OAuth disabled but logCalls enabled
 	middlewares = Callbacks(true, false, false, nil)
 	assert.Len(t, middlewares, 2, "should have telemetry and log calls middleware")
+}
+
+func TestCallbacksBlockSecretsRunsBeforeLogCalls(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetLogWriter(&buf)
+	defer log.SetLogWriter(os.Stderr)
+
+	secret := "ghp_" + strings.Repeat("T", 36)
+	arguments, err := json.Marshal(map[string]any{"token": secret})
+	require.NoError(t, err)
+
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "dangerous",
+			Arguments: arguments,
+		},
+	}
+
+	var handlerCalled bool
+	handler := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		handlerCalled = true
+		return &mcp.CallToolResult{}, nil
+	}
+
+	for _, middleware := range reverseMiddlewares(Callbacks(true, true, false, nil)) {
+		handler = middleware(handler)
+	}
+
+	result, err := handler(context.Background(), "tools/call", req)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.False(t, handlerCalled, "secret-containing calls should be blocked before reaching the tool")
+	assert.NotContains(t, buf.String(), secret)
+	assert.NotContains(t, buf.String(), "Calling tool dangerous")
+}
+
+func TestLogCallsMiddlewareDoesNotLogRawArguments(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetLogWriter(&buf)
+	defer log.SetLogWriter(os.Stderr)
+
+	secret := "ghp_" + strings.Repeat("T", 36)
+	arguments, err := json.Marshal(map[string]any{"token": secret})
+	require.NoError(t, err)
+
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "metadata-only",
+			Arguments: arguments,
+		},
+	}
+
+	handler := LogCallsMiddleware()(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.CallToolResult{}, nil
+	})
+
+	result, err := handler(context.Background(), "tools/call", req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, buf.String(), "Calling tool metadata-only with arguments: object with 1 field(s)")
+	assert.NotContains(t, buf.String(), secret)
+	assert.NotContains(t, buf.String(), "token")
+}
+
+func reverseMiddlewares(middlewares []mcp.Middleware) []mcp.Middleware {
+	reversed := make([]mcp.Middleware, 0, len(middlewares))
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		reversed = append(reversed, middlewares[i])
+	}
+	return reversed
 }

--- a/pkg/interceptors/interceptors_test.go
+++ b/pkg/interceptors/interceptors_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/mcp-gateway/pkg/log"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/interceptors/log_calls.go
+++ b/pkg/interceptors/log_calls.go
@@ -30,7 +30,7 @@ func LogCallsMiddleware() mcp.Middleware {
 			}
 
 			if toolName != "" {
-				log.Logf("  - Calling tool %s with arguments: %s\n", toolName, argumentsToString(arguments))
+				log.Logf("  - Calling tool %s with arguments: %s\n", toolName, argumentsSummary(arguments))
 			} else {
 				log.Logf("  - Calling tool (unknown) with method: %s\n", method)
 			}


### PR DESCRIPTION
## Summary

- Run secret blocking before built-in tool call logging when both gateway options are enabled.
- Stop logging raw tool argument values; log argument shape metadata instead.
- Add regression tests proving blocked secret-shaped arguments do not appear in logs.

## Validation

- go test ./pkg/secretsscan ./pkg/interceptors ./pkg/gateway