### PR TITLE
Sec #6: Prevent tool-name shadowing

### DIFF
--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -48,6 +48,24 @@ type ResourceTemplateRegistration struct {
 	Handler          mcp.ResourceHandler
 }
 
+func filterCapabilitiesByAllowedTools(caps *Capabilities, toolAllowed []bool) *Capabilities {
+	if caps == nil {
+		return &Capabilities{}
+	}
+
+	filtered := &Capabilities{
+		Prompts:           caps.Prompts,
+		Resources:         caps.Resources,
+		ResourceTemplates: caps.ResourceTemplates,
+	}
+	for i, tool := range caps.Tools {
+		if i < len(toolAllowed) && toolAllowed[i] {
+			filtered.Tools = append(filtered.Tools, tool)
+		}
+	}
+	return filtered
+}
+
 func (caps *Capabilities) getToolByName(toolName string) (ToolRegistration, error) {
 	for _, tool := range caps.Tools {
 		if tool.Tool.Name == toolName {

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -265,8 +265,9 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 				}
 
 				capabilities.Tools = append(capabilities.Tools, ToolRegistration{
-					Tool:    &mcpTool,
-					Handler: g.mcpToolHandler(tool),
+					ServerName: serverName,
+					Tool:       &mcpTool,
+					Handler:    g.mcpToolHandler(tool),
 				})
 			}
 

--- a/pkg/gateway/codemode.go
+++ b/pkg/gateway/codemode.go
@@ -133,16 +133,23 @@ func addCodemodeHandler(g *Gateway) mcp.ToolHandler {
 		// Customize the tool name and description
 		customTool.Tool.Name = toolName
 
-		// Add the tool to the gateway's MCP server
-		g.mcpServer.AddTool(customTool.Tool, customTool.Handler)
-
 		// Track the tool registration for capabilities and mcp-exec
-		g.capabilitiesMu.Lock()
-		g.toolRegistrations[toolName] = ToolRegistration{
+		registration := ToolRegistration{
 			ServerName: "code-mode",
 			Tool:       customTool.Tool,
 			Handler:    customTool.Handler,
 		}
+		g.capabilitiesMu.Lock()
+		if err := validateToolNameCollisions([]ToolRegistration{registration}, g.toolRegistrations, false); err != nil {
+			g.capabilitiesMu.Unlock()
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{
+					Text: fmt.Sprintf("Error: Cannot create code-mode tool '%s'. %s", toolName, err),
+				}},
+			}, nil
+		}
+		g.mcpServer.AddTool(customTool.Tool, customTool.Handler)
+		g.toolRegistrations[toolName] = registration
 		g.capabilitiesMu.Unlock()
 
 		// Build detailed response with tool information

--- a/pkg/gateway/findmcps.go
+++ b/pkg/gateway/findmcps.go
@@ -307,6 +307,7 @@ func bm25Strategy(g *Gateway) mcp.ToolHandler {
 			serverInfo := map[string]any{
 				"name": s.doc.serverName,
 			}
+			g.addCatalogToolNameDiagnostics(serverInfo, s.doc.serverName, s.doc.server)
 
 			if s.doc.server.Description != "" {
 				serverInfo["description"] = s.doc.server.Description
@@ -449,6 +450,7 @@ func (g *Gateway) findServersByEmbedding(ctx context.Context, query string, limi
 		serverInfo := map[string]any{
 			"name": serverName,
 		}
+		g.addCatalogToolNameDiagnostics(serverInfo, serverName, server.Spec)
 
 		if server.Spec.Description != "" {
 			serverInfo["description"] = server.Spec.Description

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -90,8 +91,8 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 		}
 
 		// Append the new server to the current serverNames if not already present
-		found = slices.Contains(g.configuration.serverNames, serverName)
-		if !found {
+		alreadyEnabled := slices.Contains(g.configuration.serverNames, serverName)
+		if !alreadyEnabled {
 			g.configuration.serverNames = append(g.configuration.serverNames, serverName)
 		}
 
@@ -234,6 +235,18 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 
 		oldCaps, err := g.reloadServerCapabilities(ctx, serverName, clientConfig)
 		if err != nil {
+			if !alreadyEnabled {
+				g.configuration.serverNames = slices.DeleteFunc(g.configuration.serverNames, func(name string) bool {
+					return name == serverName
+				})
+			}
+			if errors.Is(err, errToolNameCollision) {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{
+						Text: fmt.Sprintf("Error: Cannot add server '%s'. %s", serverName, err),
+					}},
+				}, nil
+			}
 			return nil, fmt.Errorf("failed to reload configuration: %w", err)
 		}
 

--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -35,6 +35,10 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 	}
 	log.Log(">", len(capabilities.Tools), "tools listed in", time.Since(startList))
 
+	if err := validateExternalToolNameCollisions(capabilities.Tools, nil); err != nil {
+		return err
+	}
+
 	// Update capabilities
 	// Clear existing capabilities per server and register new ones
 
@@ -338,6 +342,18 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 		oldCaps = &ServerCapabilities{}
 	}
 
+	existingToolRegistrations := make(map[string]ToolRegistration, len(g.toolRegistrations))
+	for toolName, registration := range g.toolRegistrations {
+		if registration.ServerName == serverName {
+			continue
+		}
+		existingToolRegistrations[toolName] = registration
+	}
+
+	if err := validateExternalToolNameCollisions(newServerCaps.Tools, existingToolRegistrations); err != nil {
+		return nil, err
+	}
+
 	// Store the full capabilities
 	g.serverAvailableCapabilities[serverName] = newServerCaps
 
@@ -533,6 +549,14 @@ func (g *Gateway) removeServerConfiguration(_ context.Context, serverName string
 	if len(oldCaps.ToolNames) > 0 {
 		g.mcpServer.RemoveTools(oldCaps.ToolNames...)
 		log.Log("  - Removed", len(oldCaps.ToolNames), "tools for", serverName)
+		for _, toolName := range oldCaps.ToolNames {
+			delete(g.toolRegistrations, toolName)
+		}
+	}
+	for toolName, registration := range g.toolRegistrations {
+		if registration.ServerName == serverName {
+			delete(g.toolRegistrations, toolName)
+		}
 	}
 
 	if len(oldCaps.PromptNames) > 0 {
@@ -552,6 +576,7 @@ func (g *Gateway) removeServerConfiguration(_ context.Context, serverName string
 
 	// Update tracking with new capabilities
 	delete(g.serverCapabilities, serverName)
+	delete(g.serverAvailableCapabilities, serverName)
 
 	return nil
 }

--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -342,29 +342,6 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 		oldCaps = &ServerCapabilities{}
 	}
 
-	existingToolRegistrations := make(map[string]ToolRegistration, len(g.toolRegistrations))
-	for toolName, registration := range g.toolRegistrations {
-		if registration.ServerName == serverName {
-			continue
-		}
-		existingToolRegistrations[toolName] = registration
-	}
-
-	if err := validateExternalToolNameCollisions(newServerCaps.Tools, existingToolRegistrations); err != nil {
-		return nil, err
-	}
-
-	// Store the full capabilities
-	g.serverAvailableCapabilities[serverName] = newServerCaps
-
-	// Update tool registrations for this server
-	// This happens regardless of activation so tools can be called via mcp-exec
-	if oldCaps != nil {
-		// Remove old tool registrations for this server
-		for _, toolName := range oldCaps.ToolNames {
-			delete(g.toolRegistrations, toolName)
-		}
-	}
 	// Evaluate tool policies in batch if policy client is available.
 	toolAllowed := make([]bool, len(newServerCaps.Tools))
 	if g.policyClient != nil && len(newServerCaps.Tools) > 0 {
@@ -406,11 +383,35 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 		}
 	}
 
-	// Add new tool registrations from the server (with policy filtering).
-	for i, tool := range newServerCaps.Tools {
-		if !toolAllowed[i] {
+	allowedServerCaps := filterCapabilitiesByAllowedTools(newServerCaps, toolAllowed)
+
+	existingToolRegistrations := make(map[string]ToolRegistration, len(g.toolRegistrations))
+	for toolName, registration := range g.toolRegistrations {
+		if registration.ServerName == serverName {
 			continue
 		}
+		existingToolRegistrations[toolName] = registration
+	}
+
+	if err := validateExternalToolNameCollisions(allowedServerCaps.Tools, existingToolRegistrations); err != nil {
+		return nil, err
+	}
+
+	// Store the policy-filtered capabilities. updateServerCapabilities reads
+	// from this map, so denied tools must not remain here.
+	g.serverAvailableCapabilities[serverName] = allowedServerCaps
+
+	// Update tool registrations for this server
+	// This happens regardless of activation so tools can be called via mcp-exec
+	if oldCaps != nil {
+		// Remove old tool registrations for this server
+		for _, toolName := range oldCaps.ToolNames {
+			delete(g.toolRegistrations, toolName)
+		}
+	}
+
+	// Add new tool registrations from the server (with policy filtering).
+	for _, tool := range allowedServerCaps.Tools {
 		g.toolRegistrations[tool.Tool.Name] = tool
 	}
 

--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -35,6 +35,8 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 	}
 	log.Log(">", len(capabilities.Tools), "tools listed in", time.Since(startList))
 
+	capabilities = g.filterToolCapabilitiesByPolicy(ctx, configuration, capabilities, "tool")
+
 	if err := validateExternalToolNameCollisions(capabilities.Tools, nil); err != nil {
 		return err
 	}
@@ -288,6 +290,54 @@ func diffStringSlices(older, newer []string) (additions, removals []string) {
 	return additions, removals
 }
 
+func (g *Gateway) filterToolCapabilitiesByPolicy(ctx context.Context, configuration Configuration, caps *Capabilities, logLabel string) *Capabilities {
+	if caps == nil {
+		return &Capabilities{}
+	}
+
+	toolAllowed := make([]bool, len(caps.Tools))
+	if g.policyClient != nil && len(caps.Tools) > 0 {
+		requests := make([]policy.Request, len(caps.Tools))
+		for i, tool := range caps.Tools {
+			requests[i] = configuration.policyRequest(
+				tool.ServerName, tool.Tool.Name, policy.ActionLoad,
+			)
+		}
+		decisions, err := g.policyClient.EvaluateBatch(ctx, requests)
+		decisions, err = policycli.NormalizeBatchDecisions(requests, decisions, err)
+		for i, req := range requests {
+			event := buildAuditEvent(req, decisions[i], nil, nil)
+			submitAuditEvent(g.policyClient, event)
+		}
+		if err != nil {
+			// Fail-closed: deny all tools on batch error.
+			log.Logf("batch policy check failed for %ss: %v (denying all)", logLabel, err)
+		} else {
+			for i, dec := range decisions {
+				if dec.Allowed && dec.Error == "" {
+					toolAllowed[i] = true
+					continue
+				}
+				tool := caps.Tools[i]
+				if dec.Error != "" {
+					log.Logf("policy check failed for %s %s/%s: %s (denying)",
+						logLabel, tool.ServerName, tool.Tool.Name, dec.Error)
+					continue
+				}
+				log.Logf("policy denied %s %s/%s: %s",
+					logLabel, tool.ServerName, tool.Tool.Name, dec.Reason)
+			}
+		}
+	} else {
+		// No policy client - allow all tools.
+		for i := range toolAllowed {
+			toolAllowed[i] = true
+		}
+	}
+
+	return filterCapabilitiesByAllowedTools(caps, toolAllowed)
+}
+
 // allCapabilities builds a ServerCapabilities struct from the available capabilities for a server.
 // This function expects g.capabilitiesMu to be locked by the caller.
 func (g *Gateway) allCapabilities(serverName string) *ServerCapabilities {
@@ -342,48 +392,7 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 		oldCaps = &ServerCapabilities{}
 	}
 
-	// Evaluate tool policies in batch if policy client is available.
-	toolAllowed := make([]bool, len(newServerCaps.Tools))
-	if g.policyClient != nil && len(newServerCaps.Tools) > 0 {
-		requests := make([]policy.Request, len(newServerCaps.Tools))
-		for i, tool := range newServerCaps.Tools {
-			requests[i] = g.configuration.policyRequest(
-				serverName, tool.Tool.Name, policy.ActionLoad,
-			)
-		}
-		decisions, err := g.policyClient.EvaluateBatch(ctx, requests)
-		decisions, err = policycli.NormalizeBatchDecisions(requests, decisions, err)
-		for i, req := range requests {
-			event := buildAuditEvent(req, decisions[i], nil, nil)
-			submitAuditEvent(g.policyClient, event)
-		}
-		if err != nil {
-			// Fail-closed: deny all tools on batch error.
-			log.Logf("batch policy check failed for dynamic tools: %v (denying all)", err)
-		} else {
-			for i, dec := range decisions {
-				if dec.Allowed && dec.Error == "" {
-					toolAllowed[i] = true
-					continue
-				}
-				tool := newServerCaps.Tools[i]
-				if dec.Error != "" {
-					log.Logf("policy check failed for dynamic tool %s/%s: %s (denying)",
-						serverName, tool.Tool.Name, dec.Error)
-					continue
-				}
-				log.Logf("policy denied dynamic tool %s/%s: %s",
-					serverName, tool.Tool.Name, dec.Reason)
-			}
-		}
-	} else {
-		// No policy client - allow all tools.
-		for i := range toolAllowed {
-			toolAllowed[i] = true
-		}
-	}
-
-	allowedServerCaps := filterCapabilitiesByAllowedTools(newServerCaps, toolAllowed)
+	allowedServerCaps := g.filterToolCapabilitiesByPolicy(ctx, g.configuration, newServerCaps, "dynamic tool")
 
 	existingToolRegistrations := make(map[string]ToolRegistration, len(g.toolRegistrations))
 	for toolName, registration := range g.toolRegistrations {
@@ -417,7 +426,7 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 
 	// Return old capabilities for the caller to use with updateServerCapabilities
 	// The caller should use g.allCapabilities(serverName) to get newCaps
-	// The full capabilities (newServerCaps) are now in g.serverAvailableCapabilities[serverName]
+	// The filtered capabilities are now in g.serverAvailableCapabilities[serverName]
 	// g.serverCapabilities will be set by updateServerCapabilities after all updates succeed
 	return oldCaps, nil
 }

--- a/pkg/gateway/tool_names.go
+++ b/pkg/gateway/tool_names.go
@@ -1,0 +1,156 @@
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+)
+
+var errToolNameCollision = errors.New("tool name collision")
+
+type toolNameCollisionError struct {
+	message string
+}
+
+func (e toolNameCollisionError) Error() string {
+	return e.message
+}
+
+func (e toolNameCollisionError) Is(target error) bool {
+	return target == errToolNameCollision
+}
+
+var reservedGatewayToolNames = map[string]struct{}{
+	"code-mode":            {},
+	"find-tools":           {},
+	"mcp-activate-profile": {},
+	"mcp-add":              {},
+	"mcp-config-set":       {},
+	"mcp-create-profile":   {},
+	"mcp-exec":             {},
+	"mcp-find":             {},
+	"mcp-registry-import":  {},
+	"mcp-remove":           {},
+}
+
+func validateExternalToolNameCollisions(registrations []ToolRegistration, existing map[string]ToolRegistration) error {
+	return validateToolNameCollisions(registrations, existing, true)
+}
+
+func validateToolNameCollisions(registrations []ToolRegistration, existing map[string]ToolRegistration, rejectReserved bool) error {
+	seen := make(map[string]ToolRegistration, len(registrations))
+
+	for _, registration := range sortedToolRegistrations(registrations) {
+		if registration.Tool == nil {
+			continue
+		}
+
+		toolName := strings.TrimSpace(registration.Tool.Name)
+		if toolName == "" {
+			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes an empty tool name", toolOwner(registration))}
+		}
+
+		if rejectReserved {
+			if _, reserved := reservedGatewayToolNames[toolName]; reserved {
+				return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes reserved gateway tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolName)}
+			}
+		}
+
+		if previous, ok := seen[toolName]; ok {
+			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s and %s both expose tool name %q; enable tool-name-prefix or set unique catalog prefixes", toolOwner(previous), toolOwner(registration), toolName)}
+		}
+		seen[toolName] = registration
+
+		if existing == nil {
+			continue
+		}
+		if previous, ok := existing[toolName]; ok {
+			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s would shadow %s for tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolOwner(previous), toolName)}
+		}
+	}
+
+	return nil
+}
+
+func sortedToolRegistrations(registrations []ToolRegistration) []ToolRegistration {
+	sorted := append([]ToolRegistration(nil), registrations...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		left, right := sorted[i], sorted[j]
+		if left.ServerName != right.ServerName {
+			return left.ServerName < right.ServerName
+		}
+		var leftName, rightName string
+		if left.Tool != nil {
+			leftName = left.Tool.Name
+		}
+		if right.Tool != nil {
+			rightName = right.Tool.Name
+		}
+		return leftName < rightName
+	})
+	return sorted
+}
+
+func toolOwner(registration ToolRegistration) string {
+	if registration.ServerName == "" {
+		return "gateway internal tools"
+	}
+	return fmt.Sprintf("server %q", registration.ServerName)
+}
+
+func (g *Gateway) addCatalogToolNameDiagnostics(serverInfo map[string]any, serverName string, server catalog.Server) {
+	warnings := g.catalogToolNameWarnings(serverName, server)
+	if len(warnings) > 0 {
+		serverInfo["tool_name_warnings"] = warnings
+	}
+}
+
+func (g *Gateway) catalogToolNameWarnings(serverName string, server catalog.Server) []string {
+	if len(server.Tools) == 0 {
+		return nil
+	}
+
+	prefix := server.Prefix
+	if prefix == "" && g.ToolNamePrefix {
+		prefix = serverName
+	}
+
+	g.capabilitiesMu.RLock()
+	existing := make(map[string]ToolRegistration, len(g.toolRegistrations))
+	for name, registration := range g.toolRegistrations {
+		existing[name] = registration
+	}
+	g.capabilitiesMu.RUnlock()
+
+	var warnings []string
+	seen := make(map[string]string, len(server.Tools))
+	for _, tool := range server.Tools {
+		toolName := strings.TrimSpace(tool.Name)
+		if toolName == "" {
+			warnings = append(warnings, "catalog metadata includes an empty tool name")
+			continue
+		}
+
+		exposedName := prefixToolName(prefix, toolName)
+		if previousRawName, ok := seen[exposedName]; ok {
+			warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which duplicates tool %q in this server", toolName, exposedName, previousRawName))
+			continue
+		}
+		seen[exposedName] = toolName
+
+		if _, reserved := reservedGatewayToolNames[exposedName]; reserved {
+			warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which is reserved for a gateway internal tool", toolName, exposedName))
+			continue
+		}
+
+		if previous, ok := existing[exposedName]; ok && previous.ServerName != serverName {
+			warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which conflicts with %s", toolName, exposedName, toolOwner(previous)))
+		}
+	}
+
+	sort.Strings(warnings)
+	return warnings
+}

--- a/pkg/gateway/tool_names_test.go
+++ b/pkg/gateway/tool_names_test.go
@@ -78,6 +78,27 @@ func TestValidateExternalToolNameCollisionsRejectsDynamicMcpExecShadow(t *testin
 	assert.Equal(t, "trusted", existing["deploy"].ServerName)
 }
 
+func TestPolicyFilteredDynamicToolsDoNotTriggerCollisionValidation(t *testing.T) {
+	caps := &Capabilities{
+		Tools: []ToolRegistration{
+			{
+				ServerName: "candidate",
+				Tool:       &mcp.Tool{Name: "mcp-exec"},
+			},
+			{
+				ServerName: "candidate",
+				Tool:       &mcp.Tool{Name: "safe-tool"},
+			},
+		},
+	}
+
+	filtered := filterCapabilitiesByAllowedTools(caps, []bool{false, true})
+
+	require.Len(t, filtered.Tools, 1)
+	assert.Equal(t, "safe-tool", filtered.Tools[0].Tool.Name)
+	require.NoError(t, validateExternalToolNameCollisions(filtered.Tools, nil))
+}
+
 func TestCatalogToolNameWarningsReportPotentialMcpFindCollisions(t *testing.T) {
 	g := &Gateway{
 		toolRegistrations: map[string]ToolRegistration{

--- a/pkg/gateway/tool_names_test.go
+++ b/pkg/gateway/tool_names_test.go
@@ -1,0 +1,151 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+)
+
+func TestValidateExternalToolNameCollisionsRejectsDuplicateBaseServers(t *testing.T) {
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "alpha",
+			Tool:       &mcp.Tool{Name: "search"},
+		},
+		{
+			ServerName: "beta",
+			Tool:       &mcp.Tool{Name: "search"},
+		},
+	}, nil)
+
+	require.ErrorIs(t, err, errToolNameCollision)
+	assert.Contains(t, err.Error(), `server "alpha"`)
+	assert.Contains(t, err.Error(), `server "beta"`)
+	assert.Contains(t, err.Error(), `"search"`)
+}
+
+func TestValidateExternalToolNameCollisionsAllowsPrefixedDuplicateRawNames(t *testing.T) {
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "alpha",
+			Tool:       &mcp.Tool{Name: "alpha__search"},
+		},
+		{
+			ServerName: "beta",
+			Tool:       &mcp.Tool{Name: "beta__search"},
+		},
+	}, nil)
+
+	require.NoError(t, err)
+}
+
+func TestValidateExternalToolNameCollisionsRejectsReservedGatewayToolName(t *testing.T) {
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "untrusted",
+			Tool:       &mcp.Tool{Name: "mcp-exec"},
+		},
+	}, nil)
+
+	require.ErrorIs(t, err, errToolNameCollision)
+	assert.Contains(t, err.Error(), "reserved gateway tool name")
+	assert.Contains(t, err.Error(), "mcp-exec")
+}
+
+func TestValidateExternalToolNameCollisionsRejectsDynamicMcpExecShadow(t *testing.T) {
+	existing := map[string]ToolRegistration{
+		"deploy": {
+			ServerName: "trusted",
+			Tool:       &mcp.Tool{Name: "deploy"},
+		},
+	}
+
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "untrusted",
+			Tool:       &mcp.Tool{Name: "deploy"},
+		},
+	}, existing)
+
+	require.ErrorIs(t, err, errToolNameCollision)
+	assert.Contains(t, err.Error(), `server "untrusted" would shadow server "trusted"`)
+	assert.Equal(t, "trusted", existing["deploy"].ServerName)
+}
+
+func TestCatalogToolNameWarningsReportPotentialMcpFindCollisions(t *testing.T) {
+	g := &Gateway{
+		toolRegistrations: map[string]ToolRegistration{
+			"deploy": {
+				ServerName: "trusted",
+				Tool:       &mcp.Tool{Name: "deploy"},
+			},
+		},
+	}
+
+	warnings := g.catalogToolNameWarnings("candidate", catalog.Server{
+		Tools: []catalog.Tool{
+			{Name: "mcp-add"},
+			{Name: "deploy"},
+			{Name: "duplicate"},
+			{Name: "duplicate"},
+		},
+	})
+
+	require.Len(t, warnings, 3)
+	assert.Contains(t, warnings[0]+warnings[1]+warnings[2], "reserved for a gateway internal tool")
+	assert.Contains(t, warnings[0]+warnings[1]+warnings[2], `conflicts with server "trusted"`)
+	assert.Contains(t, warnings[0]+warnings[1]+warnings[2], "duplicates tool")
+}
+
+func TestBM25StrategyIncludesToolNameWarnings(t *testing.T) {
+	g := &Gateway{
+		configuration: Configuration{
+			serverNames: []string{"candidate"},
+			servers: map[string]catalog.Server{
+				"candidate": {
+					Name:        "candidate",
+					Title:       "Candidate",
+					Description: "candidate server",
+					Tools: []catalog.Tool{
+						{Name: "mcp-add", Description: "confusing internal tool"},
+					},
+				},
+			},
+		},
+	}
+
+	args, err := json.Marshal(map[string]any{
+		"query": "candidate",
+		"limit": 1,
+	})
+	require.NoError(t, err)
+
+	result, err := bm25Strategy(g)(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: args,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+
+	var response struct {
+		Servers []struct {
+			Name             string   `json:"name"`
+			ToolNameWarnings []string `json:"tool_name_warnings"`
+		} `json:"servers"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &response))
+	require.Len(t, response.Servers, 1)
+	assert.Equal(t, "candidate", response.Servers[0].Name)
+	require.Len(t, response.Servers[0].ToolNameWarnings, 1)
+	assert.Contains(t, response.Servers[0].ToolNameWarnings[0], "reserved for a gateway internal tool")
+}

--- a/pkg/gateway/tool_names_test.go
+++ b/pkg/gateway/tool_names_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/policy"
 )
 
 func TestValidateExternalToolNameCollisionsRejectsDuplicateBaseServers(t *testing.T) {
@@ -79,7 +80,15 @@ func TestValidateExternalToolNameCollisionsRejectsDynamicMcpExecShadow(t *testin
 }
 
 func TestPolicyFilteredDynamicToolsDoNotTriggerCollisionValidation(t *testing.T) {
-	caps := &Capabilities{
+	mock := newMockPolicyClient()
+	mock.deny("candidate", "mcp-exec", policy.ActionLoad, "blocked")
+	g := &Gateway{policyClient: mock}
+
+	filtered := g.filterToolCapabilitiesByPolicy(context.Background(), Configuration{
+		servers: map[string]catalog.Server{
+			"candidate": {Name: "candidate"},
+		},
+	}, &Capabilities{
 		Tools: []ToolRegistration{
 			{
 				ServerName: "candidate",
@@ -90,9 +99,7 @@ func TestPolicyFilteredDynamicToolsDoNotTriggerCollisionValidation(t *testing.T)
 				Tool:       &mcp.Tool{Name: "safe-tool"},
 			},
 		},
-	}
-
-	filtered := filterCapabilitiesByAllowedTools(caps, []bool{false, true})
+	}, "tool")
 
 	require.Len(t, filtered.Tools, 1)
 	assert.Equal(t, "safe-tool", filtered.Tools[0].Tool.Name)


### PR DESCRIPTION
## Summary
- reject exposed upstream tool names that collide across servers or with reserved gateway tools before registration
- return explicit `mcp-add` collision errors and add `mcp-find` catalog warnings for known risky names
- protect code-mode generated tool names and clean up `mcp-exec` registrations when servers are removed

## Root cause
The gateway registered tools directly by exposed name and `mcp-exec` routed through a single map keyed by tool name, so duplicate exposed names could silently shadow the intended routing target.

## Validation
- `go test ./pkg/gateway`
- `go test ./...` fails in this local environment due Docker Desktop proxy/tools socket and integration MCP EOF failures outside this change; `pkg/gateway` passed.
