### PR TITLE
chore(deps): bump secrets-engine/x to v0.1.0-do.not.use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.3
 	github.com/docker/mcp-gateway-oauth-helpers v0.0.3
 	github.com/docker/secrets-engine/client v0.0.29
-	github.com/docker/secrets-engine/x v0.0.32-do.not.use
+	github.com/docker/secrets-engine/x v0.1.0-do.not.use
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-playground/validator/v10 v10.28.0

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/docker/mcp-gateway-oauth-helpers v0.0.3 h1:TgXk/DFaXFYpDhduN3l7LCjdjo
 github.com/docker/mcp-gateway-oauth-helpers v0.0.3/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
 github.com/docker/secrets-engine/client v0.0.29 h1:p0AiCt0z6hHy8HkIytO6xOvEbjxSIxAkSsVnbDB3buU=
 github.com/docker/secrets-engine/client v0.0.29/go.mod h1:XN+LocEipZjLx4rmH6iJ3Yb3WsURMe4Xm0/bcExgwb8=
-github.com/docker/secrets-engine/x v0.0.32-do.not.use h1:Q+RjHA+w6Yoot2N2iNdq5U1eE/bahzkSSz2i6txae/o=
-github.com/docker/secrets-engine/x v0.0.32-do.not.use/go.mod h1:hBrA0SZBNoa/VR58bwKUg9N/HRDVjO5SYcd5IjdB8zk=
+github.com/docker/secrets-engine/x v0.1.0-do.not.use h1:QdU0U0THSiGT+aZx1spWe94x9mpZNnYVRBvZ98Tmric=
+github.com/docker/secrets-engine/x v0.1.0-do.not.use/go.mod h1:DLOw4aFtjHtsvGNR3C0oFFwX7ydODEEdBNcmhyltcDE=
 github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6 h1:6dE1TmjqkY6tehR4A67gDNhvDtuZ54ocu7ab4K9o540=
 github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/vendor/github.com/docker/secrets-engine/x/api/defaults_darwin.go
+++ b/vendor/github.com/docker/secrets-engine/x/api/defaults_darwin.go
@@ -1,0 +1,29 @@
+// Copyright 2025-2026 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DaemonSocketPath() string {
+	if dir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(dir, "docker-secrets-engine", "daemon.sock")
+	}
+	return filepath.Join(os.TempDir(), "docker-secrets-engine", "daemon.sock")
+}

--- a/vendor/github.com/docker/secrets-engine/x/api/defaults_linux.go
+++ b/vendor/github.com/docker/secrets-engine/x/api/defaults_linux.go
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build linux
 
 package api
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
 )
 
+// DaemonSocketPath returns the address of the daemon's listening socket.
+//
+// On Linux it is an abstract Unix domain socket: the address has a leading
+// "@", which Go's net package maps to a NUL byte, placing the socket in the
+// abstract namespace instead of on the filesystem.
+//
+// The address is namespaced by the user's UID so daemons run by different
+// users on the same host do not collide (the abstract namespace is shared per
+// network namespace, not per user as a filesystem path would be).
 func DaemonSocketPath() string {
-	if dir, err := os.UserCacheDir(); err == nil {
-		return filepath.Join(dir, "docker-secrets-engine", "daemon.sock")
-	}
-	return filepath.Join(os.TempDir(), "docker-secrets-engine", "daemon.sock")
+	return fmt.Sprintf("@docker-secrets-engine/%d/daemon.sock", os.Getuid())
 }

--- a/vendor/github.com/docker/secrets-engine/x/api/plugins/v1/api.pb.go
+++ b/vendor/github.com/docker/secrets-engine/x/api/plugins/v1/api.pb.go
@@ -9,6 +9,7 @@ package pluginsv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -70,6 +71,430 @@ func (x RunStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+type RegisterPluginRequest struct {
+	state                  protoimpl.MessageState           `protogen:"opaque.v1"`
+	xxx_hidden_Name        *string                          `protobuf:"bytes,1,opt,name=name"`
+	xxx_hidden_Version     *string                          `protobuf:"bytes,2,opt,name=version"`
+	xxx_hidden_Metadata    isRegisterPluginRequest_Metadata `protobuf_oneof:"metadata"`
+	XXX_raceDetectHookData protoimpl.RaceDetectHookData
+	XXX_presence           [1]uint32
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *RegisterPluginRequest) Reset() {
+	*x = RegisterPluginRequest{}
+	mi := &file_plugins_v1_api_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RegisterPluginRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RegisterPluginRequest) ProtoMessage() {}
+
+func (x *RegisterPluginRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugins_v1_api_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RegisterPluginRequest) GetName() string {
+	if x != nil {
+		if x.xxx_hidden_Name != nil {
+			return *x.xxx_hidden_Name
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *RegisterPluginRequest) GetVersion() string {
+	if x != nil {
+		if x.xxx_hidden_Version != nil {
+			return *x.xxx_hidden_Version
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *RegisterPluginRequest) GetSecretsProvider() *SecretsProvider {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Metadata.(*registerPluginRequest_SecretsProvider); ok {
+			return x.SecretsProvider
+		}
+	}
+	return nil
+}
+
+func (x *RegisterPluginRequest) SetName(v string) {
+	x.xxx_hidden_Name = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 3)
+}
+
+func (x *RegisterPluginRequest) SetVersion(v string) {
+	x.xxx_hidden_Version = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *RegisterPluginRequest) SetSecretsProvider(v *SecretsProvider) {
+	if v == nil {
+		x.xxx_hidden_Metadata = nil
+		return
+	}
+	x.xxx_hidden_Metadata = &registerPluginRequest_SecretsProvider{v}
+}
+
+func (x *RegisterPluginRequest) HasName() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *RegisterPluginRequest) HasVersion() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *RegisterPluginRequest) HasMetadata() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Metadata != nil
+}
+
+func (x *RegisterPluginRequest) HasSecretsProvider() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Metadata.(*registerPluginRequest_SecretsProvider)
+	return ok
+}
+
+func (x *RegisterPluginRequest) ClearName() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_Name = nil
+}
+
+func (x *RegisterPluginRequest) ClearVersion() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_Version = nil
+}
+
+func (x *RegisterPluginRequest) ClearMetadata() {
+	x.xxx_hidden_Metadata = nil
+}
+
+func (x *RegisterPluginRequest) ClearSecretsProvider() {
+	if _, ok := x.xxx_hidden_Metadata.(*registerPluginRequest_SecretsProvider); ok {
+		x.xxx_hidden_Metadata = nil
+	}
+}
+
+const RegisterPluginRequest_Metadata_not_set_case case_RegisterPluginRequest_Metadata = 0
+const RegisterPluginRequest_SecretsProvider_case case_RegisterPluginRequest_Metadata = 3
+
+func (x *RegisterPluginRequest) WhichMetadata() case_RegisterPluginRequest_Metadata {
+	if x == nil {
+		return RegisterPluginRequest_Metadata_not_set_case
+	}
+	switch x.xxx_hidden_Metadata.(type) {
+	case *registerPluginRequest_SecretsProvider:
+		return RegisterPluginRequest_SecretsProvider_case
+	default:
+		return RegisterPluginRequest_Metadata_not_set_case
+	}
+}
+
+type RegisterPluginRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Name of the plugin to register.
+	Name *string
+	// Version of the plugin.
+	Version *string
+	// Type-specific fields
+
+	// Fields of oneof xxx_hidden_Metadata:
+	SecretsProvider *SecretsProvider
+	// -- end of xxx_hidden_Metadata
+}
+
+func (b0 RegisterPluginRequest_builder) Build() *RegisterPluginRequest {
+	m0 := &RegisterPluginRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.Name != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 3)
+		x.xxx_hidden_Name = b.Name
+	}
+	if b.Version != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_Version = b.Version
+	}
+	if b.SecretsProvider != nil {
+		x.xxx_hidden_Metadata = &registerPluginRequest_SecretsProvider{b.SecretsProvider}
+	}
+	return m0
+}
+
+type case_RegisterPluginRequest_Metadata protoreflect.FieldNumber
+
+func (x case_RegisterPluginRequest_Metadata) String() string {
+	md := file_plugins_v1_api_proto_msgTypes[0].Descriptor()
+	if x == 0 {
+		return "not set"
+	}
+	return protoimpl.X.MessageFieldStringOf(md, protoreflect.FieldNumber(x))
+}
+
+type isRegisterPluginRequest_Metadata interface {
+	isRegisterPluginRequest_Metadata()
+}
+
+type registerPluginRequest_SecretsProvider struct {
+	SecretsProvider *SecretsProvider `protobuf:"bytes,3,opt,name=secrets_provider,json=secretsProvider,oneof"`
+}
+
+func (*registerPluginRequest_SecretsProvider) isRegisterPluginRequest_Metadata() {}
+
+type RegisterPluginResponse struct {
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_EngineName     *string                `protobuf:"bytes,1,opt,name=engine_name,json=engineName"`
+	xxx_hidden_EngineVersion  *string                `protobuf:"bytes,2,opt,name=engine_version,json=engineVersion"`
+	xxx_hidden_RequestTimeout *durationpb.Duration   `protobuf:"bytes,3,opt,name=request_timeout,json=requestTimeout"`
+	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
+	XXX_presence              [1]uint32
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *RegisterPluginResponse) Reset() {
+	*x = RegisterPluginResponse{}
+	mi := &file_plugins_v1_api_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RegisterPluginResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RegisterPluginResponse) ProtoMessage() {}
+
+func (x *RegisterPluginResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugins_v1_api_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RegisterPluginResponse) GetEngineName() string {
+	if x != nil {
+		if x.xxx_hidden_EngineName != nil {
+			return *x.xxx_hidden_EngineName
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *RegisterPluginResponse) GetEngineVersion() string {
+	if x != nil {
+		if x.xxx_hidden_EngineVersion != nil {
+			return *x.xxx_hidden_EngineVersion
+		}
+		return ""
+	}
+	return ""
+}
+
+func (x *RegisterPluginResponse) GetRequestTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.xxx_hidden_RequestTimeout
+	}
+	return nil
+}
+
+func (x *RegisterPluginResponse) SetEngineName(v string) {
+	x.xxx_hidden_EngineName = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 3)
+}
+
+func (x *RegisterPluginResponse) SetEngineVersion(v string) {
+	x.xxx_hidden_EngineVersion = &v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
+}
+
+func (x *RegisterPluginResponse) SetRequestTimeout(v *durationpb.Duration) {
+	x.xxx_hidden_RequestTimeout = v
+}
+
+func (x *RegisterPluginResponse) HasEngineName() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
+}
+
+func (x *RegisterPluginResponse) HasEngineVersion() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
+}
+
+func (x *RegisterPluginResponse) HasRequestTimeout() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_RequestTimeout != nil
+}
+
+func (x *RegisterPluginResponse) ClearEngineName() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
+	x.xxx_hidden_EngineName = nil
+}
+
+func (x *RegisterPluginResponse) ClearEngineVersion() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
+	x.xxx_hidden_EngineVersion = nil
+}
+
+func (x *RegisterPluginResponse) ClearRequestTimeout() {
+	x.xxx_hidden_RequestTimeout = nil
+}
+
+type RegisterPluginResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// Name of the secrets engine is running in.
+	EngineName *string
+	// Version of the runtime engine is running in.
+	EngineVersion *string
+	// Configured request processing timeout in milliseconds.
+	RequestTimeout *durationpb.Duration
+}
+
+func (b0 RegisterPluginResponse_builder) Build() *RegisterPluginResponse {
+	m0 := &RegisterPluginResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	if b.EngineName != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 3)
+		x.xxx_hidden_EngineName = b.EngineName
+	}
+	if b.EngineVersion != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
+		x.xxx_hidden_EngineVersion = b.EngineVersion
+	}
+	x.xxx_hidden_RequestTimeout = b.RequestTimeout
+	return m0
+}
+
+type ShutdownRequest struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownRequest) Reset() {
+	*x = ShutdownRequest{}
+	mi := &file_plugins_v1_api_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownRequest) ProtoMessage() {}
+
+func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_plugins_v1_api_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type ShutdownRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 ShutdownRequest_builder) Build() *ShutdownRequest {
+	m0 := &ShutdownRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type ShutdownResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownResponse) Reset() {
+	*x = ShutdownResponse{}
+	mi := &file_plugins_v1_api_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownResponse) ProtoMessage() {}
+
+func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_plugins_v1_api_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type ShutdownResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 ShutdownResponse_builder) Build() *ShutdownResponse {
+	m0 := &ShutdownResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 type Plugin struct {
 	state                    protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Name          *string                `protobuf:"bytes,1,opt,name=name"`
@@ -88,7 +513,7 @@ type Plugin struct {
 
 func (x *Plugin) Reset() {
 	*x = Plugin{}
-	mi := &file_plugins_v1_api_proto_msgTypes[0]
+	mi := &file_plugins_v1_api_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -100,7 +525,7 @@ func (x *Plugin) String() string {
 func (*Plugin) ProtoMessage() {}
 
 func (x *Plugin) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[0]
+	mi := &file_plugins_v1_api_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +839,7 @@ func (b0 Plugin_builder) Build() *Plugin {
 type case_Plugin_Metadata protoreflect.FieldNumber
 
 func (x case_Plugin_Metadata) String() string {
-	md := file_plugins_v1_api_proto_msgTypes[0].Descriptor()
+	md := file_plugins_v1_api_proto_msgTypes[4].Descriptor()
 	if x == 0 {
 		return "not set"
 	}
@@ -442,7 +867,7 @@ type SecretsProvider struct {
 
 func (x *SecretsProvider) Reset() {
 	*x = SecretsProvider{}
-	mi := &file_plugins_v1_api_proto_msgTypes[1]
+	mi := &file_plugins_v1_api_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -454,7 +879,7 @@ func (x *SecretsProvider) String() string {
 func (*SecretsProvider) ProtoMessage() {}
 
 func (x *SecretsProvider) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[1]
+	mi := &file_plugins_v1_api_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -518,7 +943,7 @@ type ListPluginsRequest struct {
 
 func (x *ListPluginsRequest) Reset() {
 	*x = ListPluginsRequest{}
-	mi := &file_plugins_v1_api_proto_msgTypes[2]
+	mi := &file_plugins_v1_api_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -530,7 +955,7 @@ func (x *ListPluginsRequest) String() string {
 func (*ListPluginsRequest) ProtoMessage() {}
 
 func (x *ListPluginsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[2]
+	mi := &file_plugins_v1_api_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -562,7 +987,7 @@ type ListPluginsResponse struct {
 
 func (x *ListPluginsResponse) Reset() {
 	*x = ListPluginsResponse{}
-	mi := &file_plugins_v1_api_proto_msgTypes[3]
+	mi := &file_plugins_v1_api_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -574,7 +999,7 @@ func (x *ListPluginsResponse) String() string {
 func (*ListPluginsResponse) ProtoMessage() {}
 
 func (x *ListPluginsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[3]
+	mi := &file_plugins_v1_api_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -623,7 +1048,7 @@ type EnablePluginRequest struct {
 
 func (x *EnablePluginRequest) Reset() {
 	*x = EnablePluginRequest{}
-	mi := &file_plugins_v1_api_proto_msgTypes[4]
+	mi := &file_plugins_v1_api_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -635,7 +1060,7 @@ func (x *EnablePluginRequest) String() string {
 func (*EnablePluginRequest) ProtoMessage() {}
 
 func (x *EnablePluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[4]
+	mi := &file_plugins_v1_api_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -698,7 +1123,7 @@ type EnablePluginResponse struct {
 
 func (x *EnablePluginResponse) Reset() {
 	*x = EnablePluginResponse{}
-	mi := &file_plugins_v1_api_proto_msgTypes[5]
+	mi := &file_plugins_v1_api_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -710,7 +1135,7 @@ func (x *EnablePluginResponse) String() string {
 func (*EnablePluginResponse) ProtoMessage() {}
 
 func (x *EnablePluginResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[5]
+	mi := &file_plugins_v1_api_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -744,7 +1169,7 @@ type DisablePluginRequest struct {
 
 func (x *DisablePluginRequest) Reset() {
 	*x = DisablePluginRequest{}
-	mi := &file_plugins_v1_api_proto_msgTypes[6]
+	mi := &file_plugins_v1_api_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -756,7 +1181,7 @@ func (x *DisablePluginRequest) String() string {
 func (*DisablePluginRequest) ProtoMessage() {}
 
 func (x *DisablePluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[6]
+	mi := &file_plugins_v1_api_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -819,7 +1244,7 @@ type DisablePluginResponse struct {
 
 func (x *DisablePluginResponse) Reset() {
 	*x = DisablePluginResponse{}
-	mi := &file_plugins_v1_api_proto_msgTypes[7]
+	mi := &file_plugins_v1_api_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -831,7 +1256,7 @@ func (x *DisablePluginResponse) String() string {
 func (*DisablePluginResponse) ProtoMessage() {}
 
 func (x *DisablePluginResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugins_v1_api_proto_msgTypes[7]
+	mi := &file_plugins_v1_api_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -859,7 +1284,20 @@ var File_plugins_v1_api_proto protoreflect.FileDescriptor
 const file_plugins_v1_api_proto_rawDesc = "" +
 	"\n" +
 	"\x14plugins/v1/api.proto\x12\n" +
-	"plugins.v1\"\xc5\x02\n" +
+	"plugins.v1\x1a\x1egoogle/protobuf/duration.proto\"\x9b\x01\n" +
+	"\x15RegisterPluginRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\x12H\n" +
+	"\x10secrets_provider\x18\x03 \x01(\v2\x1b.plugins.v1.SecretsProviderH\x00R\x0fsecretsProviderB\n" +
+	"\n" +
+	"\bmetadata\"\xa4\x01\n" +
+	"\x16RegisterPluginResponse\x12\x1f\n" +
+	"\vengine_name\x18\x01 \x01(\tR\n" +
+	"engineName\x12%\n" +
+	"\x0eengine_version\x18\x02 \x01(\tR\rengineVersion\x12B\n" +
+	"\x0frequest_timeout\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x0erequestTimeout\"\x11\n" +
+	"\x0fShutdownRequest\"\x12\n" +
+	"\x10ShutdownResponse\"\xc5\x02\n" +
 	"\x06Plugin\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x1a\n" +
@@ -888,7 +1326,11 @@ const file_plugins_v1_api_proto_rawDesc = "" +
 	"\x12RUN_STATUS_RUNNING\x10\x01\x12\x16\n" +
 	"\x12RUN_STATUS_STOPPED\x10\x02\x12\x16\n" +
 	"\x12RUN_STATUS_CRASHED\x10\x03\x12\x1f\n" +
-	"\x1bRUN_STATUS_RETRIES_EXCEEDED\x10\x042\x92\x02\n" +
+	"\x1bRUN_STATUS_RETRIES_EXCEEDED\x10\x042j\n" +
+	"\x0fRegisterService\x12W\n" +
+	"\x0eRegisterPlugin\x12!.plugins.v1.RegisterPluginRequest\x1a\".plugins.v1.RegisterPluginResponse2V\n" +
+	"\rPluginService\x12E\n" +
+	"\bShutdown\x12\x1b.plugins.v1.ShutdownRequest\x1a\x1c.plugins.v1.ShutdownResponse2\x92\x02\n" +
 	"\x17PluginManagementService\x12N\n" +
 	"\vListPlugins\x12\x1e.plugins.v1.ListPluginsRequest\x1a\x1f.plugins.v1.ListPluginsResponse\x12Q\n" +
 	"\fEnablePlugin\x12\x1f.plugins.v1.EnablePluginRequest\x1a .plugins.v1.EnablePluginResponse\x12T\n" +
@@ -898,33 +1340,44 @@ const file_plugins_v1_api_proto_rawDesc = "" +
 	"Plugins\\V1\xe2\x02\x16Plugins\\V1\\GPBMetadata\xea\x02\vPlugins::V1b\beditionsp\xe8\a"
 
 var file_plugins_v1_api_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_plugins_v1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_plugins_v1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_plugins_v1_api_proto_goTypes = []any{
-	(RunStatus)(0),                // 0: plugins.v1.RunStatus
-	(*Plugin)(nil),                // 1: plugins.v1.Plugin
-	(*SecretsProvider)(nil),       // 2: plugins.v1.SecretsProvider
-	(*ListPluginsRequest)(nil),    // 3: plugins.v1.ListPluginsRequest
-	(*ListPluginsResponse)(nil),   // 4: plugins.v1.ListPluginsResponse
-	(*EnablePluginRequest)(nil),   // 5: plugins.v1.EnablePluginRequest
-	(*EnablePluginResponse)(nil),  // 6: plugins.v1.EnablePluginResponse
-	(*DisablePluginRequest)(nil),  // 7: plugins.v1.DisablePluginRequest
-	(*DisablePluginResponse)(nil), // 8: plugins.v1.DisablePluginResponse
+	(RunStatus)(0),                 // 0: plugins.v1.RunStatus
+	(*RegisterPluginRequest)(nil),  // 1: plugins.v1.RegisterPluginRequest
+	(*RegisterPluginResponse)(nil), // 2: plugins.v1.RegisterPluginResponse
+	(*ShutdownRequest)(nil),        // 3: plugins.v1.ShutdownRequest
+	(*ShutdownResponse)(nil),       // 4: plugins.v1.ShutdownResponse
+	(*Plugin)(nil),                 // 5: plugins.v1.Plugin
+	(*SecretsProvider)(nil),        // 6: plugins.v1.SecretsProvider
+	(*ListPluginsRequest)(nil),     // 7: plugins.v1.ListPluginsRequest
+	(*ListPluginsResponse)(nil),    // 8: plugins.v1.ListPluginsResponse
+	(*EnablePluginRequest)(nil),    // 9: plugins.v1.EnablePluginRequest
+	(*EnablePluginResponse)(nil),   // 10: plugins.v1.EnablePluginResponse
+	(*DisablePluginRequest)(nil),   // 11: plugins.v1.DisablePluginRequest
+	(*DisablePluginResponse)(nil),  // 12: plugins.v1.DisablePluginResponse
+	(*durationpb.Duration)(nil),    // 13: google.protobuf.Duration
 }
 var file_plugins_v1_api_proto_depIdxs = []int32{
-	0, // 0: plugins.v1.Plugin.run_status:type_name -> plugins.v1.RunStatus
-	2, // 1: plugins.v1.Plugin.secrets_provider:type_name -> plugins.v1.SecretsProvider
-	1, // 2: plugins.v1.ListPluginsResponse.plugins:type_name -> plugins.v1.Plugin
-	3, // 3: plugins.v1.PluginManagementService.ListPlugins:input_type -> plugins.v1.ListPluginsRequest
-	5, // 4: plugins.v1.PluginManagementService.EnablePlugin:input_type -> plugins.v1.EnablePluginRequest
-	7, // 5: plugins.v1.PluginManagementService.DisablePlugin:input_type -> plugins.v1.DisablePluginRequest
-	4, // 6: plugins.v1.PluginManagementService.ListPlugins:output_type -> plugins.v1.ListPluginsResponse
-	6, // 7: plugins.v1.PluginManagementService.EnablePlugin:output_type -> plugins.v1.EnablePluginResponse
-	8, // 8: plugins.v1.PluginManagementService.DisablePlugin:output_type -> plugins.v1.DisablePluginResponse
-	6, // [6:9] is the sub-list for method output_type
-	3, // [3:6] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	6,  // 0: plugins.v1.RegisterPluginRequest.secrets_provider:type_name -> plugins.v1.SecretsProvider
+	13, // 1: plugins.v1.RegisterPluginResponse.request_timeout:type_name -> google.protobuf.Duration
+	0,  // 2: plugins.v1.Plugin.run_status:type_name -> plugins.v1.RunStatus
+	6,  // 3: plugins.v1.Plugin.secrets_provider:type_name -> plugins.v1.SecretsProvider
+	5,  // 4: plugins.v1.ListPluginsResponse.plugins:type_name -> plugins.v1.Plugin
+	1,  // 5: plugins.v1.RegisterService.RegisterPlugin:input_type -> plugins.v1.RegisterPluginRequest
+	3,  // 6: plugins.v1.PluginService.Shutdown:input_type -> plugins.v1.ShutdownRequest
+	7,  // 7: plugins.v1.PluginManagementService.ListPlugins:input_type -> plugins.v1.ListPluginsRequest
+	9,  // 8: plugins.v1.PluginManagementService.EnablePlugin:input_type -> plugins.v1.EnablePluginRequest
+	11, // 9: plugins.v1.PluginManagementService.DisablePlugin:input_type -> plugins.v1.DisablePluginRequest
+	2,  // 10: plugins.v1.RegisterService.RegisterPlugin:output_type -> plugins.v1.RegisterPluginResponse
+	4,  // 11: plugins.v1.PluginService.Shutdown:output_type -> plugins.v1.ShutdownResponse
+	8,  // 12: plugins.v1.PluginManagementService.ListPlugins:output_type -> plugins.v1.ListPluginsResponse
+	10, // 13: plugins.v1.PluginManagementService.EnablePlugin:output_type -> plugins.v1.EnablePluginResponse
+	12, // 14: plugins.v1.PluginManagementService.DisablePlugin:output_type -> plugins.v1.DisablePluginResponse
+	10, // [10:15] is the sub-list for method output_type
+	5,  // [5:10] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_plugins_v1_api_proto_init() }
@@ -933,6 +1386,9 @@ func file_plugins_v1_api_proto_init() {
 		return
 	}
 	file_plugins_v1_api_proto_msgTypes[0].OneofWrappers = []any{
+		(*registerPluginRequest_SecretsProvider)(nil),
+	}
+	file_plugins_v1_api_proto_msgTypes[4].OneofWrappers = []any{
 		(*plugin_SecretsProvider)(nil),
 	}
 	type x struct{}
@@ -941,9 +1397,9 @@ func file_plugins_v1_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugins_v1_api_proto_rawDesc), len(file_plugins_v1_api_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   12,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   3,
 		},
 		GoTypes:           file_plugins_v1_api_proto_goTypes,
 		DependencyIndexes: file_plugins_v1_api_proto_depIdxs,

--- a/vendor/github.com/docker/secrets-engine/x/api/plugins/v1/api.proto
+++ b/vendor/github.com/docker/secrets-engine/x/api/plugins/v1/api.proto
@@ -16,9 +16,43 @@ edition = "2023";
 
 package plugins.v1;
 
+import "google/protobuf/duration.proto";
+
 option go_package = "github.com/docker/secrets-engine/x/api/plugins/v1;pluginsv1";
 
+service RegisterService {
+  // RegisterPlugin registers the plugin with the engine.
+  rpc RegisterPlugin(RegisterPluginRequest) returns (RegisterPluginResponse);
+}
 
+message RegisterPluginRequest {
+  // Name of the plugin to register.
+  string name = 1;
+  // Version of the plugin.
+  string version = 2;
+  // Type-specific fields
+  oneof metadata {
+    SecretsProvider secrets_provider = 3;
+  }
+}
+
+message RegisterPluginResponse {
+  // Name of the secrets engine is running in.
+  string engine_name = 1;
+  // Version of the runtime engine is running in.
+  string engine_version = 2;
+  // Configured request processing timeout in milliseconds.
+  google.protobuf.Duration request_timeout = 3;
+}
+
+service PluginService {
+  // Shutdown a plugin (let it know the runtime is going down).
+  rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
+}
+
+message ShutdownRequest {}
+
+message ShutdownResponse {}
 
 service PluginManagementService {
   // ListPlugins returns all plugins registered with the engine.

--- a/vendor/github.com/docker/secrets-engine/x/api/plugins/v1/pluginsv1connect/api.connect.go
+++ b/vendor/github.com/docker/secrets-engine/x/api/plugins/v1/pluginsv1connect/api.connect.go
@@ -21,6 +21,10 @@ import (
 const _ = connect.IsAtLeastVersion1_13_0
 
 const (
+	// RegisterServiceName is the fully-qualified name of the RegisterService service.
+	RegisterServiceName = "plugins.v1.RegisterService"
+	// PluginServiceName is the fully-qualified name of the PluginService service.
+	PluginServiceName = "plugins.v1.PluginService"
 	// PluginManagementServiceName is the fully-qualified name of the PluginManagementService service.
 	PluginManagementServiceName = "plugins.v1.PluginManagementService"
 )
@@ -33,6 +37,11 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
+	// RegisterServiceRegisterPluginProcedure is the fully-qualified name of the RegisterService's
+	// RegisterPlugin RPC.
+	RegisterServiceRegisterPluginProcedure = "/plugins.v1.RegisterService/RegisterPlugin"
+	// PluginServiceShutdownProcedure is the fully-qualified name of the PluginService's Shutdown RPC.
+	PluginServiceShutdownProcedure = "/plugins.v1.PluginService/Shutdown"
 	// PluginManagementServiceListPluginsProcedure is the fully-qualified name of the
 	// PluginManagementService's ListPlugins RPC.
 	PluginManagementServiceListPluginsProcedure = "/plugins.v1.PluginManagementService/ListPlugins"
@@ -43,6 +52,150 @@ const (
 	// PluginManagementService's DisablePlugin RPC.
 	PluginManagementServiceDisablePluginProcedure = "/plugins.v1.PluginManagementService/DisablePlugin"
 )
+
+// RegisterServiceClient is a client for the plugins.v1.RegisterService service.
+type RegisterServiceClient interface {
+	// RegisterPlugin registers the plugin with the engine.
+	RegisterPlugin(context.Context, *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error)
+}
+
+// NewRegisterServiceClient constructs a client for the plugins.v1.RegisterService service. By
+// default, it uses the Connect protocol with the binary Protobuf Codec, asks for gzipped responses,
+// and sends uncompressed requests. To use the gRPC or gRPC-Web protocols, supply the
+// connect.WithGRPC() or connect.WithGRPCWeb() options.
+//
+// The URL supplied here should be the base URL for the Connect or gRPC server (for example,
+// http://api.acme.com or https://acme.com/grpc).
+func NewRegisterServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) RegisterServiceClient {
+	baseURL = strings.TrimRight(baseURL, "/")
+	registerServiceMethods := v1.File_plugins_v1_api_proto.Services().ByName("RegisterService").Methods()
+	return &registerServiceClient{
+		registerPlugin: connect.NewClient[v1.RegisterPluginRequest, v1.RegisterPluginResponse](
+			httpClient,
+			baseURL+RegisterServiceRegisterPluginProcedure,
+			connect.WithSchema(registerServiceMethods.ByName("RegisterPlugin")),
+			connect.WithClientOptions(opts...),
+		),
+	}
+}
+
+// registerServiceClient implements RegisterServiceClient.
+type registerServiceClient struct {
+	registerPlugin *connect.Client[v1.RegisterPluginRequest, v1.RegisterPluginResponse]
+}
+
+// RegisterPlugin calls plugins.v1.RegisterService.RegisterPlugin.
+func (c *registerServiceClient) RegisterPlugin(ctx context.Context, req *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error) {
+	return c.registerPlugin.CallUnary(ctx, req)
+}
+
+// RegisterServiceHandler is an implementation of the plugins.v1.RegisterService service.
+type RegisterServiceHandler interface {
+	// RegisterPlugin registers the plugin with the engine.
+	RegisterPlugin(context.Context, *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error)
+}
+
+// NewRegisterServiceHandler builds an HTTP handler from the service implementation. It returns the
+// path on which to mount the handler and the handler itself.
+//
+// By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
+// and JSON codecs. They also support gzip compression.
+func NewRegisterServiceHandler(svc RegisterServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	registerServiceMethods := v1.File_plugins_v1_api_proto.Services().ByName("RegisterService").Methods()
+	registerServiceRegisterPluginHandler := connect.NewUnaryHandler(
+		RegisterServiceRegisterPluginProcedure,
+		svc.RegisterPlugin,
+		connect.WithSchema(registerServiceMethods.ByName("RegisterPlugin")),
+		connect.WithHandlerOptions(opts...),
+	)
+	return "/plugins.v1.RegisterService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case RegisterServiceRegisterPluginProcedure:
+			registerServiceRegisterPluginHandler.ServeHTTP(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// UnimplementedRegisterServiceHandler returns CodeUnimplemented from all methods.
+type UnimplementedRegisterServiceHandler struct{}
+
+func (UnimplementedRegisterServiceHandler) RegisterPlugin(context.Context, *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("plugins.v1.RegisterService.RegisterPlugin is not implemented"))
+}
+
+// PluginServiceClient is a client for the plugins.v1.PluginService service.
+type PluginServiceClient interface {
+	// Shutdown a plugin (let it know the runtime is going down).
+	Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error)
+}
+
+// NewPluginServiceClient constructs a client for the plugins.v1.PluginService service. By default,
+// it uses the Connect protocol with the binary Protobuf Codec, asks for gzipped responses, and
+// sends uncompressed requests. To use the gRPC or gRPC-Web protocols, supply the connect.WithGRPC()
+// or connect.WithGRPCWeb() options.
+//
+// The URL supplied here should be the base URL for the Connect or gRPC server (for example,
+// http://api.acme.com or https://acme.com/grpc).
+func NewPluginServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) PluginServiceClient {
+	baseURL = strings.TrimRight(baseURL, "/")
+	pluginServiceMethods := v1.File_plugins_v1_api_proto.Services().ByName("PluginService").Methods()
+	return &pluginServiceClient{
+		shutdown: connect.NewClient[v1.ShutdownRequest, v1.ShutdownResponse](
+			httpClient,
+			baseURL+PluginServiceShutdownProcedure,
+			connect.WithSchema(pluginServiceMethods.ByName("Shutdown")),
+			connect.WithClientOptions(opts...),
+		),
+	}
+}
+
+// pluginServiceClient implements PluginServiceClient.
+type pluginServiceClient struct {
+	shutdown *connect.Client[v1.ShutdownRequest, v1.ShutdownResponse]
+}
+
+// Shutdown calls plugins.v1.PluginService.Shutdown.
+func (c *pluginServiceClient) Shutdown(ctx context.Context, req *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error) {
+	return c.shutdown.CallUnary(ctx, req)
+}
+
+// PluginServiceHandler is an implementation of the plugins.v1.PluginService service.
+type PluginServiceHandler interface {
+	// Shutdown a plugin (let it know the runtime is going down).
+	Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error)
+}
+
+// NewPluginServiceHandler builds an HTTP handler from the service implementation. It returns the
+// path on which to mount the handler and the handler itself.
+//
+// By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
+// and JSON codecs. They also support gzip compression.
+func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	pluginServiceMethods := v1.File_plugins_v1_api_proto.Services().ByName("PluginService").Methods()
+	pluginServiceShutdownHandler := connect.NewUnaryHandler(
+		PluginServiceShutdownProcedure,
+		svc.Shutdown,
+		connect.WithSchema(pluginServiceMethods.ByName("Shutdown")),
+		connect.WithHandlerOptions(opts...),
+	)
+	return "/plugins.v1.PluginService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case PluginServiceShutdownProcedure:
+			pluginServiceShutdownHandler.ServeHTTP(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// UnimplementedPluginServiceHandler returns CodeUnimplemented from all methods.
+type UnimplementedPluginServiceHandler struct{}
+
+func (UnimplementedPluginServiceHandler) Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("plugins.v1.PluginService.Shutdown is not implemented"))
+}
 
 // PluginManagementServiceClient is a client for the plugins.v1.PluginManagementService service.
 type PluginManagementServiceClient interface {

--- a/vendor/github.com/docker/secrets-engine/x/api/resolver/v1/api.pb.go
+++ b/vendor/github.com/docker/secrets-engine/x/api/resolver/v1/api.pb.go
@@ -9,7 +9,6 @@ package resolverv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
@@ -22,378 +21,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type RegisterPluginRequest struct {
-	state                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name        *string                `protobuf:"bytes,1,opt,name=name"`
-	xxx_hidden_Version     *string                `protobuf:"bytes,2,opt,name=version"`
-	xxx_hidden_Pattern     *string                `protobuf:"bytes,3,opt,name=pattern"`
-	XXX_raceDetectHookData protoimpl.RaceDetectHookData
-	XXX_presence           [1]uint32
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
-}
-
-func (x *RegisterPluginRequest) Reset() {
-	*x = RegisterPluginRequest{}
-	mi := &file_resolver_v1_api_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RegisterPluginRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RegisterPluginRequest) ProtoMessage() {}
-
-func (x *RegisterPluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *RegisterPluginRequest) GetName() string {
-	if x != nil {
-		if x.xxx_hidden_Name != nil {
-			return *x.xxx_hidden_Name
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *RegisterPluginRequest) GetVersion() string {
-	if x != nil {
-		if x.xxx_hidden_Version != nil {
-			return *x.xxx_hidden_Version
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *RegisterPluginRequest) GetPattern() string {
-	if x != nil {
-		if x.xxx_hidden_Pattern != nil {
-			return *x.xxx_hidden_Pattern
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *RegisterPluginRequest) SetName(v string) {
-	x.xxx_hidden_Name = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 3)
-}
-
-func (x *RegisterPluginRequest) SetVersion(v string) {
-	x.xxx_hidden_Version = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
-}
-
-func (x *RegisterPluginRequest) SetPattern(v string) {
-	x.xxx_hidden_Pattern = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 3)
-}
-
-func (x *RegisterPluginRequest) HasName() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
-}
-
-func (x *RegisterPluginRequest) HasVersion() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
-}
-
-func (x *RegisterPluginRequest) HasPattern() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
-}
-
-func (x *RegisterPluginRequest) ClearName() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
-	x.xxx_hidden_Name = nil
-}
-
-func (x *RegisterPluginRequest) ClearVersion() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
-	x.xxx_hidden_Version = nil
-}
-
-func (x *RegisterPluginRequest) ClearPattern() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
-	x.xxx_hidden_Pattern = nil
-}
-
-type RegisterPluginRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	// Name of the plugin to register.
-	Name *string
-	// Version of the plugin.
-	Version *string
-	// Pattern
-	Pattern *string
-}
-
-func (b0 RegisterPluginRequest_builder) Build() *RegisterPluginRequest {
-	m0 := &RegisterPluginRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	if b.Name != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 3)
-		x.xxx_hidden_Name = b.Name
-	}
-	if b.Version != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
-		x.xxx_hidden_Version = b.Version
-	}
-	if b.Pattern != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 3)
-		x.xxx_hidden_Pattern = b.Pattern
-	}
-	return m0
-}
-
-type RegisterPluginResponse struct {
-	state                     protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_EngineName     *string                `protobuf:"bytes,1,opt,name=engine_name,json=engineName"`
-	xxx_hidden_EngineVersion  *string                `protobuf:"bytes,2,opt,name=engine_version,json=engineVersion"`
-	xxx_hidden_RequestTimeout *durationpb.Duration   `protobuf:"bytes,3,opt,name=request_timeout,json=requestTimeout"`
-	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
-	XXX_presence              [1]uint32
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
-}
-
-func (x *RegisterPluginResponse) Reset() {
-	*x = RegisterPluginResponse{}
-	mi := &file_resolver_v1_api_proto_msgTypes[1]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RegisterPluginResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RegisterPluginResponse) ProtoMessage() {}
-
-func (x *RegisterPluginResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[1]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *RegisterPluginResponse) GetEngineName() string {
-	if x != nil {
-		if x.xxx_hidden_EngineName != nil {
-			return *x.xxx_hidden_EngineName
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *RegisterPluginResponse) GetEngineVersion() string {
-	if x != nil {
-		if x.xxx_hidden_EngineVersion != nil {
-			return *x.xxx_hidden_EngineVersion
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *RegisterPluginResponse) GetRequestTimeout() *durationpb.Duration {
-	if x != nil {
-		return x.xxx_hidden_RequestTimeout
-	}
-	return nil
-}
-
-func (x *RegisterPluginResponse) SetEngineName(v string) {
-	x.xxx_hidden_EngineName = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 3)
-}
-
-func (x *RegisterPluginResponse) SetEngineVersion(v string) {
-	x.xxx_hidden_EngineVersion = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
-}
-
-func (x *RegisterPluginResponse) SetRequestTimeout(v *durationpb.Duration) {
-	x.xxx_hidden_RequestTimeout = v
-}
-
-func (x *RegisterPluginResponse) HasEngineName() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
-}
-
-func (x *RegisterPluginResponse) HasEngineVersion() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
-}
-
-func (x *RegisterPluginResponse) HasRequestTimeout() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_RequestTimeout != nil
-}
-
-func (x *RegisterPluginResponse) ClearEngineName() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
-	x.xxx_hidden_EngineName = nil
-}
-
-func (x *RegisterPluginResponse) ClearEngineVersion() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
-	x.xxx_hidden_EngineVersion = nil
-}
-
-func (x *RegisterPluginResponse) ClearRequestTimeout() {
-	x.xxx_hidden_RequestTimeout = nil
-}
-
-type RegisterPluginResponse_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	// Name of the secrets engine is running in.
-	EngineName *string
-	// Version of the runtime engine is running in.
-	EngineVersion *string
-	// Configured request processing timeout in milliseconds.
-	RequestTimeout *durationpb.Duration
-}
-
-func (b0 RegisterPluginResponse_builder) Build() *RegisterPluginResponse {
-	m0 := &RegisterPluginResponse{}
-	b, x := &b0, m0
-	_, _ = b, x
-	if b.EngineName != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 3)
-		x.xxx_hidden_EngineName = b.EngineName
-	}
-	if b.EngineVersion != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
-		x.xxx_hidden_EngineVersion = b.EngineVersion
-	}
-	x.xxx_hidden_RequestTimeout = b.RequestTimeout
-	return m0
-}
-
-type ShutdownRequest struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ShutdownRequest) Reset() {
-	*x = ShutdownRequest{}
-	mi := &file_resolver_v1_api_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ShutdownRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ShutdownRequest) ProtoMessage() {}
-
-func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-type ShutdownRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-}
-
-func (b0 ShutdownRequest_builder) Build() *ShutdownRequest {
-	m0 := &ShutdownRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	return m0
-}
-
-type ShutdownResponse struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ShutdownResponse) Reset() {
-	*x = ShutdownResponse{}
-	mi := &file_resolver_v1_api_proto_msgTypes[3]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ShutdownResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ShutdownResponse) ProtoMessage() {}
-
-func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[3]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-type ShutdownResponse_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-}
-
-func (b0 ShutdownResponse_builder) Build() *ShutdownResponse {
-	m0 := &ShutdownResponse{}
-	b, x := &b0, m0
-	_, _ = b, x
-	return m0
-}
-
 type GetSecretsRequest struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Pattern     *string                `protobuf:"bytes,1,opt,name=pattern"`
@@ -405,7 +32,7 @@ type GetSecretsRequest struct {
 
 func (x *GetSecretsRequest) Reset() {
 	*x = GetSecretsRequest{}
-	mi := &file_resolver_v1_api_proto_msgTypes[4]
+	mi := &file_resolver_v1_api_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -417,7 +44,7 @@ func (x *GetSecretsRequest) String() string {
 func (*GetSecretsRequest) ProtoMessage() {}
 
 func (x *GetSecretsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[4]
+	mi := &file_resolver_v1_api_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -482,7 +109,7 @@ type GetSecretsResponse struct {
 
 func (x *GetSecretsResponse) Reset() {
 	*x = GetSecretsResponse{}
-	mi := &file_resolver_v1_api_proto_msgTypes[5]
+	mi := &file_resolver_v1_api_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -494,7 +121,7 @@ func (x *GetSecretsResponse) String() string {
 func (*GetSecretsResponse) ProtoMessage() {}
 
 func (x *GetSecretsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[5]
+	mi := &file_resolver_v1_api_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -550,7 +177,7 @@ type GetSecretsResponse_Envelope struct {
 
 func (x *GetSecretsResponse_Envelope) Reset() {
 	*x = GetSecretsResponse_Envelope{}
-	mi := &file_resolver_v1_api_proto_msgTypes[6]
+	mi := &file_resolver_v1_api_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -562,7 +189,7 @@ func (x *GetSecretsResponse_Envelope) String() string {
 func (*GetSecretsResponse_Envelope) ProtoMessage() {}
 
 func (x *GetSecretsResponse_Envelope) ProtoReflect() protoreflect.Message {
-	mi := &file_resolver_v1_api_proto_msgTypes[6]
+	mi := &file_resolver_v1_api_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -804,18 +431,7 @@ var File_resolver_v1_api_proto protoreflect.FileDescriptor
 
 const file_resolver_v1_api_proto_rawDesc = "" +
 	"\n" +
-	"\x15resolver/v1/api.proto\x12\vresolver.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"_\n" +
-	"\x15RegisterPluginRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\tR\aversion\x12\x18\n" +
-	"\apattern\x18\x03 \x01(\tR\apattern\"\xa4\x01\n" +
-	"\x16RegisterPluginResponse\x12\x1f\n" +
-	"\vengine_name\x18\x01 \x01(\tR\n" +
-	"engineName\x12%\n" +
-	"\x0eengine_version\x18\x02 \x01(\tR\rengineVersion\x12B\n" +
-	"\x0frequest_timeout\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x0erequestTimeout\"\x11\n" +
-	"\x0fShutdownRequest\"\x12\n" +
-	"\x10ShutdownResponse\"-\n" +
+	"\x15resolver/v1/api.proto\x12\vresolver.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"-\n" +
 	"\x11GetSecretsRequest\x12\x18\n" +
 	"\apattern\x18\x01 \x01(\tR\apattern\"\x89\x04\n" +
 	"\x12GetSecretsResponse\x12F\n" +
@@ -834,47 +450,33 @@ const file_resolver_v1_api_proto_rawDesc = "" +
 	"\bmetadata\x18\b \x03(\v26.resolver.v1.GetSecretsResponse.Envelope.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x012l\n" +
-	"\x0fRegisterService\x12Y\n" +
-	"\x0eRegisterPlugin\x12\".resolver.v1.RegisterPluginRequest\x1a#.resolver.v1.RegisterPluginResponse2X\n" +
-	"\rPluginService\x12G\n" +
-	"\bShutdown\x12\x1c.resolver.v1.ShutdownRequest\x1a\x1d.resolver.v1.ShutdownResponse2`\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x012`\n" +
 	"\x0fResolverService\x12M\n" +
 	"\n" +
 	"GetSecrets\x12\x1e.resolver.v1.GetSecretsRequest\x1a\x1f.resolver.v1.GetSecretsResponseB\xa7\x01\n" +
 	"\x0fcom.resolver.v1B\bApiProtoP\x01Z=github.com/docker/secrets-engine/x/api/resolver/v1;resolverv1\xa2\x02\x03RXX\xaa\x02\vResolver.V1\xca\x02\vResolver\\V1\xe2\x02\x17Resolver\\V1\\GPBMetadata\xea\x02\fResolver::V1b\beditionsp\xe8\a"
 
-var file_resolver_v1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_resolver_v1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_resolver_v1_api_proto_goTypes = []any{
-	(*RegisterPluginRequest)(nil),       // 0: resolver.v1.RegisterPluginRequest
-	(*RegisterPluginResponse)(nil),      // 1: resolver.v1.RegisterPluginResponse
-	(*ShutdownRequest)(nil),             // 2: resolver.v1.ShutdownRequest
-	(*ShutdownResponse)(nil),            // 3: resolver.v1.ShutdownResponse
-	(*GetSecretsRequest)(nil),           // 4: resolver.v1.GetSecretsRequest
-	(*GetSecretsResponse)(nil),          // 5: resolver.v1.GetSecretsResponse
-	(*GetSecretsResponse_Envelope)(nil), // 6: resolver.v1.GetSecretsResponse.Envelope
-	nil,                                 // 7: resolver.v1.GetSecretsResponse.Envelope.MetadataEntry
-	(*durationpb.Duration)(nil),         // 8: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),       // 9: google.protobuf.Timestamp
+	(*GetSecretsRequest)(nil),           // 0: resolver.v1.GetSecretsRequest
+	(*GetSecretsResponse)(nil),          // 1: resolver.v1.GetSecretsResponse
+	(*GetSecretsResponse_Envelope)(nil), // 2: resolver.v1.GetSecretsResponse.Envelope
+	nil,                                 // 3: resolver.v1.GetSecretsResponse.Envelope.MetadataEntry
+	(*timestamppb.Timestamp)(nil),       // 4: google.protobuf.Timestamp
 }
 var file_resolver_v1_api_proto_depIdxs = []int32{
-	8, // 0: resolver.v1.RegisterPluginResponse.request_timeout:type_name -> google.protobuf.Duration
-	6, // 1: resolver.v1.GetSecretsResponse.envelopes:type_name -> resolver.v1.GetSecretsResponse.Envelope
-	9, // 2: resolver.v1.GetSecretsResponse.Envelope.created_at:type_name -> google.protobuf.Timestamp
-	9, // 3: resolver.v1.GetSecretsResponse.Envelope.resolved_at:type_name -> google.protobuf.Timestamp
-	9, // 4: resolver.v1.GetSecretsResponse.Envelope.expires_at:type_name -> google.protobuf.Timestamp
-	7, // 5: resolver.v1.GetSecretsResponse.Envelope.metadata:type_name -> resolver.v1.GetSecretsResponse.Envelope.MetadataEntry
-	0, // 6: resolver.v1.RegisterService.RegisterPlugin:input_type -> resolver.v1.RegisterPluginRequest
-	2, // 7: resolver.v1.PluginService.Shutdown:input_type -> resolver.v1.ShutdownRequest
-	4, // 8: resolver.v1.ResolverService.GetSecrets:input_type -> resolver.v1.GetSecretsRequest
-	1, // 9: resolver.v1.RegisterService.RegisterPlugin:output_type -> resolver.v1.RegisterPluginResponse
-	3, // 10: resolver.v1.PluginService.Shutdown:output_type -> resolver.v1.ShutdownResponse
-	5, // 11: resolver.v1.ResolverService.GetSecrets:output_type -> resolver.v1.GetSecretsResponse
-	9, // [9:12] is the sub-list for method output_type
-	6, // [6:9] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	2, // 0: resolver.v1.GetSecretsResponse.envelopes:type_name -> resolver.v1.GetSecretsResponse.Envelope
+	4, // 1: resolver.v1.GetSecretsResponse.Envelope.created_at:type_name -> google.protobuf.Timestamp
+	4, // 2: resolver.v1.GetSecretsResponse.Envelope.resolved_at:type_name -> google.protobuf.Timestamp
+	4, // 3: resolver.v1.GetSecretsResponse.Envelope.expires_at:type_name -> google.protobuf.Timestamp
+	3, // 4: resolver.v1.GetSecretsResponse.Envelope.metadata:type_name -> resolver.v1.GetSecretsResponse.Envelope.MetadataEntry
+	0, // 5: resolver.v1.ResolverService.GetSecrets:input_type -> resolver.v1.GetSecretsRequest
+	1, // 6: resolver.v1.ResolverService.GetSecrets:output_type -> resolver.v1.GetSecretsResponse
+	6, // [6:7] is the sub-list for method output_type
+	5, // [5:6] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_resolver_v1_api_proto_init() }
@@ -888,9 +490,9 @@ func file_resolver_v1_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resolver_v1_api_proto_rawDesc), len(file_resolver_v1_api_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   4,
 			NumExtensions: 0,
-			NumServices:   3,
+			NumServices:   1,
 		},
 		GoTypes:           file_resolver_v1_api_proto_goTypes,
 		DependencyIndexes: file_resolver_v1_api_proto_depIdxs,

--- a/vendor/github.com/docker/secrets-engine/x/api/resolver/v1/api.proto
+++ b/vendor/github.com/docker/secrets-engine/x/api/resolver/v1/api.proto
@@ -17,41 +17,8 @@ edition = "2023";
 package resolver.v1;
 
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/duration.proto";
 
 option go_package = "github.com/docker/secrets-engine/x/api/resolver/v1;resolverv1";
-
-service RegisterService {
-  // RegisterPlugin registers the plugin with the engine.
-  rpc RegisterPlugin(RegisterPluginRequest) returns (RegisterPluginResponse);
-}
-
-message RegisterPluginRequest {
-  // Name of the plugin to register.
-  string name = 1;
-  // Version of the plugin.
-  string version = 2;
-  // Pattern
-  string pattern = 3;
-}
-
-message RegisterPluginResponse {
-  // Name of the secrets engine is running in.
-  string engine_name = 1;
-  // Version of the runtime engine is running in.
-  string engine_version = 2;
-  // Configured request processing timeout in milliseconds.
-  google.protobuf.Duration request_timeout = 3;
-}
-
-service PluginService {
-  // Shutdown a plugin (let it know the runtime is going down).
-  rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
-}
-
-message ShutdownRequest {}
-
-message ShutdownResponse {}
 
 service ResolverService {
   // Resolve a secret by its ID.

--- a/vendor/github.com/docker/secrets-engine/x/api/resolver/v1/resolverv1connect/api.connect.go
+++ b/vendor/github.com/docker/secrets-engine/x/api/resolver/v1/resolverv1connect/api.connect.go
@@ -21,10 +21,6 @@ import (
 const _ = connect.IsAtLeastVersion1_13_0
 
 const (
-	// RegisterServiceName is the fully-qualified name of the RegisterService service.
-	RegisterServiceName = "resolver.v1.RegisterService"
-	// PluginServiceName is the fully-qualified name of the PluginService service.
-	PluginServiceName = "resolver.v1.PluginService"
 	// ResolverServiceName is the fully-qualified name of the ResolverService service.
 	ResolverServiceName = "resolver.v1.ResolverService"
 )
@@ -37,159 +33,10 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
-	// RegisterServiceRegisterPluginProcedure is the fully-qualified name of the RegisterService's
-	// RegisterPlugin RPC.
-	RegisterServiceRegisterPluginProcedure = "/resolver.v1.RegisterService/RegisterPlugin"
-	// PluginServiceShutdownProcedure is the fully-qualified name of the PluginService's Shutdown RPC.
-	PluginServiceShutdownProcedure = "/resolver.v1.PluginService/Shutdown"
 	// ResolverServiceGetSecretsProcedure is the fully-qualified name of the ResolverService's
 	// GetSecrets RPC.
 	ResolverServiceGetSecretsProcedure = "/resolver.v1.ResolverService/GetSecrets"
 )
-
-// RegisterServiceClient is a client for the resolver.v1.RegisterService service.
-type RegisterServiceClient interface {
-	// RegisterPlugin registers the plugin with the engine.
-	RegisterPlugin(context.Context, *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error)
-}
-
-// NewRegisterServiceClient constructs a client for the resolver.v1.RegisterService service. By
-// default, it uses the Connect protocol with the binary Protobuf Codec, asks for gzipped responses,
-// and sends uncompressed requests. To use the gRPC or gRPC-Web protocols, supply the
-// connect.WithGRPC() or connect.WithGRPCWeb() options.
-//
-// The URL supplied here should be the base URL for the Connect or gRPC server (for example,
-// http://api.acme.com or https://acme.com/grpc).
-func NewRegisterServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) RegisterServiceClient {
-	baseURL = strings.TrimRight(baseURL, "/")
-	registerServiceMethods := v1.File_resolver_v1_api_proto.Services().ByName("RegisterService").Methods()
-	return &registerServiceClient{
-		registerPlugin: connect.NewClient[v1.RegisterPluginRequest, v1.RegisterPluginResponse](
-			httpClient,
-			baseURL+RegisterServiceRegisterPluginProcedure,
-			connect.WithSchema(registerServiceMethods.ByName("RegisterPlugin")),
-			connect.WithClientOptions(opts...),
-		),
-	}
-}
-
-// registerServiceClient implements RegisterServiceClient.
-type registerServiceClient struct {
-	registerPlugin *connect.Client[v1.RegisterPluginRequest, v1.RegisterPluginResponse]
-}
-
-// RegisterPlugin calls resolver.v1.RegisterService.RegisterPlugin.
-func (c *registerServiceClient) RegisterPlugin(ctx context.Context, req *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error) {
-	return c.registerPlugin.CallUnary(ctx, req)
-}
-
-// RegisterServiceHandler is an implementation of the resolver.v1.RegisterService service.
-type RegisterServiceHandler interface {
-	// RegisterPlugin registers the plugin with the engine.
-	RegisterPlugin(context.Context, *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error)
-}
-
-// NewRegisterServiceHandler builds an HTTP handler from the service implementation. It returns the
-// path on which to mount the handler and the handler itself.
-//
-// By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
-// and JSON codecs. They also support gzip compression.
-func NewRegisterServiceHandler(svc RegisterServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
-	registerServiceMethods := v1.File_resolver_v1_api_proto.Services().ByName("RegisterService").Methods()
-	registerServiceRegisterPluginHandler := connect.NewUnaryHandler(
-		RegisterServiceRegisterPluginProcedure,
-		svc.RegisterPlugin,
-		connect.WithSchema(registerServiceMethods.ByName("RegisterPlugin")),
-		connect.WithHandlerOptions(opts...),
-	)
-	return "/resolver.v1.RegisterService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case RegisterServiceRegisterPluginProcedure:
-			registerServiceRegisterPluginHandler.ServeHTTP(w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	})
-}
-
-// UnimplementedRegisterServiceHandler returns CodeUnimplemented from all methods.
-type UnimplementedRegisterServiceHandler struct{}
-
-func (UnimplementedRegisterServiceHandler) RegisterPlugin(context.Context, *connect.Request[v1.RegisterPluginRequest]) (*connect.Response[v1.RegisterPluginResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("resolver.v1.RegisterService.RegisterPlugin is not implemented"))
-}
-
-// PluginServiceClient is a client for the resolver.v1.PluginService service.
-type PluginServiceClient interface {
-	// Shutdown a plugin (let it know the runtime is going down).
-	Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error)
-}
-
-// NewPluginServiceClient constructs a client for the resolver.v1.PluginService service. By default,
-// it uses the Connect protocol with the binary Protobuf Codec, asks for gzipped responses, and
-// sends uncompressed requests. To use the gRPC or gRPC-Web protocols, supply the connect.WithGRPC()
-// or connect.WithGRPCWeb() options.
-//
-// The URL supplied here should be the base URL for the Connect or gRPC server (for example,
-// http://api.acme.com or https://acme.com/grpc).
-func NewPluginServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) PluginServiceClient {
-	baseURL = strings.TrimRight(baseURL, "/")
-	pluginServiceMethods := v1.File_resolver_v1_api_proto.Services().ByName("PluginService").Methods()
-	return &pluginServiceClient{
-		shutdown: connect.NewClient[v1.ShutdownRequest, v1.ShutdownResponse](
-			httpClient,
-			baseURL+PluginServiceShutdownProcedure,
-			connect.WithSchema(pluginServiceMethods.ByName("Shutdown")),
-			connect.WithClientOptions(opts...),
-		),
-	}
-}
-
-// pluginServiceClient implements PluginServiceClient.
-type pluginServiceClient struct {
-	shutdown *connect.Client[v1.ShutdownRequest, v1.ShutdownResponse]
-}
-
-// Shutdown calls resolver.v1.PluginService.Shutdown.
-func (c *pluginServiceClient) Shutdown(ctx context.Context, req *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error) {
-	return c.shutdown.CallUnary(ctx, req)
-}
-
-// PluginServiceHandler is an implementation of the resolver.v1.PluginService service.
-type PluginServiceHandler interface {
-	// Shutdown a plugin (let it know the runtime is going down).
-	Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error)
-}
-
-// NewPluginServiceHandler builds an HTTP handler from the service implementation. It returns the
-// path on which to mount the handler and the handler itself.
-//
-// By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
-// and JSON codecs. They also support gzip compression.
-func NewPluginServiceHandler(svc PluginServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
-	pluginServiceMethods := v1.File_resolver_v1_api_proto.Services().ByName("PluginService").Methods()
-	pluginServiceShutdownHandler := connect.NewUnaryHandler(
-		PluginServiceShutdownProcedure,
-		svc.Shutdown,
-		connect.WithSchema(pluginServiceMethods.ByName("Shutdown")),
-		connect.WithHandlerOptions(opts...),
-	)
-	return "/resolver.v1.PluginService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case PluginServiceShutdownProcedure:
-			pluginServiceShutdownHandler.ServeHTTP(w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	})
-}
-
-// UnimplementedPluginServiceHandler returns CodeUnimplemented from all methods.
-type UnimplementedPluginServiceHandler struct{}
-
-func (UnimplementedPluginServiceHandler) Shutdown(context.Context, *connect.Request[v1.ShutdownRequest]) (*connect.Response[v1.ShutdownResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("resolver.v1.PluginService.Shutdown is not implemented"))
-}
 
 // ResolverServiceClient is a client for the resolver.v1.ResolverService service.
 type ResolverServiceClient interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,8 +167,8 @@ github.com/docker/mcp-gateway-oauth-helpers
 ## explicit; go 1.25.11
 github.com/docker/secrets-engine/client
 github.com/docker/secrets-engine/client/realms
-# github.com/docker/secrets-engine/x v0.0.32-do.not.use
-## explicit; go 1.25.10
+# github.com/docker/secrets-engine/x v0.1.0-do.not.use
+## explicit; go 1.25.11
 github.com/docker/secrets-engine/x/api
 github.com/docker/secrets-engine/x/api/health/v1
 github.com/docker/secrets-engine/x/api/health/v1/healthv1connect


### PR DESCRIPTION
Vendor the updated github.com/docker/secrets-engine/x module.

**What I did**
bump secrets-engine/x to v0.1.0-do.not.use

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**