### PR TITLE
ci: migrate Hub login from PAT to OIDC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Merge on Main
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -33,10 +34,12 @@ jobs:
         run: make docker-mcp-cross
 
       - name: Hub login
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ secrets.OIDC_CONNECTION_ID }}
+          DOCKERHUB_OIDC_EXPIREIN: 3600
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
 
       - name: Push Gateway image
         run: make push-mcp-gateway


### PR DESCRIPTION
## Summary

Docker Hub is blocking image pushes using long-lived PATs to Docker-owned namespaces starting **August 7, 2026**. This migrates `main.yml` to OIDC authentication.

## Changes

- Add `id-token: write` to workflow-level permissions (required for GitHub OIDC token issuance)
- Upgrade `docker/login-action` v3.7.0 → v4.6.0 (`dbcb813`)
- Replace `DOCKERPUBLICBOT_WRITE_PAT` with `DOCKERHUB_OIDC_CONNECTIONID` env var
- Remove `DOCKERPUBLICBOT_USERNAME` var; hardcode `username: docker`
