### PR TITLE
feat(gha): migrate Docker Hub logins to OIDC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Merge on Main
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -33,10 +34,12 @@ jobs:
         run: make docker-mcp-cross
 
       - name: Hub login
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.OIDC_ID_CONNECTION }}
+          DOCKERHUB_OIDC_EXPIREIN: 3600
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
 
       - name: Push Gateway image
         run: make push-mcp-gateway


### PR DESCRIPTION
You'll need to add a new secret `OIDC_ID_CONNECTION` matching the some UUID to make it works. I'm no admin of this repo, please do reach me.