### PR TITLE
Sec #5: Harden untrusted URL fetches

### DIFF
--- a/cmd/docker-mcp/commands/import.go
+++ b/cmd/docker-mcp/commands/import.go
@@ -5,22 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
+	"time"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
-	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/oci"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 func runMcpregistryImport(ctx context.Context, serverURL string, servers *[]catalog.Server) error {
-	// Validate URL
-	parsedURL, err := url.Parse(serverURL)
-	if err != nil {
+	if err := remoteurl.Validate(ctx, serverURL); err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
-	}
-
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return fmt.Errorf("URL must use http or https protocol")
 	}
 
 	// Fetch the server definition
@@ -31,9 +25,7 @@ func runMcpregistryImport(ctx context.Context, serverURL string, servers *[]cata
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	client := &http.Client{
-		Transport: desktop.ProxyTransport(),
-	}
+	client := remoteurl.NewDirectHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to fetch server definition: %w", err)

--- a/cmd/docker-mcp/commands/mcpregistry_test.go
+++ b/cmd/docker-mcp/commands/mcpregistry_test.go
@@ -5,9 +5,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 func TestMcpregistryImportCommand(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	// Test server that serves the Garmin MCP example JSON
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -92,6 +99,8 @@ func TestMcpregistryImportCommand_InvalidURL(t *testing.T) {
 }
 
 func TestMcpregistryImportCommand_HTTPError(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	// Test server that returns 404
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -106,6 +115,8 @@ func TestMcpregistryImportCommand_HTTPError(t *testing.T) {
 }
 
 func TestMcpregistryImportCommand_InvalidJSON(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	// Test server that returns invalid JSON
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -122,4 +133,10 @@ func TestMcpregistryImportCommand_InvalidJSON(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got none")
 	}
+}
+
+func TestMcpregistryImportCommand_RejectsUnsafeURL(t *testing.T) {
+	err := runMcpregistryImport(context.Background(), "https://127.0.0.1/v0/servers/test", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 	"github.com/docker/mcp-gateway/pkg/user"
 )
 
@@ -86,9 +87,7 @@ func readFileOrURL(ctx context.Context, fileOrURL string) ([]byte, error) {
 			return nil, err
 		}
 
-		client := &http.Client{
-			Transport: desktop.ProxyTransport(),
-		}
+		client := remoteurl.NewDirectHTTPClient(30 * time.Second)
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -2,12 +2,16 @@ package catalog
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 func TestCatalogGetWithConfigured(t *testing.T) {
@@ -193,6 +197,25 @@ func TestReadOneRejectsCatalogPathTraversal(t *testing.T) {
 			require.ErrorIs(t, err, errUntrustedLocalPath)
 		})
 	}
+}
+
+func TestReadOneRejectsUnsafeRemoteCatalogURL(t *testing.T) {
+	_, _, _, err := ReadOne(t.Context(), "https://127.0.0.1/docker-mcp.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestReadOneAllowsLocalHTTPRemoteCatalogWithOptIn(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("registry: {}\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	catalog, _, _, err := ReadOne(t.Context(), server.URL)
+	require.NoError(t, err)
+	assert.Empty(t, catalog.Servers)
 }
 
 func TestReadOneRejectsSymlinkEscape(t *testing.T) {

--- a/pkg/catalog_next/server_test.go
+++ b/pkg/catalog_next/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 	"github.com/docker/mcp-gateway/pkg/workingset"
 	"github.com/docker/mcp-gateway/test/mocks"
 )
@@ -98,6 +99,8 @@ func TestInspectServer(t *testing.T) {
 }
 
 func TestInspectServerWithReadme(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	readmeContent := "# Notion Remote\n\nThis is a remote server"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // Fetches a URL and returns the body as a byte slice.
@@ -19,10 +19,7 @@ func Untrusted(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 
-	client := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: desktop.ProxyTransport(),
-	}
+	client := remoteurl.NewDirectHTTPClient(30 * time.Second)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/fetch/fetch_test.go
+++ b/pkg/fetch/fetch_test.go
@@ -1,0 +1,31 @@
+package fetch
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
+)
+
+func TestUntrustedRejectsUnsafeURL(t *testing.T) {
+	_, err := Untrusted(t.Context(), "https://127.0.0.1/readme.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestUntrustedAllowsLocalHTTPWithOptIn(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("readme"))
+	}))
+	t.Cleanup(server.Close)
+
+	got, err := Untrusted(t.Context(), server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("readme"), got)
+}

--- a/pkg/registryapi/client.go
+++ b/pkg/registryapi/client.go
@@ -10,7 +10,7 @@ import (
 
 	registryapi "github.com/modelcontextprotocol/registry/pkg/api/v0"
 
-	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // CommunityRegistryBaseURL is the base URL for the community MCP registry
@@ -35,10 +35,7 @@ type client struct {
 
 func NewClient() Client {
 	return &client{
-		client: &http.Client{
-			Transport: desktop.ProxyTransport(),
-			Timeout:   20 * time.Second,
-		},
+		client: remoteurl.NewDirectHTTPClient(20 * time.Second),
 	}
 }
 

--- a/pkg/registryapi/url.go
+++ b/pkg/registryapi/url.go
@@ -1,9 +1,12 @@
 package registryapi
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // ServerURL represents a parsed MCP registry URL
@@ -21,10 +24,13 @@ type ServerURL struct {
 }
 
 // ParseServerURL parses an MCP registry URL into its components
-func ParseServerURL(rawURL string) (*ServerURL, error) {
+func ParseServerURL(ctx context.Context, rawURL string) (*ServerURL, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	if err := remoteurl.DefaultValidator().ValidateURL(ctx, parsedURL); err != nil {
+		return nil, err
 	}
 
 	// Extract base URL (scheme + host)

--- a/pkg/registryapi/url.go
+++ b/pkg/registryapi/url.go
@@ -1,7 +1,6 @@
 package registryapi
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -24,12 +23,12 @@ type ServerURL struct {
 }
 
 // ParseServerURL parses an MCP registry URL into its components
-func ParseServerURL(ctx context.Context, rawURL string) (*ServerURL, error) {
+func ParseServerURL(rawURL string) (*ServerURL, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}
-	if err := remoteurl.DefaultValidator().ValidateURL(ctx, parsedURL); err != nil {
+	if err := remoteurl.DefaultValidator().ValidateURLWithoutResolution(parsedURL); err != nil {
 		return nil, err
 	}
 

--- a/pkg/registryapi/url_test.go
+++ b/pkg/registryapi/url_test.go
@@ -4,9 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 func TestParseServerURL(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	tests := []struct {
 		name            string
 		url             string
@@ -81,7 +85,7 @@ func TestParseServerURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseServerURL(tt.url)
+			got, err := ParseServerURL(t.Context(), tt.url)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -94,6 +98,12 @@ func TestParseServerURL(t *testing.T) {
 			require.Equal(t, tt.wantVersion, got.Version)
 		})
 	}
+}
+
+func TestParseServerURLRejectsUnsafeHost(t *testing.T) {
+	_, err := ParseServerURL(t.Context(), "https://127.0.0.1/v0/servers/test")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not allowed")
 }
 
 func TestServerURL_String(t *testing.T) {

--- a/pkg/registryapi/url_test.go
+++ b/pkg/registryapi/url_test.go
@@ -4,13 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 func TestParseServerURL(t *testing.T) {
-	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
-
 	tests := []struct {
 		name            string
 		url             string
@@ -85,7 +81,7 @@ func TestParseServerURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseServerURL(t.Context(), tt.url)
+			got, err := ParseServerURL(tt.url)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -101,9 +97,15 @@ func TestParseServerURL(t *testing.T) {
 }
 
 func TestParseServerURLRejectsUnsafeHost(t *testing.T) {
-	_, err := ParseServerURL(t.Context(), "https://127.0.0.1/v0/servers/test")
+	_, err := ParseServerURL("https://127.0.0.1/v0/servers/test")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not allowed")
+}
+
+func TestParseServerURLDoesNotResolveHost(t *testing.T) {
+	got, err := ParseServerURL("https://not-resolvable.invalid/v0/servers/test")
+	require.NoError(t, err)
+	require.Equal(t, "https://not-resolvable.invalid", got.BaseURL)
 }
 
 func TestServerURL_String(t *testing.T) {

--- a/pkg/remoteurl/remoteurl.go
+++ b/pkg/remoteurl/remoteurl.go
@@ -68,47 +68,11 @@ func (v Validator) Validate(ctx context.Context, rawURL string) error {
 }
 
 func (v Validator) ValidateURL(ctx context.Context, u *url.URL) error {
-	if u == nil {
-		return fmt.Errorf("remote URL is empty")
+	host, needsResolution, err := v.validateURLWithoutResolution(u)
+	if err != nil {
+		return err
 	}
-	if u.Scheme == "" || u.Host == "" {
-		return fmt.Errorf("remote URL must be absolute")
-	}
-	if u.User != nil {
-		return fmt.Errorf("remote URL must not include userinfo")
-	}
-
-	scheme := strings.ToLower(u.Scheme)
-	switch scheme {
-	case "https":
-	case "http":
-		if !v.allowInsecure {
-			return fmt.Errorf("remote URL must use https")
-		}
-	default:
-		return fmt.Errorf("remote URL must use http or https")
-	}
-
-	host := u.Hostname()
-	if host == "" {
-		return fmt.Errorf("remote URL host is empty")
-	}
-	if strings.ContainsAny(host, "\x00%") {
-		return fmt.Errorf("remote URL host is malformed")
-	}
-
-	if v.allowInsecure {
-		return nil
-	}
-
-	if isBlockedHostname(host) {
-		return fmt.Errorf("remote URL host %q is not allowed", host)
-	}
-
-	if ip, err := netip.ParseAddr(host); err == nil {
-		if err := validateAddr(ip); err != nil {
-			return fmt.Errorf("remote URL host %q is not allowed: %w", host, err)
-		}
+	if !needsResolution {
 		return nil
 	}
 
@@ -126,6 +90,62 @@ func (v Validator) ValidateURL(ctx context.Context, u *url.URL) error {
 	}
 
 	return nil
+}
+
+// ValidateURLWithoutResolution applies URL safety checks that do not require DNS.
+// It rejects unsafe schemes, userinfo, unsafe hostname forms, and disallowed IP
+// literals. Call ValidateURL or use a guarded transport before network access.
+func (v Validator) ValidateURLWithoutResolution(u *url.URL) error {
+	_, _, err := v.validateURLWithoutResolution(u)
+	return err
+}
+
+func (v Validator) validateURLWithoutResolution(u *url.URL) (string, bool, error) {
+	if u == nil {
+		return "", false, fmt.Errorf("remote URL is empty")
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", false, fmt.Errorf("remote URL must be absolute")
+	}
+	if u.User != nil {
+		return "", false, fmt.Errorf("remote URL must not include userinfo")
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	switch scheme {
+	case "https":
+	case "http":
+		if !v.allowInsecure {
+			return "", false, fmt.Errorf("remote URL must use https")
+		}
+	default:
+		return "", false, fmt.Errorf("remote URL must use http or https")
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return "", false, fmt.Errorf("remote URL host is empty")
+	}
+	if strings.ContainsAny(host, "\x00%") {
+		return "", false, fmt.Errorf("remote URL host is malformed")
+	}
+
+	if v.allowInsecure {
+		return host, false, nil
+	}
+
+	if isBlockedHostname(host) {
+		return "", false, fmt.Errorf("remote URL host %q is not allowed", host)
+	}
+
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validateAddr(ip); err != nil {
+			return "", false, fmt.Errorf("remote URL host %q is not allowed: %w", host, err)
+		}
+		return host, false, nil
+	}
+
+	return host, true, nil
 }
 
 func GuardTransport(base http.RoundTripper) http.RoundTripper {

--- a/pkg/remoteurl/remoteurl_test.go
+++ b/pkg/remoteurl/remoteurl_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,37 @@ func TestValidateAllowsPublicHTTPS(t *testing.T) {
 	})
 
 	require.NoError(t, validator.Validate(context.Background(), "https://public.example.test/mcp"))
+}
+
+func TestValidateURLWithoutResolutionDoesNotResolveHost(t *testing.T) {
+	validator := NewValidator(Options{
+		Resolver: fakeResolver{},
+	})
+	u, err := url.Parse("https://not-in-resolver.example.test/mcp")
+	require.NoError(t, err)
+
+	require.NoError(t, validator.ValidateURLWithoutResolution(u))
+}
+
+func TestValidateURLWithoutResolutionRejectsUnsafeLiterals(t *testing.T) {
+	validator := NewValidator(Options{})
+
+	tests := []string{
+		"http://example.com/mcp",
+		"https://localhost/mcp",
+		"https://127.0.0.1/mcp",
+		"https://[::1]/mcp",
+		"https://user@example.com/mcp",
+	}
+
+	for _, rawURL := range tests {
+		t.Run(rawURL, func(t *testing.T) {
+			u, err := url.Parse(rawURL)
+			require.NoError(t, err)
+
+			require.Error(t, validator.ValidateURLWithoutResolution(u))
+		})
+	}
 }
 
 func TestValidateAllowsInsecureDevURLsWhenOptedIn(t *testing.T) {

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -656,7 +656,7 @@ func ConvertRegistryServerToCatalog(ctx context.Context, serverResp *v0.ServerRe
 }
 
 func ResolveRegistry(ctx context.Context, registryClient registryapi.Client, value string) (Server, error) {
-	url, err := registryapi.ParseServerURL(ctx, value)
+	url, err := registryapi.ParseServerURL(value)
 	if err != nil {
 		return Server{}, fmt.Errorf("failed to parse server URL %s: %w", value, err)
 	}

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -656,7 +656,7 @@ func ConvertRegistryServerToCatalog(ctx context.Context, serverResp *v0.ServerRe
 }
 
 func ResolveRegistry(ctx context.Context, registryClient registryapi.Client, value string) (Server, error) {
-	url, err := registryapi.ParseServerURL(value)
+	url, err := registryapi.ParseServerURL(ctx, value)
 	if err != nil {
 		return Server{}, fmt.Errorf("failed to parse server URL %s: %w", value, err)
 	}

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/oci"
-	"github.com/docker/mcp-gateway/pkg/remoteurl"
 	"github.com/docker/mcp-gateway/test/mocks"
 )
 
@@ -957,8 +956,6 @@ func TestCreateWorkingSetID(t *testing.T) {
 }
 
 func TestResolveServerFromString(t *testing.T) {
-	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
-
 	tests := []struct {
 		name            string
 		input           string
@@ -1377,8 +1374,6 @@ func TestResolveFileRejectsUntrustedPaths(t *testing.T) {
 }
 
 func TestResolveServerFromStringResolvesLatestVersion(t *testing.T) {
-	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
-
 	dao := setupTestDB(t)
 
 	serverResponse := v0.ServerResponse{

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/oci"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 	"github.com/docker/mcp-gateway/test/mocks"
 )
 
@@ -956,6 +957,8 @@ func TestCreateWorkingSetID(t *testing.T) {
 }
 
 func TestResolveServerFromString(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	tests := []struct {
 		name            string
 		input           string
@@ -994,27 +997,6 @@ func TestResolveServerFromString(t *testing.T) {
 					},
 				},
 				Secrets: "default",
-			}},
-			expectedVersion: "latest",
-		},
-		{
-			name:  "http registry",
-			input: "http://example.com/v0/servers/my-server",
-			expected: []Server{{
-				Type:    ServerTypeRegistry,
-				Source:  "http://example.com/v0/servers/my-server/versions/latest",
-				Secrets: "default",
-				Snapshot: &ServerSnapshot{
-					Server: catalog.Server{
-						Name:        "io-example-my-server",
-						Type:        "server",
-						Image:       "ghcr.io/example/my-server:latest",
-						Description: "Test MCP server",
-						Metadata: &catalog.Metadata{
-							RegistryURL: "https://registry.modelcontextprotocol.io/v0/servers/io.example%2Fmy-server/versions/latest",
-						},
-					},
-				},
 			}},
 			expectedVersion: "latest",
 		},
@@ -1093,14 +1075,11 @@ func TestResolveServerFromString(t *testing.T) {
 				},
 			}
 			registryClient := mocks.NewMockRegistryAPIClient(mocks.WithServerListResponses(map[string]v0.ServerListResponse{
-				"http://example.com/v0/servers/my-server/versions": {
-					Servers: []v0.ServerResponse{serverResponse},
-				},
 				"https://example.com/v0/servers/my-server/versions": {
 					Servers: []v0.ServerResponse{serverResponse},
 				},
 			}), mocks.WithServerResponses(map[string]v0.ServerResponse{
-				"http://example.com/v0/servers/my-server/versions/" + tt.expectedVersion: serverResponse,
+				"https://example.com/v0/servers/my-server/versions/" + tt.expectedVersion: serverResponse,
 			}))
 
 			ociService := mocks.NewMockOCIService(
@@ -1132,6 +1111,14 @@ func TestResolveServerFromString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveServerFromStringRejectsHTTPRegistryByDefault(t *testing.T) {
+	dao := setupTestDB(t)
+
+	_, err := ResolveServersFromString(t.Context(), mocks.NewMockRegistryAPIClient(), mocks.NewMockOCIService(), dao, "http://example.com/v0/servers/my-server")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote URL must use https")
 }
 
 func TestResolveFile(t *testing.T) {
@@ -1390,6 +1377,8 @@ func TestResolveFileRejectsUntrustedPaths(t *testing.T) {
 }
 
 func TestResolveServerFromStringResolvesLatestVersion(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
 	dao := setupTestDB(t)
 
 	serverResponse := v0.ServerResponse{
@@ -1435,17 +1424,17 @@ func TestResolveServerFromStringResolvesLatestVersion(t *testing.T) {
 		},
 	}
 	registryClient := mocks.NewMockRegistryAPIClient(mocks.WithServerListResponses(map[string]v0.ServerListResponse{
-		"http://example.com/v0/servers/my-server/versions": {
+		"https://example.com/v0/servers/my-server/versions": {
 			Servers: []v0.ServerResponse{serverResponse, oldServerResponse},
 		},
 	}), mocks.WithServerResponses(map[string]v0.ServerResponse{
-		"http://example.com/v0/servers/my-server/versions/0.1.0": oldServerResponse,
-		"http://example.com/v0/servers/my-server/versions/0.2.0": serverResponse,
+		"https://example.com/v0/servers/my-server/versions/0.1.0": oldServerResponse,
+		"https://example.com/v0/servers/my-server/versions/0.2.0": serverResponse,
 	}))
 
-	server, err := ResolveServersFromString(t.Context(), registryClient, mocks.NewMockOCIService(), dao, "http://example.com/v0/servers/my-server")
+	server, err := ResolveServersFromString(t.Context(), registryClient, mocks.NewMockOCIService(), dao, "https://example.com/v0/servers/my-server")
 	require.NoError(t, err)
-	assert.Equal(t, "http://example.com/v0/servers/my-server/versions/0.2.0", server[0].Source)
+	assert.Equal(t, "https://example.com/v0/servers/my-server/versions/0.2.0", server[0].Source)
 }
 
 func TestResolveSnapshot(t *testing.T) {


### PR DESCRIPTION
## Summary

- Route untrusted catalog, README, and MCP registry fetches through `pkg/remoteurl` guarded direct HTTP clients.
- Validate parsed MCP registry URLs with the remote URL guard before deriving registry API endpoints.
- Add regression coverage for unsafe loopback/default HTTP rejection and explicit insecure test opt-in.

## Why

Follow-up to #507: several non-MCP-client fetch paths still used `desktop.ProxyTransport()` directly, which bypassed the host/range validation model added for remote MCP URLs.

## Validation

- `go test -short ./pkg/...`
- `go test ./pkg/fetch ./pkg/catalog ./pkg/catalog_next ./pkg/registryapi ./pkg/workingset`
- `go test ./cmd/docker-mcp/commands -run 'TestMcpregistryImportCommand'`\n\nNote: the full `go test ./cmd/docker-mcp/commands` still hits existing Docker Desktop proxy socket assumptions in `TestDockerCatalogProtection` in this environment.