### PR TITLE
refactor(secret): thread secrets-engine client.ID through credstore

### DIFF
--- a/cmd/docker-mcp/commands/secret.go
+++ b/cmd/docker-mcp/commands/secret.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/formatting"
@@ -42,18 +42,27 @@ func rmSecretCommand() *cobra.Command {
 				return err
 			}
 
-			ids := slices.Clone(args)
+			var errs []error
+			var ids []seclient.ID
 			if all {
-				var err error
-				ids, err = secret.List(cmd.Context())
+				listed, err := secret.List(cmd.Context())
 				if err != nil {
 					return err
 				}
+				ids = listed
+			} else {
+				for _, s := range args {
+					id, err := seclient.ParseID(s)
+					if err != nil {
+						errs = append(errs, fmt.Errorf("invalid secret name %q: %w", s, err))
+						continue
+					}
+					ids = append(ids, id)
+				}
 			}
 
-			var errs []error
-			for _, s := range ids {
-				errs = append(errs, secret.DeleteDefaultSecret(cmd.Context(), s))
+			for _, id := range ids {
+				errs = append(errs, secret.DeleteDefaultSecret(cmd.Context(), id))
 			}
 			return errors.Join(errs...)
 		},

--- a/cmd/docker-mcp/commands/secret.go
+++ b/cmd/docker-mcp/commands/secret.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	seclient "github.com/docker/secrets-engine/client"
+	"github.com/docker/secrets-engine/client/realms"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/formatting"
@@ -43,25 +44,23 @@ func rmSecretCommand() *cobra.Command {
 			}
 
 			var errs []error
-			var ids []seclient.ID
 			if all {
 				listed, err := secret.List(cmd.Context())
 				if err != nil {
 					return err
 				}
-				ids = listed
-			} else {
-				for _, s := range args {
-					id, err := seclient.ParseID(s)
-					if err != nil {
-						errs = append(errs, fmt.Errorf("invalid secret name %q: %w", s, err))
-						continue
-					}
-					ids = append(ids, id)
+				for _, id := range filterAllDockerMCP(listed) {
+					errs = append(errs, secret.DeleteByID(cmd.Context(), id))
 				}
+				return errors.Join(errs...)
 			}
 
-			for _, id := range ids {
+			for _, s := range args {
+				id, err := seclient.ParseID(s)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("invalid secret name %q: %w", s, err))
+					continue
+				}
 				errs = append(errs, secret.DeleteDefaultSecret(cmd.Context(), id))
 			}
 			return errors.Join(errs...)
@@ -70,6 +69,17 @@ func rmSecretCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVar(&all, "all", false, "Remove all secrets")
 	return cmd
+}
+
+// filterAllDockerMCP returns only the IDs within the default MCP realm (docker/mcp/**)
+func filterAllDockerMCP(ids []seclient.ID) []seclient.ID {
+	var out []seclient.ID
+	for _, id := range ids {
+		if id.Match(realms.DockerMCPDefault) {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func validateRmArgs(args []string, all bool) error {

--- a/cmd/docker-mcp/commands/secret_test.go
+++ b/cmd/docker-mcp/commands/secret_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"testing"
+
+	seclient "github.com/docker/secrets-engine/client"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFilterAllDockerMCP verifies that `rm --all` only targets docker/mcp/** IDs
+// (including oauth/oauth-dcr) and excludes unrelated docker pass keys such as
+// docker/auth/**, docker/sandbox/** or arbitrary app keys.
+func TestFilterAllDockerMCP(t *testing.T) {
+	ids := []seclient.ID{
+		seclient.MustParseID("docker/mcp/foo"),
+		seclient.MustParseID("docker/mcp/oauth/github"),
+		seclient.MustParseID("docker/mcp/oauth-dcr/github"),
+		seclient.MustParseID("docker/auth/hub/user"),
+		seclient.MustParseID("docker/sandbox/thing"),
+		seclient.MustParseID("myapp/key"),
+	}
+
+	var got []string
+	for _, id := range filterAllDockerMCP(ids) {
+		got = append(got, id.String())
+	}
+
+	assert.Equal(t, []string{
+		"docker/mcp/foo",
+		"docker/mcp/oauth/github",
+		"docker/mcp/oauth-dcr/github",
+	}, got)
+}

--- a/cmd/docker-mcp/oauth/cleanup.go
+++ b/cmd/docker-mcp/oauth/cleanup.go
@@ -3,6 +3,8 @@ package oauth
 import (
 	"context"
 
+	seclient "github.com/docker/secrets-engine/client"
+
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
@@ -38,16 +40,29 @@ func cleanStaleDockerPassEntries(ctx context.Context, app string) {
 	if err != nil {
 		return
 	}
-	oauthKey := secret.GetOAuthKey(app)
-	dcrKey := secret.GetDCRKey(app)
+	appID, err := seclient.ParseID(app)
+	if err != nil {
+		log.Logf("Warning: skipping stale docker pass cleanup for invalid app name %q: %v", app, err)
+		return
+	}
+	oauthKey, err := secret.GetOAuthKey(appID)
+	if err != nil {
+		log.Logf("Warning: failed to build OAuth key for %s: %v", app, err)
+		return
+	}
+	dcrKey, err := secret.GetDCRKey(appID)
+	if err != nil {
+		log.Logf("Warning: failed to build DCR key for %s: %v", app, err)
+		return
+	}
 	for _, k := range keys {
 		if k == oauthKey {
-			if err := secret.DeleteOAuthToken(ctx, app); err != nil {
+			if err := secret.DeleteOAuthToken(ctx, appID); err != nil {
 				log.Logf("Warning: failed to clean stale docker pass OAuth token for %s: %v", app, err)
 			}
 		}
 		if k == dcrKey {
-			if err := secret.DeleteDCRClient(ctx, app); err != nil {
+			if err := secret.DeleteDCRClient(ctx, appID); err != nil {
 				log.Logf("Warning: failed to clean stale docker pass DCR client for %s: %v", app, err)
 			}
 		}

--- a/cmd/docker-mcp/oauth/ls.go
+++ b/cmd/docker-mcp/oauth/ls.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	seclient "github.com/docker/secrets-engine/client"
+
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/formatting"
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
@@ -27,7 +29,11 @@ func Ls(ctx context.Context, outputJSON bool) error {
 		credHelper := pkgoauth.NewOAuthCredentialHelperWithMode(pkgoauth.ModeCommunity)
 		for i, app := range apps {
 			if !app.Authorized {
-				if exists, _ := credHelper.TokenExists(ctx, app.App); exists {
+				appID, err := seclient.ParseID(app.App)
+				if err != nil {
+					continue
+				}
+				if exists, _ := credHelper.TokenExists(ctx, appID); exists {
 					apps[i].Authorized = true
 				}
 			}

--- a/cmd/docker-mcp/oauth/revoke.go
+++ b/cmd/docker-mcp/oauth/revoke.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	seclient "github.com/docker/secrets-engine/client"
+
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/desktop"
@@ -102,15 +104,20 @@ func revokeCEMode(ctx context.Context, app string) error {
 // any stale Desktop Secrets Engine entries left from prior Desktop OAuth
 // authorizations.
 func revokeCommunityMode(ctx context.Context, app string) error {
+	appID, err := seclient.ParseID(app)
+	if err != nil {
+		return fmt.Errorf("invalid server name %q: %w", app, err)
+	}
+
 	// Delete OAuth token from docker pass
-	if err := deleteOAuthTokenFunc(ctx, app); err != nil {
+	if err := deleteOAuthTokenFunc(ctx, appID); err != nil {
 		// Token might not exist, continue to DCR deletion
 		fmt.Printf("Note: %v\n", err)
 	}
 
 	// Delete DCR client from docker pass (soft failure -- entry may not exist
 	// if authorize was never completed or was already revoked)
-	if err := deleteDCRClientFunc(ctx, app); err != nil {
+	if err := deleteDCRClientFunc(ctx, appID); err != nil {
 		fmt.Printf("Note: %v\n", err)
 	}
 

--- a/cmd/docker-mcp/oauth/revoke_test.go
+++ b/cmd/docker-mcp/oauth/revoke_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -140,8 +141,8 @@ func TestRevokeCommunityMode_CleansDesktopEntries(t *testing.T) {
 	})
 
 	// Mock the docker pass operations so the real handler doesn't shell out.
-	deleteOAuthTokenFunc = func(_ context.Context, _ string) error { return nil }
-	deleteDCRClientFunc = func(_ context.Context, _ string) error { return nil }
+	deleteOAuthTokenFunc = func(_ context.Context, _ seclient.ID) error { return nil }
+	deleteDCRClientFunc = func(_ context.Context, _ seclient.ID) error { return nil }
 
 	var desktopCleanupCalled string
 	cleanStaleDesktopEntriesFunc = func(_ context.Context, app string) {

--- a/cmd/docker-mcp/secret-management/secret/credstore.go
+++ b/cmd/docker-mcp/secret-management/secret/credstore.go
@@ -7,15 +7,10 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"path"
 	"strings"
-)
 
-const (
-	// Namespace prefixes for different secret types
-	NamespaceDefault  = "docker/mcp/"
-	NamespaceOAuth    = "docker/mcp/oauth/"
-	NamespaceOAuthDCR = "docker/mcp/oauth-dcr/"
+	"github.com/docker/secrets-engine/client"
+	"github.com/docker/secrets-engine/client/realms"
 )
 
 type CredStoreProvider struct{}
@@ -24,69 +19,68 @@ func cmd(ctx context.Context, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "docker", append([]string{"pass"}, args...)...)
 }
 
-// ValidateSecretName returns an error if the name contains glob metacharacters
-// or path traversal sequences that could be injected into the pattern sent to
-// the Desktop secrets resolver (which treats the pattern field as a glob).
-func ValidateSecretName(name string) error {
-	if strings.ContainsAny(name, "*?[]{") {
-		return fmt.Errorf("secret name %q contains illegal glob metacharacter", name)
-	}
-	return nil
+// realmPrefix returns the fixed prefix of a realm pattern by dropping its
+// trailing `**` wildcard (e.g. "docker/mcp/oauth/**" => "docker/mcp/oauth/").
+func realmPrefix(realm client.Pattern) string {
+	return strings.TrimSuffix(realm.String(), "**")
 }
 
-// GetDefaultSecretKey constructs the full namespaced ID for an MCP secret
-// using the default namespace (docker/mcp/).
-//
-// Example:
-//
-//	secretName = "postgres_password"
-//	return "docker/mcp/postgres_password"
-//
-// This can later be queried by the Secrets Engine using a pattern or direct ID match.
-func GetDefaultSecretKey(secretName string) string {
-	return path.Join(NamespaceDefault, secretName)
+// GetDefaultSecretKey returns the full ID for an MCP secret in the default realm
+// (docker/mcp/**), e.g. "postgres_password" => "docker/mcp/postgres_password".
+func GetDefaultSecretKey(name client.ID) (client.ID, error) {
+	return realms.DockerMCPDefault.ExpandID(name)
 }
 
-// GetOAuthKey constructs the full namespaced ID for an OAuth token
-func GetOAuthKey(provider string) string {
-	return path.Join(NamespaceOAuth, provider)
+// GetOAuthKey returns the full ID for an OAuth token (docker/mcp/oauth/**).
+func GetOAuthKey(provider client.ID) (client.ID, error) {
+	return realms.DockerMCPOAuth.ExpandID(provider)
 }
 
-// GetDCRKey constructs the full namespaced ID for a DCR client config
-func GetDCRKey(serverName string) string {
-	return path.Join(NamespaceOAuthDCR, serverName)
+// GetDCRKey returns the full ID for a DCR client config (docker/mcp/oauth-dcr/**).
+func GetDCRKey(serverName client.ID) (client.ID, error) {
+	return realms.DockerMCPOAuthDCR.ExpandID(serverName)
 }
 
-// StripNamespace removes the namespace prefix from a secret ID to get the simple name.
-// OAuth and DCR namespaces must be stripped first (more specific), then default.
+// StripNamespace removes the realm prefix from a secret ID to get the simple name.
+// OAuth and DCR realms must be stripped first (more specific), then default.
 func StripNamespace(secretID string) string {
-	name := strings.TrimPrefix(secretID, NamespaceOAuth)
-	name = strings.TrimPrefix(name, NamespaceOAuthDCR)
-	name = strings.TrimPrefix(name, NamespaceDefault)
+	name := strings.TrimPrefix(secretID, realmPrefix(realms.DockerMCPOAuth))
+	name = strings.TrimPrefix(name, realmPrefix(realms.DockerMCPOAuthDCR))
+	name = strings.TrimPrefix(name, realmPrefix(realms.DockerMCPDefault))
 	return name
 }
 
-func List(ctx context.Context) ([]string, error) {
+// List returns the IDs of all secrets stored in the local OS Keychain.
+// Stored keys that are not valid secret IDs are skipped.
+func List(ctx context.Context) ([]client.ID, error) {
 	c := cmd(ctx, "ls")
 	out, err := c.Output()
 	if err != nil {
 		return nil, fmt.Errorf("could not list secrets: %s\n%s", bytes.TrimSpace(out), err)
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(out))
-	var secrets []string
+	var secrets []client.ID
 	for scanner.Scan() {
-		secret := scanner.Text()
-		if len(secret) == 0 {
+		line := scanner.Text()
+		if len(line) == 0 {
 			continue
 		}
-		secrets = append(secrets, secret)
+		id, err := client.ParseID(line)
+		if err != nil {
+			continue
+		}
+		secrets = append(secrets, id)
 	}
 	return secrets, nil
 }
 
-// setDefaultSecret stores a secret in the default namespace (docker/mcp/).
-func setDefaultSecret(ctx context.Context, id string, value string) error {
-	c := cmd(ctx, "set", GetDefaultSecretKey(id))
+// setDefaultSecret stores a secret in the default realm (docker/mcp/**).
+func setDefaultSecret(ctx context.Context, id client.ID, value string) error {
+	key, err := GetDefaultSecretKey(id)
+	if err != nil {
+		return err
+	}
+	c := cmd(ctx, "set", key.String())
 	c.Stdin = strings.NewReader(value)
 	out, err := c.CombinedOutput()
 	if err != nil {
@@ -95,30 +89,38 @@ func setDefaultSecret(ctx context.Context, id string, value string) error {
 	return nil
 }
 
-// DeleteDefaultSecret removes a secret from the default namespace (docker/mcp/).
-func DeleteDefaultSecret(ctx context.Context, id string) error {
-	out, err := cmd(ctx, "rm", GetDefaultSecretKey(id)).CombinedOutput()
+// DeleteDefaultSecret removes a secret from the default realm (docker/mcp/**).
+func DeleteDefaultSecret(ctx context.Context, id client.ID) error {
+	key, err := GetDefaultSecretKey(id)
 	if err != nil {
-		return fmt.Errorf("could not delete secret: %s\n%s\n%s", id, bytes.TrimSpace(out), err)
+		return err
+	}
+	out, err := cmd(ctx, "rm", key.String()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not delete secret: %s\n%s\n%s", id.String(), bytes.TrimSpace(out), err)
 	}
 	return nil
 }
 
-// SetOAuthToken stores an OAuth token via docker pass at docker/mcp/oauth/{serverName}.
+// SetOAuthToken stores an OAuth token via docker pass at docker/mcp/oauth/{serverID}.
 // The value should be base64-encoded JSON of the full oauth2.Token.
-func SetOAuthToken(ctx context.Context, serverName string, value string) error {
-	key := GetOAuthKey(serverName)
+func SetOAuthToken(ctx context.Context, serverID client.ID, value string) error {
+	keyID, err := GetOAuthKey(serverID)
+	if err != nil {
+		return err
+	}
+	key := keyID.String()
 
 	keys, err := List(ctx)
 	if err != nil {
-		return fmt.Errorf("could not check existing OAuth token for %s: %w", serverName, err)
+		return fmt.Errorf("could not check existing OAuth token for %s: %w", serverID.String(), err)
 	}
 
 	// docker pass set is insert-only, so if the key already exists we need to remove it first.
 	for _, k := range keys {
-		if k == key {
+		if k == keyID {
 			if out, err := cmd(ctx, "rm", key).CombinedOutput(); err != nil {
-				return fmt.Errorf("could not remove existing OAuth token for %s: %s\n%s", serverName, bytes.TrimSpace(out), err)
+				return fmt.Errorf("could not remove existing OAuth token for %s: %s\n%s", serverID.String(), bytes.TrimSpace(out), err)
 			}
 			break
 		}
@@ -128,35 +130,43 @@ func SetOAuthToken(ctx context.Context, serverName string, value string) error {
 	c.Stdin = strings.NewReader(value)
 	out, err := c.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("could not store OAuth token for %s: %s\n%s", serverName, bytes.TrimSpace(out), err)
+		return fmt.Errorf("could not store OAuth token for %s: %s\n%s", serverID.String(), bytes.TrimSpace(out), err)
 	}
 	return nil
 }
 
 // DeleteOAuthToken removes an OAuth token from docker pass.
-func DeleteOAuthToken(ctx context.Context, serverName string) error {
-	out, err := cmd(ctx, "rm", GetOAuthKey(serverName)).CombinedOutput()
+func DeleteOAuthToken(ctx context.Context, serverID client.ID) error {
+	keyID, err := GetOAuthKey(serverID)
 	if err != nil {
-		return fmt.Errorf("could not delete OAuth token for %s: %s\n%s", serverName, bytes.TrimSpace(out), err)
+		return err
+	}
+	out, err := cmd(ctx, "rm", keyID.String()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not delete OAuth token for %s: %s\n%s", serverID.String(), bytes.TrimSpace(out), err)
 	}
 	return nil
 }
 
-// SetDCRClient stores a DCR client config via docker pass at docker/mcp/oauth-dcr/{serverName}.
+// SetDCRClient stores a DCR client config via docker pass at docker/mcp/oauth-dcr/{serverID}.
 // The value should be base64-encoded JSON of the DCR client.
-func SetDCRClient(ctx context.Context, serverName string, value string) error {
-	key := GetDCRKey(serverName)
+func SetDCRClient(ctx context.Context, serverID client.ID, value string) error {
+	keyID, err := GetDCRKey(serverID)
+	if err != nil {
+		return err
+	}
+	key := keyID.String()
 
 	keys, err := List(ctx)
 	if err != nil {
-		return fmt.Errorf("could not check existing DCR client for %s: %w", serverName, err)
+		return fmt.Errorf("could not check existing DCR client for %s: %w", serverID.String(), err)
 	}
 
 	// docker pass set is insert-only, so if the key already exists we need to remove it first.
 	for _, k := range keys {
-		if k == key {
+		if k == keyID {
 			if out, err := cmd(ctx, "rm", key).CombinedOutput(); err != nil {
-				return fmt.Errorf("could not remove existing DCR client for %s: %s\n%s", serverName, bytes.TrimSpace(out), err)
+				return fmt.Errorf("could not remove existing DCR client for %s: %s\n%s", serverID.String(), bytes.TrimSpace(out), err)
 			}
 			break
 		}
@@ -166,16 +176,20 @@ func SetDCRClient(ctx context.Context, serverName string, value string) error {
 	c.Stdin = strings.NewReader(value)
 	out, err := c.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("could not store DCR client for %s: %s\n%s", serverName, bytes.TrimSpace(out), err)
+		return fmt.Errorf("could not store DCR client for %s: %s\n%s", serverID.String(), bytes.TrimSpace(out), err)
 	}
 	return nil
 }
 
 // DeleteDCRClient removes a DCR client config from docker pass.
-func DeleteDCRClient(ctx context.Context, serverName string) error {
-	out, err := cmd(ctx, "rm", GetDCRKey(serverName)).CombinedOutput()
+func DeleteDCRClient(ctx context.Context, serverID client.ID) error {
+	keyID, err := GetDCRKey(serverID)
 	if err != nil {
-		return fmt.Errorf("could not delete DCR client for %s: %s\n%s", serverName, bytes.TrimSpace(out), err)
+		return err
+	}
+	out, err := cmd(ctx, "rm", keyID.String()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not delete DCR client for %s: %s\n%s", serverID.String(), bytes.TrimSpace(out), err)
 	}
 	return nil
 }

--- a/cmd/docker-mcp/secret-management/secret/credstore.go
+++ b/cmd/docker-mcp/secret-management/secret/credstore.go
@@ -89,6 +89,15 @@ func setDefaultSecret(ctx context.Context, id client.ID, value string) error {
 	return nil
 }
 
+// DeleteByID removes a secret from docker pass by its full ID, without any realm expansion.
+func DeleteByID(ctx context.Context, id client.ID) error {
+	out, err := cmd(ctx, "rm", id.String()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not delete secret: %s\n%s\n%s", id.String(), bytes.TrimSpace(out), err)
+	}
+	return nil
+}
+
 // DeleteDefaultSecret removes a secret from the default realm (docker/mcp/**).
 func DeleteDefaultSecret(ctx context.Context, id client.ID) error {
 	key, err := GetDefaultSecretKey(id)

--- a/cmd/docker-mcp/secret-management/secret/secret_test.go
+++ b/cmd/docker-mcp/secret-management/secret/secret_test.go
@@ -3,25 +3,15 @@ package secret
 import (
 	"testing"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetDefaultSecretKey(t *testing.T) {
-	result := GetDefaultSecretKey("mykey")
-	assert.Equal(t, "docker/mcp/mykey", result)
-}
-
-func TestValidateSecretName(t *testing.T) {
-	valid := []string{"mykey", "postgres_password", "GITHUB_TOKEN", "some-key", "key.with.dots"}
-	for _, name := range valid {
-		require.NoError(t, ValidateSecretName(name), "expected %q to be valid", name)
-	}
-
-	invalid := []string{"**", "*", "docker/mcp/**", "key*", "key?", "key[0]", "key{a}"}
-	for _, name := range invalid {
-		assert.Error(t, ValidateSecretName(name), "expected %q to be invalid", name)
-	}
+	result, err := GetDefaultSecretKey(seclient.MustParseID("mykey"))
+	require.NoError(t, err)
+	assert.Equal(t, "docker/mcp/mykey", result.String())
 }
 
 func TestParseArg(t *testing.T) {

--- a/cmd/docker-mcp/secret-management/secret/secretsengine.go
+++ b/cmd/docker-mcp/secret-management/secret/secretsengine.go
@@ -35,10 +35,10 @@ func GetSecrets(ctx context.Context) ([]client.Envelope, error) {
 	return envelopes, nil
 }
 
-// GetSecret retrieves a single secret by its full key (e.g., "docker/mcp/oauth/github").
+// GetSecret retrieves a single secret by its full ID (e.g., "docker/mcp/oauth/github").
 // Returns ErrSecretNotFound if the secret does not exist.
-func GetSecret(ctx context.Context, key string) (*client.Envelope, error) {
-	pattern, err := client.ParsePattern(key)
+func GetSecret(ctx context.Context, id client.ID) (*client.Envelope, error) {
+	pattern, err := client.ParsePattern(id.String())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/docker-mcp/secret-management/secret/set.go
+++ b/cmd/docker-mcp/secret-management/secret/set.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/docker/secrets-engine/client"
+
 	"github.com/docker/mcp-gateway/pkg/tui"
 )
 
@@ -56,5 +58,9 @@ func isDirectValueProvider(provider string) bool {
 }
 
 func Set(ctx context.Context, s Secret, _ SetOpts) error {
-	return setDefaultSecret(ctx, s.key, s.val)
+	id, err := client.ParseID(s.key)
+	if err != nil {
+		return fmt.Errorf("invalid secret name %q: %w", s.key, err)
+	}
+	return setDefaultSecret(ctx, id, s.val)
 }

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -566,12 +567,14 @@ func (g *Gateway) getRemoteOAuthServerStatus(ctx context.Context, serverName str
 	// Check if user is already authorized by checking if token exists (only if provider exists)
 	if providerExists {
 		credHelper := oauth.NewOAuthCredentialHelperWithMode(mode)
-		exists, err := credHelper.TokenExists(ctx, serverName)
-		if err == nil && exists {
-			if shouldSendTools {
-				return true, fmt.Sprintf("You will need to authorize this server with: docker mcp oauth authorize %s.\n  After authorizing, reconnect your agent to the MCP gateway.", serverName)
+		if serverID, parseErr := seclient.ParseID(serverName); parseErr == nil {
+			exists, err := credHelper.TokenExists(ctx, serverID)
+			if err == nil && exists {
+				if shouldSendTools {
+					return true, fmt.Sprintf("You will need to authorize this server with: docker mcp oauth authorize %s.\n  After authorizing, reconnect your agent to the MCP gateway.", serverName)
+				}
+				return true, fmt.Sprintf("Successfully added server '%s'. Server is authorized.", serverName)
 			}
-			return true, fmt.Sprintf("Successfully added server '%s'. Server is authorized.", serverName)
 		}
 	}
 

--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel"
 
@@ -393,7 +394,10 @@ func (g *Gateway) Run(ctx context.Context) error {
 			} else if serverConfig.IsRemote() {
 				// Community/remote servers: start provider if they have a stored OAuth token
 				// from dynamic discovery (DCR without explicit OAuth metadata)
-				if exists, err := credHelper.TokenExists(ctx, serverName); err != nil {
+				serverID, parseErr := seclient.ParseID(serverName)
+				if parseErr != nil {
+					log.Logf("Warning: Failed to check OAuth token for %s: %v", serverName, parseErr)
+				} else if exists, err := credHelper.TokenExists(ctx, serverID); err != nil {
 					log.Logf("Warning: Failed to check OAuth token for %s: %v", serverName, err)
 				} else if exists {
 					log.Logf("- Starting OAuth provider for remote server: %s (mode=%s)", serverName, mode)

--- a/pkg/gateway/secrets_uri.go
+++ b/pkg/gateway/secrets_uri.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 
+	seclient "github.com/docker/secrets-engine/client"
+
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/log"
@@ -48,7 +50,8 @@ func buildFallbackURIs(configs []ServerSecretConfig) map[string]string {
 		secretToOAuthID := oauthMapping(cfg)
 
 		for _, s := range cfg.Secrets {
-			if err := secret.ValidateSecretName(s.Name); err != nil {
+			id, err := seclient.ParseID(s.Name)
+			if err != nil {
 				log.Logf("Warning: skipping secret with invalid name %q: %v", s.Name, err)
 				continue
 			}
@@ -56,7 +59,12 @@ func buildFallbackURIs(configs []ServerSecretConfig) map[string]string {
 			if oauthSecretID, ok := secretToOAuthID[s.Name]; ok {
 				secretNameToURI[secretName] = "se://" + oauthSecretID
 			} else {
-				secretNameToURI[secretName] = "se://" + secret.GetDefaultSecretKey(s.Name)
+				key, err := secret.GetDefaultSecretKey(id)
+				if err != nil {
+					log.Logf("Warning: skipping secret with invalid name %q: %v", s.Name, err)
+					continue
+				}
+				secretNameToURI[secretName] = "se://" + key.String()
 			}
 		}
 	}
@@ -72,7 +80,8 @@ func buildVerifiedURIs(configs []ServerSecretConfig, availableSecrets map[string
 		secretToOAuthID := oauthMapping(cfg)
 
 		for _, s := range cfg.Secrets {
-			if err := secret.ValidateSecretName(s.Name); err != nil {
+			id, err := seclient.ParseID(s.Name)
+			if err != nil {
 				log.Logf("Warning: skipping secret with invalid name %q: %v", s.Name, err)
 				continue
 			}
@@ -86,7 +95,12 @@ func buildVerifiedURIs(configs []ServerSecretConfig, availableSecrets map[string
 				}
 			}
 			// Fall back to direct secret (API keys, tokens, etc.)
-			secretID := secret.GetDefaultSecretKey(s.Name)
+			key, err := secret.GetDefaultSecretKey(id)
+			if err != nil {
+				log.Logf("Warning: skipping secret with invalid name %q: %v", s.Name, err)
+				continue
+			}
+			secretID := key.String()
 			if availableSecrets[secretID] != "" {
 				secretNameToURI[secretName] = "se://" + secretID
 			}
@@ -100,7 +114,17 @@ func oauthMapping(cfg ServerSecretConfig) map[string]string {
 	m := make(map[string]string)
 	if cfg.OAuth != nil {
 		for _, p := range cfg.OAuth.Providers {
-			m[p.Secret] = secret.GetOAuthKey(p.Provider)
+			providerID, err := seclient.ParseID(p.Provider)
+			if err != nil {
+				log.Logf("Warning: skipping OAuth provider with invalid name %q: %v", p.Provider, err)
+				continue
+			}
+			key, err := secret.GetOAuthKey(providerID)
+			if err != nil {
+				log.Logf("Warning: skipping OAuth provider with invalid name %q: %v", p.Provider, err)
+				continue
+			}
+			m[p.Secret] = key.String()
 		}
 	}
 	return m

--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
@@ -70,7 +71,7 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 		} else {
 			// Fall back to secrets engine (Docker Desktop direct API)
 			if verbose {
-				log.Logf("    - Fetching secret: %s", secret.GetDefaultSecretKey(s.Name))
+				log.Logf("    - Fetching secret: %s", s.Name)
 			}
 			env[s.Env] = getSecretValue(ctx, s.Name)
 			if verbose {
@@ -180,12 +181,17 @@ func (c *remoteMCPClient) AddRoots(roots []*mcp.Root) {
 }
 
 func getSecretValue(ctx context.Context, secretName string) string {
-	if err := secret.ValidateSecretName(secretName); err != nil {
+	id, err := seclient.ParseID(secretName)
+	if err != nil {
 		log.Logf("Warning: skipping secret with invalid name %q: %v", secretName, err)
 		return ""
 	}
-	fullID := secret.GetDefaultSecretKey(secretName)
-	env, err := secret.GetSecret(ctx, fullID)
+	key, err := secret.GetDefaultSecretKey(id)
+	if err != nil {
+		log.Logf("Warning: skipping secret with invalid name %q: %v", secretName, err)
+		return ""
+	}
+	env, err := secret.GetSecret(ctx, key)
 	if err != nil {
 		return ""
 	}

--- a/pkg/oauth/credhelper.go
+++ b/pkg/oauth/credhelper.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
+	seclient "github.com/docker/secrets-engine/client"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	"github.com/docker/mcp-gateway/pkg/log"
@@ -134,7 +135,14 @@ func (h *CredentialHelper) getOAuthTokenCE(serverName string) (string, error) {
 // getOAuthTokenDesktop retrieves OAuth token in Desktop mode using Secrets Engine.
 // The Secrets Engine returns the raw access token directly (Go auto-decodes base64 into []byte).
 func (h *CredentialHelper) getOAuthTokenDesktop(ctx context.Context, serverName string) (string, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+	serverID, err := seclient.ParseID(serverName)
+	if err != nil {
+		return "", fmt.Errorf("invalid server name %q: %w", serverName, err)
+	}
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return "", err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return "", fmt.Errorf("OAuth token not found for %s. Run 'docker mcp oauth authorize %s' to authenticate", serverName, serverName)
@@ -152,19 +160,20 @@ func (h *CredentialHelper) getOAuthTokenDesktop(ctx context.Context, serverName 
 
 // TokenExists checks if an OAuth token exists for the specified server.
 // Routes to the appropriate storage backend based on the resolved mode.
-func (h *CredentialHelper) TokenExists(ctx context.Context, serverName string) (bool, error) {
+func (h *CredentialHelper) TokenExists(ctx context.Context, serverID seclient.ID) (bool, error) {
 	switch h.resolveMode() {
 	case ModeCE:
-		return h.tokenExistsCE(serverName)
+		return h.tokenExistsCE(serverID)
 	case ModeCommunity:
-		return h.tokenExistsDockerPass(ctx, serverName)
+		return h.tokenExistsDockerPass(ctx, serverID)
 	default:
-		return h.tokenExistsDesktop(ctx, serverName)
+		return h.tokenExistsDesktop(ctx, serverID)
 	}
 }
 
 // tokenExistsCE checks if a token exists in the credential helper (CE mode).
-func (h *CredentialHelper) tokenExistsCE(serverName string) (bool, error) {
+func (h *CredentialHelper) tokenExistsCE(serverID seclient.ID) (bool, error) {
+	serverName := serverID.String()
 	dcrMgr := dcr.NewManager(h.credentialHelper, "")
 	client, err := dcrMgr.GetDCRClient(serverName)
 	if err != nil {
@@ -179,8 +188,11 @@ func (h *CredentialHelper) tokenExistsCE(serverName string) (bool, error) {
 }
 
 // tokenExistsDesktop checks if a token exists in the Secrets Engine (Desktop mode).
-func (h *CredentialHelper) tokenExistsDesktop(ctx context.Context, serverName string) (bool, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+func (h *CredentialHelper) tokenExistsDesktop(ctx context.Context, serverID seclient.ID) (bool, error) {
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return false, err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return false, nil
@@ -196,22 +208,26 @@ func (h *CredentialHelper) tokenExistsDesktop(ctx context.Context, serverName st
 //   - CE: reads token JSON from credential helper, parses expiry
 //   - Desktop: queries Secrets Engine, reads ExpiryAt from response metadata
 //   - Community: reads token JSON from docker pass via Secrets Engine, parses expiry
-func (h *CredentialHelper) GetTokenStatus(ctx context.Context, serverName string) (TokenStatus, error) {
+func (h *CredentialHelper) GetTokenStatus(ctx context.Context, serverID seclient.ID) (TokenStatus, error) {
 	switch h.resolveMode() {
 	case ModeCE:
-		return h.getTokenStatusCE(serverName)
+		return h.getTokenStatusCE(serverID)
 	case ModeCommunity:
-		return h.getTokenStatusDockerPass(ctx, serverName)
+		return h.getTokenStatusDockerPass(ctx, serverID)
 	default:
-		return h.getTokenStatusDesktop(ctx, serverName)
+		return h.getTokenStatusDesktop(ctx, serverID)
 	}
 }
 
 // getTokenStatusDesktop retrieves token status in Desktop mode using Secrets Engine metadata.
 // The Secrets Engine response includes ExpiryAt and ExpiresIn in the metadata map,
 // added by Docker Desktop's OAuthCredential.Metadata() method.
-func (h *CredentialHelper) getTokenStatusDesktop(ctx context.Context, serverName string) (TokenStatus, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+func (h *CredentialHelper) getTokenStatusDesktop(ctx context.Context, serverID seclient.ID) (TokenStatus, error) {
+	serverName := serverID.String()
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return TokenStatus{Valid: false}, err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return TokenStatus{Valid: false}, fmt.Errorf("OAuth token not found for %s", serverName)
@@ -258,7 +274,8 @@ func (h *CredentialHelper) getTokenStatusDesktop(ctx context.Context, serverName
 
 // getTokenStatusCE retrieves token status in CE mode using the credential helper.
 // Reads the base64-encoded JSON token and parses the expiry field.
-func (h *CredentialHelper) getTokenStatusCE(serverName string) (TokenStatus, error) {
+func (h *CredentialHelper) getTokenStatusCE(serverID seclient.ID) (TokenStatus, error) {
+	serverName := serverID.String()
 	dcrMgr := dcr.NewManager(h.credentialHelper, "")
 	client, err := dcrMgr.GetDCRClient(serverName)
 	if err != nil {

--- a/pkg/oauth/dockerpass.go
+++ b/pkg/oauth/dockerpass.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"golang.org/x/oauth2"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
@@ -38,7 +39,14 @@ import (
 // server stored in docker pass. The Secrets Engine's docker-pass plugin
 // returns the raw stored value at docker/mcp/oauth/{server}.
 func (h *CredentialHelper) getOAuthTokenDockerPass(ctx context.Context, serverName string) (string, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+	serverID, err := seclient.ParseID(serverName)
+	if err != nil {
+		return "", fmt.Errorf("invalid server name %q: %w", serverName, err)
+	}
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return "", err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return "", fmt.Errorf("OAuth token not found for %s. Run 'docker mcp oauth authorize %s' to authenticate", serverName, serverName)
@@ -75,14 +83,17 @@ func (h *CredentialHelper) getOAuthTokenDockerPass(ctx context.Context, serverNa
 
 // tokenExistsDockerPass checks whether a token exists in docker pass for a
 // community server. Reads via the Secrets Engine.
-func (h *CredentialHelper) tokenExistsDockerPass(ctx context.Context, serverName string) (bool, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+func (h *CredentialHelper) tokenExistsDockerPass(ctx context.Context, serverID seclient.ID) (bool, error) {
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return false, err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("failed to query Secrets Engine for %s: %w", serverName, err)
+		return false, fmt.Errorf("failed to query Secrets Engine for %s: %w", serverID.String(), err)
 	}
 	return string(env.Value) != "", nil
 }
@@ -90,8 +101,12 @@ func (h *CredentialHelper) tokenExistsDockerPass(ctx context.Context, serverName
 // getTokenStatusDockerPass retrieves token validity and expiry from docker
 // pass for a community server. The stored value is base64-encoded JSON
 // containing the expiry field.
-func (h *CredentialHelper) getTokenStatusDockerPass(ctx context.Context, serverName string) (TokenStatus, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+func (h *CredentialHelper) getTokenStatusDockerPass(ctx context.Context, serverID seclient.ID) (TokenStatus, error) {
+	serverName := serverID.String()
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return TokenStatus{Valid: false}, err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return TokenStatus{Valid: false}, fmt.Errorf("OAuth token not found for %s", serverName)
@@ -158,7 +173,14 @@ func (h *CredentialHelper) getTokenStatusDockerPass(ctx context.Context, serverN
 // the Secrets Engine. Used by the refresh loop to get the current token
 // (including refresh_token) before refreshing.
 func GetTokenFromDockerPass(ctx context.Context, serverName string) (*oauth2.Token, error) {
-	oauthID := secret.GetOAuthKey(serverName)
+	serverID, err := seclient.ParseID(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid server name %q: %w", serverName, err)
+	}
+	oauthID, err := secret.GetOAuthKey(serverID)
+	if err != nil {
+		return nil, err
+	}
 	env, err := secret.GetSecret(ctx, oauthID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return nil, fmt.Errorf("OAuth token not found for %s", serverName)
@@ -189,6 +211,10 @@ func GetTokenFromDockerPass(ctx context.Context, serverName string) (*oauth2.Tok
 // JSON at docker/mcp/oauth/{serverName}. Used by the authorize flow and the
 // refresh loop for community servers in Desktop mode.
 func SaveTokenToDockerPass(ctx context.Context, serverName string, token *oauth2.Token) error {
+	serverID, err := seclient.ParseID(serverName)
+	if err != nil {
+		return fmt.Errorf("invalid server name %q: %w", serverName, err)
+	}
 	tokenJSON, err := json.Marshal(token)
 	if err != nil {
 		return fmt.Errorf("marshalling token for %s: %w", serverName, err)
@@ -196,7 +222,7 @@ func SaveTokenToDockerPass(ctx context.Context, serverName string, token *oauth2
 
 	encoded := base64.StdEncoding.EncodeToString(tokenJSON)
 
-	if err := secret.SetOAuthToken(ctx, serverName, encoded); err != nil {
+	if err := secret.SetOAuthToken(ctx, serverID, encoded); err != nil {
 		return fmt.Errorf("storing OAuth token for %s: %w", serverName, err)
 	}
 
@@ -208,7 +234,14 @@ func SaveTokenToDockerPass(ctx context.Context, serverName string, token *oauth2
 // Secrets Engine. The value is base64-encoded JSON of dcr.Client stored at
 // docker/mcp/oauth-dcr/{serverName}.
 func GetDCRClientFromDockerPass(ctx context.Context, serverName string) (dcr.Client, error) {
-	dcrID := secret.GetDCRKey(serverName)
+	serverID, err := seclient.ParseID(serverName)
+	if err != nil {
+		return dcr.Client{}, fmt.Errorf("invalid server name %q: %w", serverName, err)
+	}
+	dcrID, err := secret.GetDCRKey(serverID)
+	if err != nil {
+		return dcr.Client{}, err
+	}
 	env, err := secret.GetSecret(ctx, dcrID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
 		return dcr.Client{}, fmt.Errorf("DCR client not found for %s", serverName)
@@ -239,6 +272,10 @@ func GetDCRClientFromDockerPass(ctx context.Context, serverName string) (dcr.Cli
 // JSON at docker/mcp/oauth-dcr/{serverName}. Used by the authorize flow for
 // community servers in Desktop mode.
 func SaveDCRClientToDockerPass(ctx context.Context, serverName string, client dcr.Client) error {
+	serverID, err := seclient.ParseID(serverName)
+	if err != nil {
+		return fmt.Errorf("invalid server name %q: %w", serverName, err)
+	}
 	jsonData, err := json.Marshal(client)
 	if err != nil {
 		return fmt.Errorf("marshalling DCR client for %s: %w", serverName, err)
@@ -246,7 +283,7 @@ func SaveDCRClientToDockerPass(ctx context.Context, serverName string, client dc
 
 	encoded := base64.StdEncoding.EncodeToString(jsonData)
 
-	if err := secret.SetDCRClient(ctx, serverName, encoded); err != nil {
+	if err := secret.SetDCRClient(ctx, serverID, encoded); err != nil {
 		return fmt.Errorf("storing DCR client for %s: %w", serverName, err)
 	}
 

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"golang.org/x/oauth2"
 
 	"github.com/docker/mcp-gateway/pkg/desktop"
@@ -109,7 +110,12 @@ func (p *Provider) Run(ctx context.Context) {
 
 	for {
 		// Check current token status
-		status, err := p.credHelper.GetTokenStatus(ctx, p.name)
+		serverID, err := seclient.ParseID(p.name)
+		if err != nil {
+			log.Logf("! Invalid server name %q: %v", p.name, err)
+			return
+		}
+		status, err := p.credHelper.GetTokenStatus(ctx, serverID)
 		if err != nil {
 			log.Logf("! Unable to get token status for %s: %v", p.name, err)
 			log.Logf("! Run 'docker mcp oauth authorize %s' if not yet authorized", p.name)


### PR DESCRIPTION
Rework the secret credstore to use the docker/secrets-engine SDK types throughout instead of raw strings:

- Derive namespaced keys from the canonical realm patterns (realms.DockerMCP*) via Pattern.ExpandID, replacing the hand-rolled namespace prefix constants.
- GetDefaultSecretKey / GetOAuthKey / GetDCRKey now take and return client.ID and return an error (no panic, no expandRealm helper).
- All Set/Delete credstore funcs and List now traffic in client.ID; List skips entries that are not valid secret IDs.
- GetSecret accepts a client.ID rather than a string key.
- Remove ValidateSecretName; callers validate names via client.ParseID directly, pushing parsing to the outer boundary.
- Propagate client.ID end-to-end through the OAuth credential helper (TokenExists, GetTokenStatus and their per-mode handlers) and all callers (gateway run/mcpadd, oauth ls/revoke/cleanup, remote mcp).

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**