### PR TITLE
Sec #6: Prevent capability shadowing

### DIFF
--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -3,7 +3,6 @@ package gateway
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -240,7 +239,7 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 					return name == serverName
 				})
 			}
-			if errors.Is(err, errToolNameCollision) {
+			if isCapabilityNameCollision(err) {
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{
 						Text: fmt.Sprintf("Error: Cannot add server '%s'. %s", serverName, err),

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -255,6 +255,18 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 			newCaps := g.allCapabilities(serverName)
 			if err := g.updateServerCapabilities(serverName, oldCaps, newCaps, nil); err != nil {
 				g.capabilitiesMu.Unlock()
+				if !alreadyEnabled {
+					g.configuration.serverNames = slices.DeleteFunc(g.configuration.serverNames, func(name string) bool {
+						return name == serverName
+					})
+				}
+				if isCapabilityNameCollision(err) {
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{
+							Text: fmt.Sprintf("Error: Cannot add server '%s'. %s", serverName, err),
+						}},
+					}, nil
+				}
 				return nil, fmt.Errorf("failed to update server capabilities: %w", err)
 			}
 			g.capabilitiesMu.Unlock()

--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -507,6 +507,10 @@ func (g *Gateway) updateServerCapabilities(serverName string, oldCaps, newCaps *
 		return nil
 	}
 
+	if err := validateExternalCapabilityNameCollisions(newServerCaps, g.registeredCapabilityNameIndexes(serverName), g.DynamicTools); err != nil {
+		return err
+	}
+
 	// Remove old capabilities that are no longer present
 	if len(removedTools) > 0 {
 		g.mcpServer.RemoveTools(removedTools...)

--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -36,8 +36,12 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 	log.Log(">", len(capabilities.Tools), "tools listed in", time.Since(startList))
 
 	capabilities = g.filterToolCapabilitiesByPolicy(ctx, configuration, capabilities, "tool")
+	capabilities = g.filterPromptCapabilitiesByPolicy(ctx, configuration, capabilities)
 
 	if err := validateExternalToolNameCollisions(capabilities.Tools, nil); err != nil {
+		return err
+	}
+	if err := validateExternalCapabilityNameCollisions(capabilities, capabilityNameIndexes{}, g.DynamicTools); err != nil {
 		return err
 	}
 
@@ -164,51 +168,7 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 		log.Log("  > mcp-discover: prompt for learning about dynamic server management")
 	}
 
-	// Evaluate prompt policies in batch if policy client is available.
-	promptAllowed := make([]bool, len(capabilities.Prompts))
-	if g.policyClient != nil && len(capabilities.Prompts) > 0 {
-		requests := make([]policy.Request, len(capabilities.Prompts))
-		for i, prompt := range capabilities.Prompts {
-			requests[i] = g.configuration.policyRequest(
-				prompt.ServerName, prompt.Prompt.Name, policy.ActionPrompt,
-			)
-		}
-		decisions, err := g.policyClient.EvaluateBatch(ctx, requests)
-		decisions, err = policycli.NormalizeBatchDecisions(requests, decisions, err)
-		for i, req := range requests {
-			event := buildAuditEvent(req, decisions[i], nil, nil)
-			submitAuditEvent(g.policyClient, event)
-		}
-		if err != nil {
-			log.Logf("batch policy check failed for prompts: %v (denying all)", err)
-		} else {
-			for i, dec := range decisions {
-				if dec.Allowed && dec.Error == "" {
-					promptAllowed[i] = true
-					continue
-				}
-				prompt := capabilities.Prompts[i]
-				if dec.Error != "" {
-					log.Logf("policy check failed for prompt %s/%s: %s (denying)",
-						prompt.ServerName, prompt.Prompt.Name, dec.Error)
-					continue
-				}
-				log.Logf("policy denied prompt %s/%s: %s",
-					prompt.ServerName, prompt.Prompt.Name, dec.Reason)
-			}
-		}
-	} else {
-		// No policy client - allow all prompts.
-		for i := range promptAllowed {
-			promptAllowed[i] = true
-		}
-	}
-
-	for i, prompt := range capabilities.Prompts {
-		if !promptAllowed[i] {
-			continue
-		}
-
+	for _, prompt := range capabilities.Prompts {
 		g.mcpServer.AddPrompt(prompt.Prompt, prompt.Handler)
 
 		// Track by server
@@ -338,6 +298,63 @@ func (g *Gateway) filterToolCapabilitiesByPolicy(ctx context.Context, configurat
 	return filterCapabilitiesByAllowedTools(caps, toolAllowed)
 }
 
+func (g *Gateway) filterPromptCapabilitiesByPolicy(ctx context.Context, configuration Configuration, caps *Capabilities) *Capabilities {
+	if caps == nil {
+		return &Capabilities{}
+	}
+
+	promptAllowed := make([]bool, len(caps.Prompts))
+	if g.policyClient != nil && len(caps.Prompts) > 0 {
+		requests := make([]policy.Request, len(caps.Prompts))
+		for i, prompt := range caps.Prompts {
+			requests[i] = configuration.policyRequest(
+				prompt.ServerName, prompt.Prompt.Name, policy.ActionPrompt,
+			)
+		}
+		decisions, err := g.policyClient.EvaluateBatch(ctx, requests)
+		decisions, err = policycli.NormalizeBatchDecisions(requests, decisions, err)
+		for i, req := range requests {
+			event := buildAuditEvent(req, decisions[i], nil, nil)
+			submitAuditEvent(g.policyClient, event)
+		}
+		if err != nil {
+			log.Logf("batch policy check failed for prompts: %v (denying all)", err)
+		} else {
+			for i, dec := range decisions {
+				if dec.Allowed && dec.Error == "" {
+					promptAllowed[i] = true
+					continue
+				}
+				prompt := caps.Prompts[i]
+				if dec.Error != "" {
+					log.Logf("policy check failed for prompt %s/%s: %s (denying)",
+						prompt.ServerName, prompt.Prompt.Name, dec.Error)
+					continue
+				}
+				log.Logf("policy denied prompt %s/%s: %s",
+					prompt.ServerName, prompt.Prompt.Name, dec.Reason)
+			}
+		}
+	} else {
+		// No policy client - allow all prompts.
+		for i := range promptAllowed {
+			promptAllowed[i] = true
+		}
+	}
+
+	filtered := &Capabilities{
+		Tools:             caps.Tools,
+		Resources:         caps.Resources,
+		ResourceTemplates: caps.ResourceTemplates,
+	}
+	for i, prompt := range caps.Prompts {
+		if i < len(promptAllowed) && promptAllowed[i] {
+			filtered.Prompts = append(filtered.Prompts, prompt)
+		}
+	}
+	return filtered
+}
+
 // allCapabilities builds a ServerCapabilities struct from the available capabilities for a server.
 // This function expects g.capabilitiesMu to be locked by the caller.
 func (g *Gateway) allCapabilities(serverName string) *ServerCapabilities {
@@ -393,6 +410,7 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 	}
 
 	allowedServerCaps := g.filterToolCapabilitiesByPolicy(ctx, g.configuration, newServerCaps, "dynamic tool")
+	allowedServerCaps = g.filterPromptCapabilitiesByPolicy(ctx, g.configuration, allowedServerCaps)
 
 	existingToolRegistrations := make(map[string]ToolRegistration, len(g.toolRegistrations))
 	for toolName, registration := range g.toolRegistrations {
@@ -403,6 +421,9 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 	}
 
 	if err := validateExternalToolNameCollisions(allowedServerCaps.Tools, existingToolRegistrations); err != nil {
+		return nil, err
+	}
+	if err := validateExternalCapabilityNameCollisions(allowedServerCaps, g.registeredCapabilityNameIndexes(serverName), g.DynamicTools); err != nil {
 		return nil, err
 	}
 
@@ -429,6 +450,34 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 	// The filtered capabilities are now in g.serverAvailableCapabilities[serverName]
 	// g.serverCapabilities will be set by updateServerCapabilities after all updates succeed
 	return oldCaps, nil
+}
+
+// registeredCapabilityNameIndexes builds indexes for capabilities currently
+// registered in the MCP server. This function expects g.capabilitiesMu to be
+// locked by the caller.
+func (g *Gateway) registeredCapabilityNameIndexes(excludeServerName string) capabilityNameIndexes {
+	indexes := capabilityNameIndexes{
+		Prompts:           make(map[string]string),
+		Resources:         make(map[string]string),
+		ResourceTemplates: make(map[string]string),
+	}
+
+	for serverName, caps := range g.serverCapabilities {
+		if serverName == excludeServerName || caps == nil {
+			continue
+		}
+		for _, promptName := range caps.PromptNames {
+			indexes.Prompts[promptName] = serverName
+		}
+		for _, resourceURI := range caps.ResourceURIs {
+			indexes.Resources[resourceURI] = serverName
+		}
+		for _, resourceTemplateURI := range caps.ResourceTemplateURIs {
+			indexes.ResourceTemplates[resourceTemplateURI] = serverName
+		}
+	}
+
+	return indexes
 }
 
 // updateServerCapabilities updates g.mcpServer with capabilities from the server.

--- a/pkg/gateway/tool_names.go
+++ b/pkg/gateway/tool_names.go
@@ -9,8 +9,10 @@ import (
 	"github.com/docker/mcp-gateway/pkg/catalog"
 )
 
-var errToolNameCollision = errors.New("tool name collision")
-var errCapabilityNameCollision = errors.New("capability name collision")
+var (
+	errToolNameCollision       = errors.New("tool name collision")
+	errCapabilityNameCollision = errors.New("capability name collision")
+)
 
 type toolNameCollisionError struct {
 	message string

--- a/pkg/gateway/tool_names.go
+++ b/pkg/gateway/tool_names.go
@@ -177,25 +177,24 @@ func validateCapabilityIdentityCollisions(kind string, registrations []capabilit
 	seen := make(map[string]capabilityIdentityRegistration, len(registrations))
 
 	for _, registration := range sortedCapabilityIdentityRegistrations(registrations) {
-		identifier := strings.TrimSpace(registration.identifier)
-		if identifier == "" {
+		if strings.TrimSpace(registration.identifier) == "" {
 			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s exposes an empty %s", kind, capabilityOwner(registration.serverName), kind)}
 		}
 
-		if _, ok := reserved[identifier]; ok {
-			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s exposes reserved gateway %s %q; %s", kind, capabilityOwner(registration.serverName), kind, identifier, mitigation)}
+		if _, ok := reserved[registration.identifier]; ok {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s exposes reserved gateway %s %q; %s", kind, capabilityOwner(registration.serverName), kind, registration.identifier, mitigation)}
 		}
 
-		if previous, ok := seen[identifier]; ok {
-			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s and %s both expose %s %q; %s", kind, capabilityOwner(previous.serverName), capabilityOwner(registration.serverName), kind, identifier, mitigation)}
+		if previous, ok := seen[registration.identifier]; ok {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s and %s both expose %s %q; %s", kind, capabilityOwner(previous.serverName), capabilityOwner(registration.serverName), kind, registration.identifier, mitigation)}
 		}
-		seen[identifier] = registration
+		seen[registration.identifier] = registration
 
 		if existing == nil {
 			continue
 		}
-		if previousServerName, ok := existing[identifier]; ok {
-			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s would shadow %s for %s %q; %s", kind, capabilityOwner(registration.serverName), capabilityOwner(previousServerName), kind, identifier, mitigation)}
+		if previousServerName, ok := existing[registration.identifier]; ok {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s would shadow %s for %s %q; %s", kind, capabilityOwner(registration.serverName), capabilityOwner(previousServerName), kind, registration.identifier, mitigation)}
 		}
 	}
 

--- a/pkg/gateway/tool_names.go
+++ b/pkg/gateway/tool_names.go
@@ -10,6 +10,7 @@ import (
 )
 
 var errToolNameCollision = errors.New("tool name collision")
+var errCapabilityNameCollision = errors.New("capability name collision")
 
 type toolNameCollisionError struct {
 	message string
@@ -23,6 +24,22 @@ func (e toolNameCollisionError) Is(target error) bool {
 	return target == errToolNameCollision
 }
 
+type capabilityNameCollisionError struct {
+	message string
+}
+
+func (e capabilityNameCollisionError) Error() string {
+	return e.message
+}
+
+func (e capabilityNameCollisionError) Is(target error) bool {
+	return target == errCapabilityNameCollision
+}
+
+func isCapabilityNameCollision(err error) bool {
+	return errors.Is(err, errToolNameCollision) || errors.Is(err, errCapabilityNameCollision)
+}
+
 var reservedGatewayToolNames = map[string]struct{}{
 	"code-mode":            {},
 	"find-tools":           {},
@@ -34,6 +51,10 @@ var reservedGatewayToolNames = map[string]struct{}{
 	"mcp-find":             {},
 	"mcp-registry-import":  {},
 	"mcp-remove":           {},
+}
+
+var reservedGatewayPromptNames = map[string]struct{}{
+	"mcp-discover": {},
 }
 
 func validateExternalToolNameCollisions(registrations []ToolRegistration, existing map[string]ToolRegistration) error {
@@ -99,6 +120,144 @@ func toolOwner(registration ToolRegistration) string {
 		return "gateway internal tools"
 	}
 	return fmt.Sprintf("server %q", registration.ServerName)
+}
+
+type capabilityNameIndexes struct {
+	Prompts           map[string]string
+	Resources         map[string]string
+	ResourceTemplates map[string]string
+}
+
+type capabilityIdentityRegistration struct {
+	serverName string
+	identifier string
+}
+
+func validateExternalCapabilityNameCollisions(caps *Capabilities, existing capabilityNameIndexes, rejectReservedPrompts bool) error {
+	if caps == nil {
+		return nil
+	}
+
+	var reservedPrompts map[string]struct{}
+	if rejectReservedPrompts {
+		reservedPrompts = reservedGatewayPromptNames
+	}
+	if err := validateCapabilityIdentityCollisions(
+		"prompt name",
+		promptIdentities(caps.Prompts),
+		existing.Prompts,
+		reservedPrompts,
+		"disable one server or expose unique prompt names",
+	); err != nil {
+		return err
+	}
+	if err := validateCapabilityIdentityCollisions(
+		"resource URI",
+		resourceIdentities(caps.Resources),
+		existing.Resources,
+		nil,
+		"disable one server or expose unique resource URIs",
+	); err != nil {
+		return err
+	}
+	if err := validateCapabilityIdentityCollisions(
+		"resource template URI template",
+		resourceTemplateIdentities(caps.ResourceTemplates),
+		existing.ResourceTemplates,
+		nil,
+		"disable one server or expose unique resource template URI templates",
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateCapabilityIdentityCollisions(kind string, registrations []capabilityIdentityRegistration, existing map[string]string, reserved map[string]struct{}, mitigation string) error {
+	seen := make(map[string]capabilityIdentityRegistration, len(registrations))
+
+	for _, registration := range sortedCapabilityIdentityRegistrations(registrations) {
+		identifier := strings.TrimSpace(registration.identifier)
+		if identifier == "" {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s exposes an empty %s", kind, capabilityOwner(registration.serverName), kind)}
+		}
+
+		if _, ok := reserved[identifier]; ok {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s exposes reserved gateway %s %q; %s", kind, capabilityOwner(registration.serverName), kind, identifier, mitigation)}
+		}
+
+		if previous, ok := seen[identifier]; ok {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s and %s both expose %s %q; %s", kind, capabilityOwner(previous.serverName), capabilityOwner(registration.serverName), kind, identifier, mitigation)}
+		}
+		seen[identifier] = registration
+
+		if existing == nil {
+			continue
+		}
+		if previousServerName, ok := existing[identifier]; ok {
+			return capabilityNameCollisionError{message: fmt.Sprintf("%s collision: %s would shadow %s for %s %q; %s", kind, capabilityOwner(registration.serverName), capabilityOwner(previousServerName), kind, identifier, mitigation)}
+		}
+	}
+
+	return nil
+}
+
+func promptIdentities(registrations []PromptRegistration) []capabilityIdentityRegistration {
+	identities := make([]capabilityIdentityRegistration, 0, len(registrations))
+	for _, registration := range registrations {
+		if registration.Prompt == nil {
+			continue
+		}
+		identities = append(identities, capabilityIdentityRegistration{
+			serverName: registration.ServerName,
+			identifier: registration.Prompt.Name,
+		})
+	}
+	return identities
+}
+
+func resourceIdentities(registrations []ResourceRegistration) []capabilityIdentityRegistration {
+	identities := make([]capabilityIdentityRegistration, 0, len(registrations))
+	for _, registration := range registrations {
+		if registration.Resource == nil {
+			continue
+		}
+		identities = append(identities, capabilityIdentityRegistration{
+			serverName: registration.ServerName,
+			identifier: registration.Resource.URI,
+		})
+	}
+	return identities
+}
+
+func resourceTemplateIdentities(registrations []ResourceTemplateRegistration) []capabilityIdentityRegistration {
+	identities := make([]capabilityIdentityRegistration, 0, len(registrations))
+	for _, registration := range registrations {
+		identities = append(identities, capabilityIdentityRegistration{
+			serverName: registration.ServerName,
+			identifier: registration.ResourceTemplate.URITemplate,
+		})
+	}
+	return identities
+}
+
+func sortedCapabilityIdentityRegistrations(registrations []capabilityIdentityRegistration) []capabilityIdentityRegistration {
+	sorted := append([]capabilityIdentityRegistration(nil), registrations...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		left, right := sorted[i], sorted[j]
+		if left.serverName != right.serverName {
+			return left.serverName < right.serverName
+		}
+		return left.identifier < right.identifier
+	})
+	return sorted
+}
+
+func capabilityOwner(serverName string) string {
+	if serverName == "" {
+		return "gateway internal capabilities"
+	}
+	return fmt.Sprintf("server %q", serverName)
 }
 
 func (g *Gateway) addCatalogToolNameDiagnostics(serverInfo map[string]any, serverName string, server catalog.Server) {

--- a/pkg/gateway/tool_names_test.go
+++ b/pkg/gateway/tool_names_test.go
@@ -118,6 +118,27 @@ func TestValidateExternalCapabilityNameCollisionsRejectsReservedDynamicPromptNam
 	require.NoError(t, validateExternalCapabilityNameCollisions(caps, capabilityNameIndexes{}, false))
 }
 
+func TestValidateExternalCapabilityNameCollisionsUsesRawIdentifiersForComparison(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		Prompts: []PromptRegistration{
+			{
+				ServerName: "alpha",
+				Prompt:     &mcp.Prompt{Name: "summarize"},
+			},
+			{
+				ServerName: "beta",
+				Prompt:     &mcp.Prompt{Name: " summarize "},
+			},
+			{
+				ServerName: "gamma",
+				Prompt:     &mcp.Prompt{Name: " mcp-discover "},
+			},
+		},
+	}, capabilityNameIndexes{}, true)
+
+	require.NoError(t, err)
+}
+
 func TestValidateExternalCapabilityNameCollisionsRejectsPromptShadow(t *testing.T) {
 	err := validateExternalCapabilityNameCollisions(&Capabilities{
 		Prompts: []PromptRegistration{
@@ -209,6 +230,39 @@ func TestValidateExternalCapabilityNameCollisionsRejectsResourceTemplateShadow(t
 	require.ErrorIs(t, err, errCapabilityNameCollision)
 	assert.Contains(t, err.Error(), `server "candidate" would shadow server "trusted"`)
 	assert.Contains(t, err.Error(), "file://shared/{name}")
+}
+
+func TestUpdateServerCapabilitiesRevalidatesCapabilityCollisionsUnderLock(t *testing.T) {
+	g := &Gateway{
+		serverCapabilities: map[string]*ServerCapabilities{
+			"trusted": {
+				PromptNames: []string{"summarize"},
+			},
+		},
+		serverAvailableCapabilities: map[string]*Capabilities{
+			"candidate": {
+				Prompts: []PromptRegistration{
+					{
+						ServerName: "candidate",
+						Prompt:     &mcp.Prompt{Name: "summarize"},
+					},
+				},
+			},
+		},
+	}
+
+	g.capabilitiesMu.Lock()
+	err := g.updateServerCapabilities(
+		"candidate",
+		&ServerCapabilities{},
+		&ServerCapabilities{PromptNames: []string{"summarize"}},
+		nil,
+	)
+	g.capabilitiesMu.Unlock()
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), `server "candidate" would shadow server "trusted"`)
+	assert.Nil(t, g.serverCapabilities["candidate"])
 }
 
 func TestPolicyFilteredDynamicToolsDoNotTriggerCollisionValidation(t *testing.T) {

--- a/pkg/gateway/tool_names_test.go
+++ b/pkg/gateway/tool_names_test.go
@@ -79,6 +79,138 @@ func TestValidateExternalToolNameCollisionsRejectsDynamicMcpExecShadow(t *testin
 	assert.Equal(t, "trusted", existing["deploy"].ServerName)
 }
 
+func TestValidateExternalCapabilityNameCollisionsRejectsDuplicatePrompts(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		Prompts: []PromptRegistration{
+			{
+				ServerName: "alpha",
+				Prompt:     &mcp.Prompt{Name: "summarize"},
+			},
+			{
+				ServerName: "beta",
+				Prompt:     &mcp.Prompt{Name: "summarize"},
+			},
+		},
+	}, capabilityNameIndexes{}, true)
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), "prompt name collision")
+	assert.Contains(t, err.Error(), `server "alpha"`)
+	assert.Contains(t, err.Error(), `server "beta"`)
+	assert.Contains(t, err.Error(), `"summarize"`)
+}
+
+func TestValidateExternalCapabilityNameCollisionsRejectsReservedDynamicPromptName(t *testing.T) {
+	caps := &Capabilities{
+		Prompts: []PromptRegistration{
+			{
+				ServerName: "candidate",
+				Prompt:     &mcp.Prompt{Name: "mcp-discover"},
+			},
+		},
+	}
+
+	err := validateExternalCapabilityNameCollisions(caps, capabilityNameIndexes{}, true)
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), "reserved gateway prompt name")
+	assert.Contains(t, err.Error(), "mcp-discover")
+
+	require.NoError(t, validateExternalCapabilityNameCollisions(caps, capabilityNameIndexes{}, false))
+}
+
+func TestValidateExternalCapabilityNameCollisionsRejectsPromptShadow(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		Prompts: []PromptRegistration{
+			{
+				ServerName: "candidate",
+				Prompt:     &mcp.Prompt{Name: "summarize"},
+			},
+		},
+	}, capabilityNameIndexes{
+		Prompts: map[string]string{"summarize": "trusted"},
+	}, true)
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), `server "candidate" would shadow server "trusted"`)
+	assert.Contains(t, err.Error(), `"summarize"`)
+}
+
+func TestValidateExternalCapabilityNameCollisionsRejectsDuplicateResourceURIs(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		Resources: []ResourceRegistration{
+			{
+				ServerName: "alpha",
+				Resource:   &mcp.Resource{URI: "file://shared/readme"},
+			},
+			{
+				ServerName: "beta",
+				Resource:   &mcp.Resource{URI: "file://shared/readme"},
+			},
+		},
+	}, capabilityNameIndexes{}, false)
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), "resource URI collision")
+	assert.Contains(t, err.Error(), `server "alpha"`)
+	assert.Contains(t, err.Error(), `server "beta"`)
+	assert.Contains(t, err.Error(), "file://shared/readme")
+}
+
+func TestValidateExternalCapabilityNameCollisionsRejectsResourceURIShadow(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		Resources: []ResourceRegistration{
+			{
+				ServerName: "candidate",
+				Resource:   &mcp.Resource{URI: "file://shared/readme"},
+			},
+		},
+	}, capabilityNameIndexes{
+		Resources: map[string]string{"file://shared/readme": "trusted"},
+	}, false)
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), `server "candidate" would shadow server "trusted"`)
+	assert.Contains(t, err.Error(), "file://shared/readme")
+}
+
+func TestValidateExternalCapabilityNameCollisionsRejectsDuplicateResourceTemplates(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		ResourceTemplates: []ResourceTemplateRegistration{
+			{
+				ServerName:       "alpha",
+				ResourceTemplate: mcp.ResourceTemplate{URITemplate: "file://shared/{name}"},
+			},
+			{
+				ServerName:       "beta",
+				ResourceTemplate: mcp.ResourceTemplate{URITemplate: "file://shared/{name}"},
+			},
+		},
+	}, capabilityNameIndexes{}, false)
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), "resource template URI template collision")
+	assert.Contains(t, err.Error(), `server "alpha"`)
+	assert.Contains(t, err.Error(), `server "beta"`)
+	assert.Contains(t, err.Error(), "file://shared/{name}")
+}
+
+func TestValidateExternalCapabilityNameCollisionsRejectsResourceTemplateShadow(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		ResourceTemplates: []ResourceTemplateRegistration{
+			{
+				ServerName:       "candidate",
+				ResourceTemplate: mcp.ResourceTemplate{URITemplate: "file://shared/{name}"},
+			},
+		},
+	}, capabilityNameIndexes{
+		ResourceTemplates: map[string]string{"file://shared/{name}": "trusted"},
+	}, false)
+
+	require.ErrorIs(t, err, errCapabilityNameCollision)
+	assert.Contains(t, err.Error(), `server "candidate" would shadow server "trusted"`)
+	assert.Contains(t, err.Error(), "file://shared/{name}")
+}
+
 func TestPolicyFilteredDynamicToolsDoNotTriggerCollisionValidation(t *testing.T) {
 	mock := newMockPolicyClient()
 	mock.deny("candidate", "mcp-exec", policy.ActionLoad, "blocked")


### PR DESCRIPTION
## Summary
- reject duplicated prompt names, resource URIs, and resource template URI templates before SDK registration can replace entries
- apply the checks during startup and dynamic server reloads, with a final under-lock revalidation immediately before dynamic capability registration
- reserve the dynamic gateway prompt name `mcp-discover` when dynamic tools are enabled

## Behavior note
Prompt policy filtering now also runs on the dynamic-reload path before prompt collision validation. Previously that path filtered tools only, so denied prompts could still remain in dynamic available capabilities.

## Root cause
PR #513 protected exposed tool names, but the MCP SDK also replaces prompts, resources, and resource templates when the same prompt name, resource URI, or resource template URI template is registered. The gateway did not validate those identifiers, so later capabilities could shadow earlier registrations.

## Validation
- `go test ./pkg/gateway`
- `go test ./pkg/gateway -run 'TestValidateExternalCapabilityNameCollisions|TestUpdateServerCapabilitiesRevalidatesCapabilityCollisionsUnderLock'`
- `go test ./...` fails in existing integration areas in this local environment: `TestIntegrationWithElicitation` and `TestIntegrationShortLivedContainerCloses` hit MCP initialize EOFs, and `TestIntegrationCallToolClickhouse` reports Docker `unknown flag: --gateway-arg`.
