### PR TITLE
Sec #3: Verify MCP images before pulling

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -36,12 +36,13 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 		options = gateway.Config{
 			SecretsPath: "docker-desktop:/run/secrets/mcp_secret:/.env",
 			Options: gateway.Options{
-				Cpus:         1,
-				Memory:       "2Gb",
-				Transport:    "stdio",
-				LogCalls:     true,
-				BlockSecrets: true,
-				Verbose:      true,
+				Cpus:             1,
+				Memory:           "2Gb",
+				Transport:        "stdio",
+				LogCalls:         true,
+				BlockSecrets:     true,
+				Verbose:          true,
+				VerifySignatures: true,
 			},
 		}
 	} else {
@@ -49,12 +50,13 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 		options = gateway.Config{
 			SecretsPath: "docker-desktop",
 			Options: gateway.Options{
-				Cpus:         1,
-				Memory:       "2Gb",
-				Transport:    "stdio",
-				LogCalls:     true,
-				BlockSecrets: true,
-				Watch:        true,
+				Cpus:             1,
+				Memory:           "2Gb",
+				Transport:        "stdio",
+				LogCalls:         true,
+				BlockSecrets:     true,
+				Watch:            true,
+				VerifySignatures: true,
 			},
 		}
 	}
@@ -209,7 +211,7 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 	runCmd.Flags().BoolVar(&options.LogCalls, "log-calls", options.LogCalls, "Log calls to the tools")
 	runCmd.Flags().BoolVar(&options.BlockSecrets, "block-secrets", options.BlockSecrets, "Block secrets from being/received sent to/from tools")
 	runCmd.Flags().BoolVar(&options.BlockNetwork, "block-network", options.BlockNetwork, "Block tools from accessing forbidden network resources")
-	runCmd.Flags().BoolVar(&options.VerifySignatures, "verify-signatures", options.VerifySignatures, "Verify signatures of the server images")
+	runCmd.Flags().BoolVar(&options.VerifySignatures, "verify-signatures", options.VerifySignatures, "Verify signatures of Docker MCP server images")
 	runCmd.Flags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "Start the gateway but do not listen for connections (useful for testing the configuration)")
 	runCmd.Flags().BoolVar(&options.Verbose, "verbose", options.Verbose, "Verbose output")
 	runCmd.Flags().BoolVar(&options.LongLived, "long-lived", options.LongLived, "Containers are long-lived and will not be removed until the gateway is stopped, useful for stateful servers")

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -338,3 +338,4 @@ experimental: false
 experimentalcli: false
 kubernetes: false
 swarm: false
+

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -314,8 +314,8 @@ options:
       swarm: false
     - option: verify-signatures
       value_type: bool
-      default_value: "false"
-      description: Verify signatures of the server images
+      default_value: "true"
+      description: Verify signatures of Docker MCP server images
       deprecated: false
       hidden: false
       experimental: false
@@ -338,4 +338,3 @@ experimental: false
 experimentalcli: false
 kubernetes: false
 swarm: false
-

--- a/docs/generator/reference/mcp_gateway_run.md
+++ b/docs/generator/reference/mcp_gateway_run.md
@@ -36,9 +36,8 @@ Run the gateway
 | `--tools-config`            | `stringSlice` | `[tools.yaml]`      | Paths to the tools files (absolute or relative to ~/.docker/mcp/)                                                                             |
 | `--transport`               | `string`      | `stdio`             | stdio, sse or streaming. Uses MCP_GATEWAY_AUTH_TOKEN environment variable for localhost authentication to prevent dns rebinding attacks.      |
 | `--verbose`                 | `bool`        |                     | Verbose output                                                                                                                                |
-| `--verify-signatures`       | `bool`        |                     | Verify signatures of the server images                                                                                                        |
+| `--verify-signatures`       | `bool`        | `true`              | Verify signatures of Docker MCP server images                                                                                                 |
 | `--watch`                   | `bool`        | `true`              | Watch for changes and reconfigure the gateway                                                                                                 |
 
 
 <!---MARKER_GEN_END-->
-

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -107,7 +107,7 @@ Flags:
       --tools strings             List of tools to enable
       --transport string          stdio, sse or streaming (default is stdio) (default "stdio")
       --verbose                   Verbose output
-      --verify-signatures         Verify signatures of the server images
+      --verify-signatures         Verify signatures of Docker MCP server images (default true)
       --watch                     Watch for changes and reconfigure the gateway (default true)
       --profile string            Profile ID to use (requires working-sets feature, mutually exclusive with --servers and --enable-all-servers)
 ```

--- a/pkg/gateway/activateprofile.go
+++ b/pkg/gateway/activateprofile.go
@@ -223,7 +223,7 @@ func (g *Gateway) ActivateProfile(ctx context.Context, ws workingset.WorkingSet)
 		// Validate that Docker image can be pulled
 		if serverConfig.Image != "" {
 			log.Log(fmt.Sprintf("Validating image for server '%s': %s", serverName, serverConfig.Image))
-			if err := g.docker.PullImage(ctx, serverConfig.Image); err != nil {
+			if err := g.pullAndVerifyImage(ctx, serverConfig.Image); err != nil {
 				validation.imagePullError = err
 			}
 		}

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -222,7 +222,7 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 		// Pull the Docker image before trying to use the server
 		if serverConfig.Spec.Image != "" {
 			log.Log(fmt.Sprintf("Pulling image for server '%s': %s", serverName, serverConfig.Spec.Image))
-			if err := g.docker.PullImage(ctx, serverConfig.Spec.Image); err != nil {
+			if err := g.pullAndVerifyImage(ctx, serverConfig.Spec.Image); err != nil {
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{
 						Text: fmt.Sprintf("Error: Failed to pull image '%s' for server '%s'.\n\nDetails: %v\n\nThe server was not added. Please check the image name and your network connection.",

--- a/pkg/gateway/pull.go
+++ b/pkg/gateway/pull.go
@@ -67,13 +67,18 @@ func (g *Gateway) pullImages(ctx context.Context, images []string) error {
 }
 
 func (g *Gateway) verifyImages(ctx context.Context, images []string) error {
-	if !g.VerifySignatures || len(images) == 0 {
+	if len(images) == 0 {
+		return nil
+	}
+
+	if !g.VerifySignatures {
+		log.Log("Warning: signature verification is disabled; MCP server images will not be verified and may use mutable tags")
 		return nil
 	}
 
 	for _, image := range images {
 		if !strings.Contains(image, "@sha256:") {
-			return fmt.Errorf("verifying docker image %s: image must be referenced by digest", image)
+			return fmt.Errorf("verifying docker image %s: image must be referenced by digest; pin the MCP image to a sha256 digest or disable signature verification with --verify-signatures=false", image)
 		}
 	}
 

--- a/pkg/gateway/pull.go
+++ b/pkg/gateway/pull.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/distribution/reference"
+
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/signatures"
 )
@@ -87,9 +89,17 @@ func (g *Gateway) verifyImages(ctx context.Context, images []string) error {
 }
 
 func isDockerMCPImage(image string) bool {
-	image = strings.TrimPrefix(image, "docker.io/")
-	image = strings.TrimPrefix(image, "registry-1.docker.io/")
-	return strings.HasPrefix(image, "mcp/")
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return false
+	}
+
+	switch reference.Domain(named) {
+	case "docker.io", "registry-1.docker.io":
+		return strings.HasPrefix(reference.Path(named), "mcp/")
+	default:
+		return false
+	}
 }
 
 func imageBaseNames(names []string) []string {

--- a/pkg/gateway/pull.go
+++ b/pkg/gateway/pull.go
@@ -10,6 +10,8 @@ import (
 	"github.com/docker/mcp-gateway/pkg/signatures"
 )
 
+var verifyDockerImageSignatures = signatures.Verify
+
 func (g *Gateway) pullAndVerify(ctx context.Context, configuration Configuration) error {
 	dockerImages := configuration.DockerImages()
 	if len(dockerImages) == 0 {
@@ -21,20 +23,34 @@ func (g *Gateway) pullAndVerify(ctx context.Context, configuration Configuration
 	var verifiableImages []string
 	for _, image := range dockerImages {
 		log.Log("  - " + image)
-		if strings.HasPrefix(image, "mcp/") {
+		if isDockerMCPImage(image) {
 			verifiableImages = append(verifiableImages, image)
 		}
-	}
-
-	if err := g.pullImages(ctx, dockerImages); err != nil {
-		return err
 	}
 
 	if err := g.verifyImages(ctx, verifiableImages); err != nil {
 		return err
 	}
 
+	if err := g.pullImages(ctx, dockerImages); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (g *Gateway) pullAndVerifyImage(ctx context.Context, image string) error {
+	if image == "" {
+		return nil
+	}
+
+	if isDockerMCPImage(image) {
+		if err := g.verifyImages(ctx, []string{image}); err != nil {
+			return err
+		}
+	}
+
+	return g.pullImages(ctx, []string{image})
 }
 
 func (g *Gateway) pullImages(ctx context.Context, images []string) error {
@@ -49,19 +65,31 @@ func (g *Gateway) pullImages(ctx context.Context, images []string) error {
 }
 
 func (g *Gateway) verifyImages(ctx context.Context, images []string) error {
-	if !g.VerifySignatures {
+	if !g.VerifySignatures || len(images) == 0 {
 		return nil
+	}
+
+	for _, image := range images {
+		if !strings.Contains(image, "@sha256:") {
+			return fmt.Errorf("verifying docker image %s: image must be referenced by digest", image)
+		}
 	}
 
 	start := time.Now()
 	log.Log("- Verifying images", imageBaseNames(images))
 
-	if err := signatures.Verify(ctx, images); err != nil {
+	if err := verifyDockerImageSignatures(ctx, images); err != nil {
 		return fmt.Errorf("verifying docker images: %w", err)
 	}
 
 	log.Log("> Images verified in", time.Since(start))
 	return nil
+}
+
+func isDockerMCPImage(image string) bool {
+	image = strings.TrimPrefix(image, "docker.io/")
+	image = strings.TrimPrefix(image, "registry-1.docker.io/")
+	return strings.HasPrefix(image, "mcp/")
 }
 
 func imageBaseNames(names []string) []string {

--- a/pkg/gateway/pull_test.go
+++ b/pkg/gateway/pull_test.go
@@ -1,0 +1,206 @@
+package gateway
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+)
+
+func TestPullAndVerifyVerifiesMCPImagesBeforePull(t *testing.T) {
+	oldVerify := verifyDockerImageSignatures
+	defer func() {
+		verifyDockerImageSignatures = oldVerify
+	}()
+
+	var events []string
+	verifyDockerImageSignatures = func(_ context.Context, images []string) error {
+		events = append(events, "verify:"+strings.Join(images, ","))
+		return nil
+	}
+
+	docker := &recordingDockerClient{
+		pullImages: func(_ context.Context, names ...string) error {
+			for _, name := range names {
+				events = append(events, "pull:"+name)
+			}
+			return nil
+		},
+	}
+	g := &Gateway{
+		Options: Options{VerifySignatures: true},
+		docker:  docker,
+	}
+
+	err := g.pullAndVerify(context.Background(), Configuration{
+		serverNames: []string{"custom", "signed"},
+		servers: map[string]catalog.Server{
+			"custom": {Image: "ghcr.io/acme/server:latest"},
+			"signed": {Image: "mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"verify:mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf",
+		"pull:ghcr.io/acme/server:latest",
+		"pull:mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf",
+	}, events)
+}
+
+func TestPullAndVerifyImageRejectsMutableMCPReference(t *testing.T) {
+	oldVerify := verifyDockerImageSignatures
+	defer func() {
+		verifyDockerImageSignatures = oldVerify
+	}()
+
+	var verifierCalled bool
+	verifyDockerImageSignatures = func(_ context.Context, _ []string) error {
+		verifierCalled = true
+		return nil
+	}
+
+	docker := &recordingDockerClient{}
+	g := &Gateway{
+		Options: Options{VerifySignatures: true},
+		docker:  docker,
+	}
+
+	err := g.pullAndVerifyImage(context.Background(), "mcp/time:latest")
+
+	require.ErrorContains(t, err, "must be referenced by digest")
+	require.False(t, verifierCalled)
+	require.Empty(t, docker.pulledImages)
+}
+
+func TestPullAndVerifyImageSkipsNonMCPImages(t *testing.T) {
+	oldVerify := verifyDockerImageSignatures
+	defer func() {
+		verifyDockerImageSignatures = oldVerify
+	}()
+
+	var verifierCalled bool
+	verifyDockerImageSignatures = func(_ context.Context, _ []string) error {
+		verifierCalled = true
+		return nil
+	}
+
+	docker := &recordingDockerClient{}
+	g := &Gateway{
+		Options: Options{VerifySignatures: true},
+		docker:  docker,
+	}
+
+	err := g.pullAndVerifyImage(context.Background(), "ghcr.io/acme/server:latest")
+
+	require.NoError(t, err)
+	require.False(t, verifierCalled)
+	require.Equal(t, []string{"ghcr.io/acme/server:latest"}, docker.pulledImages)
+}
+
+func TestPullAndVerifyImageCanSkipVerificationWhenDisabled(t *testing.T) {
+	oldVerify := verifyDockerImageSignatures
+	defer func() {
+		verifyDockerImageSignatures = oldVerify
+	}()
+
+	var verifierCalled bool
+	verifyDockerImageSignatures = func(_ context.Context, _ []string) error {
+		verifierCalled = true
+		return nil
+	}
+
+	docker := &recordingDockerClient{}
+	g := &Gateway{
+		Options: Options{VerifySignatures: false},
+		docker:  docker,
+	}
+
+	err := g.pullAndVerifyImage(context.Background(), "mcp/time:latest")
+
+	require.NoError(t, err)
+	require.False(t, verifierCalled)
+	require.Equal(t, []string{"mcp/time:latest"}, docker.pulledImages)
+}
+
+type recordingDockerClient struct {
+	pulledImages []string
+	pullImages   func(context.Context, ...string) error
+}
+
+func (c *recordingDockerClient) ContainerExists(context.Context, string) (bool, container.InspectResponse, error) {
+	return false, container.InspectResponse{}, nil
+}
+
+func (c *recordingDockerClient) RemoveContainer(context.Context, string, bool) error {
+	return nil
+}
+
+func (c *recordingDockerClient) StartContainer(context.Context, string, container.Config, container.HostConfig, network.NetworkingConfig) error {
+	return nil
+}
+
+func (c *recordingDockerClient) StopContainer(context.Context, string, int) error {
+	return nil
+}
+
+func (c *recordingDockerClient) FindContainerByLabel(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (c *recordingDockerClient) FindAllContainersByLabel(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *recordingDockerClient) InspectContainer(context.Context, string) (container.InspectResponse, error) {
+	return container.InspectResponse{}, nil
+}
+
+func (c *recordingDockerClient) ReadLogs(context.Context, string, container.LogsOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (c *recordingDockerClient) ImageExists(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (c *recordingDockerClient) InspectImage(context.Context, string) (image.InspectResponse, error) {
+	return image.InspectResponse{}, nil
+}
+
+func (c *recordingDockerClient) PullImage(_ context.Context, name string) error {
+	c.pulledImages = append(c.pulledImages, name)
+	return nil
+}
+
+func (c *recordingDockerClient) PullImages(ctx context.Context, names ...string) error {
+	c.pulledImages = append(c.pulledImages, names...)
+	if c.pullImages != nil {
+		return c.pullImages(ctx, names...)
+	}
+	return nil
+}
+
+func (c *recordingDockerClient) CreateNetwork(context.Context, string, bool, map[string]string) error {
+	return nil
+}
+
+func (c *recordingDockerClient) RemoveNetwork(context.Context, string) error {
+	return nil
+}
+
+func (c *recordingDockerClient) ConnectNetwork(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *recordingDockerClient) InspectVolume(context.Context, string) (volume.Volume, error) {
+	return volume.Volume{}, nil
+}

--- a/pkg/gateway/pull_test.go
+++ b/pkg/gateway/pull_test.go
@@ -41,17 +41,19 @@ func TestPullAndVerifyVerifiesMCPImagesBeforePull(t *testing.T) {
 	}
 
 	err := g.pullAndVerify(context.Background(), Configuration{
-		serverNames: []string{"custom", "signed"},
+		serverNames: []string{"custom", "signed", "legacy"},
 		servers: map[string]catalog.Server{
 			"custom": {Image: "ghcr.io/acme/server:latest"},
 			"signed": {Image: "mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf"},
+			"legacy": {Image: "index.docker.io/mcp/github@sha256:756e73c2bd3777032dff922f4a8768135b5446b42619fe9239a190e20eb61757"},
 		},
 	})
 
 	require.NoError(t, err)
 	require.Equal(t, []string{
-		"verify:mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf",
+		"verify:index.docker.io/mcp/github@sha256:756e73c2bd3777032dff922f4a8768135b5446b42619fe9239a190e20eb61757,mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf",
 		"pull:ghcr.io/acme/server:latest",
+		"pull:index.docker.io/mcp/github@sha256:756e73c2bd3777032dff922f4a8768135b5446b42619fe9239a190e20eb61757",
 		"pull:mcp/time@sha256:9c46a918633fb474bf8035e3ee90ebac6bcf2b18ccb00679ac4c179cba0ebfcf",
 	}, events)
 }

--- a/pkg/gateway/pull_test.go
+++ b/pkg/gateway/pull_test.go
@@ -1,8 +1,10 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	gatewaylog "github.com/docker/mcp-gateway/pkg/log"
 )
 
 func TestPullAndVerifyVerifiesMCPImagesBeforePull(t *testing.T) {
@@ -79,6 +82,8 @@ func TestPullAndVerifyImageRejectsMutableMCPReference(t *testing.T) {
 	err := g.pullAndVerifyImage(context.Background(), "mcp/time:latest")
 
 	require.ErrorContains(t, err, "must be referenced by digest")
+	require.ErrorContains(t, err, "pin the MCP image to a sha256 digest")
+	require.ErrorContains(t, err, "--verify-signatures=false")
 	require.False(t, verifierCalled)
 	require.Empty(t, docker.pulledImages)
 }
@@ -130,6 +135,25 @@ func TestPullAndVerifyImageCanSkipVerificationWhenDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, verifierCalled)
+	require.Equal(t, []string{"mcp/time:latest"}, docker.pulledImages)
+}
+
+func TestPullAndVerifyImageWarnsWhenVerificationDisabled(t *testing.T) {
+	var output bytes.Buffer
+	gatewaylog.SetLogWriter(&output)
+	defer gatewaylog.SetLogWriter(os.Stderr)
+
+	docker := &recordingDockerClient{}
+	g := &Gateway{
+		Options: Options{VerifySignatures: false},
+		docker:  docker,
+	}
+
+	err := g.pullAndVerifyImage(context.Background(), "mcp/time:latest")
+
+	require.NoError(t, err)
+	require.Contains(t, output.String(), "Warning: signature verification is disabled")
+	require.Contains(t, output.String(), "MCP server images will not be verified")
 	require.Equal(t, []string{"mcp/time:latest"}, docker.pulledImages)
 }
 

--- a/pkg/gateway/pull_test.go
+++ b/pkg/gateway/pull_test.go
@@ -165,7 +165,7 @@ func (c *recordingDockerClient) InspectContainer(context.Context, string) (conta
 }
 
 func (c *recordingDockerClient) ReadLogs(context.Context, string, container.LogsOptions) (io.ReadCloser, error) {
-	return nil, nil
+	return io.NopCloser(strings.NewReader("")), nil
 }
 
 func (c *recordingDockerClient) ImageExists(context.Context, string) (bool, error) {


### PR DESCRIPTION
## Summary
- Verify Docker MCP `mcp/...` image signatures before pulling server images.
- Route dynamic server add/profile activation pulls through the same pull-and-verify helper.
- Enable signature verification by default for `docker mcp gateway run` and update command docs.

## Why
The gateway had signature verification infrastructure, but runtime image pulls could still happen without enforcement unless verification was explicitly enabled. Dynamic server add/profile activation paths also called `PullImage` directly. This makes Docker MCP images fail closed by default while leaving non-`mcp/...` third-party images outside Docker-key verification.

## Validation
- `go test ./pkg/gateway`
- `go test ./cmd/docker-mcp/commands -run 'TestGateway'`\n- `go test ./pkg/gateway ./pkg/docker ./pkg/signatures`\n- `git diff --check`\n\nNote: `go test ./cmd/docker-mcp/commands ./pkg/gateway` fails in existing command package tests (`TestDockerCatalogProtection`, `TestMcpregistryImportCommand`) because the test environment points HTTP traffic at an invalid Docker Desktop proxy socket under the test temp home.