### PR TITLE
Harden OAuth lifecycle and tool policy enforcement

### DIFF
--- a/cmd/docker-mcp/oauth/revoke.go
+++ b/cmd/docker-mcp/oauth/revoke.go
@@ -23,6 +23,9 @@ var (
 	// requiring docker pass, Docker Desktop, or a real database.
 	deleteOAuthTokenFunc      = secret.DeleteOAuthToken
 	deleteDCRClientFunc       = secret.DeleteDCRClient
+	getCommunityDCRClientFunc = pkgoauth.GetDCRClientFromDockerPass
+	getCommunityTokenFunc     = pkgoauth.GetTokenFromDockerPass
+	revokeProviderTokenFunc   = pkgoauth.RevokeTokenAtProvider
 	desktopDeleteOAuthAppFunc = func(ctx context.Context, app string) error {
 		return desktop.NewAuthClient().DeleteOAuthApp(ctx, app)
 	}
@@ -84,10 +87,10 @@ func revokeCEMode(ctx context.Context, app string) error {
 	credHelper := pkgoauth.NewReadWriteCredentialHelper()
 	manager := pkgoauth.NewManager(credHelper)
 
-	// Delete OAuth token
+	// Revoke at the provider before deleting local credentials. If remote
+	// revocation fails, preserve both the token and DCR metadata for retry.
 	if err := manager.RevokeToken(ctx, app); err != nil {
-		// Token might not exist, continue to DCR deletion
-		fmt.Printf("Note: %v\n", err)
+		return fmt.Errorf("failed to revoke OAuth access: %w", err)
 	}
 
 	// Delete DCR client (matches Desktop behavior)
@@ -109,10 +112,21 @@ func revokeCommunityMode(ctx context.Context, app string) error {
 		return fmt.Errorf("invalid server name %q: %w", app, err)
 	}
 
-	// Delete OAuth token from docker pass
+	dcrClient, err := getCommunityDCRClientFunc(ctx, app)
+	if err != nil {
+		return fmt.Errorf("failed to load DCR client for provider revocation: %w", err)
+	}
+	token, err := getCommunityTokenFunc(ctx, app)
+	if err != nil {
+		return fmt.Errorf("failed to load OAuth token for provider revocation: %w", err)
+	}
+	if err := revokeProviderTokenFunc(ctx, dcrClient, token); err != nil {
+		return fmt.Errorf("failed to revoke OAuth access: %w", err)
+	}
+
+	// Delete OAuth token from docker pass only after provider revocation.
 	if err := deleteOAuthTokenFunc(ctx, appID); err != nil {
-		// Token might not exist, continue to DCR deletion
-		fmt.Printf("Note: %v\n", err)
+		return fmt.Errorf("provider token revoked but failed to delete local OAuth token: %w", err)
 	}
 
 	// Delete DCR client from docker pass (soft failure -- entry may not exist

--- a/cmd/docker-mcp/oauth/revoke.go
+++ b/cmd/docker-mcp/oauth/revoke.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	seclient "github.com/docker/secrets-engine/client"
@@ -121,6 +122,18 @@ func revokeCommunityMode(ctx context.Context, app string) error {
 
 	dcrClient, err := getCommunityDCRClientFunc(ctx, app)
 	if err != nil {
+		if errors.Is(err, secret.ErrSecretNotFound) {
+			fmt.Printf("Note: %v\n", err)
+			if err := deleteOAuthTokenFunc(ctx, appID); err != nil {
+				fmt.Printf("Note: %v\n", err)
+			}
+			if err := deleteDCRClientFunc(ctx, appID); err != nil {
+				fmt.Printf("Note: %v\n", err)
+			}
+			cleanStaleDesktopEntriesFunc(ctx, app)
+			fmt.Printf("OAuth access revoked for %s\n", app)
+			return nil
+		}
 		return fmt.Errorf("failed to load DCR client for provider revocation: %w", err)
 	}
 	providerRevoked := false

--- a/cmd/docker-mcp/oauth/revoke.go
+++ b/cmd/docker-mcp/oauth/revoke.go
@@ -13,6 +13,11 @@ import (
 	"github.com/docker/mcp-gateway/pkg/workingset"
 )
 
+type ceRevokeManager interface {
+	RevokeToken(context.Context, string) error
+	DeleteDCRClient(string) error
+}
+
 // Function pointers for testability (same pattern as pkg/workingset/oauth.go).
 var (
 	revokeCEModeFunc        = revokeCEMode
@@ -26,6 +31,9 @@ var (
 	getCommunityDCRClientFunc = pkgoauth.GetDCRClientFromDockerPass
 	getCommunityTokenFunc     = pkgoauth.GetTokenFromDockerPass
 	revokeProviderTokenFunc   = pkgoauth.RevokeTokenAtProvider
+	newCERevokeManagerFunc    = func() ceRevokeManager {
+		return pkgoauth.NewManager(pkgoauth.NewReadWriteCredentialHelper())
+	}
 	desktopDeleteOAuthAppFunc = func(ctx context.Context, app string) error {
 		return desktop.NewAuthClient().DeleteOAuthApp(ctx, app)
 	}
@@ -84,8 +92,7 @@ func revokeDesktopMode(ctx context.Context, app string) error {
 // revokeCEMode handles revoke in standalone CE mode
 // Matches Desktop behavior: deletes both token and DCR client
 func revokeCEMode(ctx context.Context, app string) error {
-	credHelper := pkgoauth.NewReadWriteCredentialHelper()
-	manager := pkgoauth.NewManager(credHelper)
+	manager := newCERevokeManagerFunc()
 
 	// Revoke at the provider before deleting local credentials. If remote
 	// revocation fails, preserve both the token and DCR metadata for retry.
@@ -116,17 +123,27 @@ func revokeCommunityMode(ctx context.Context, app string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load DCR client for provider revocation: %w", err)
 	}
-	token, err := getCommunityTokenFunc(ctx, app)
-	if err != nil {
-		return fmt.Errorf("failed to load OAuth token for provider revocation: %w", err)
-	}
-	if err := revokeProviderTokenFunc(ctx, dcrClient, token); err != nil {
-		return fmt.Errorf("failed to revoke OAuth access: %w", err)
+	providerRevoked := false
+	if dcrClient.RevocationEndpoint != "" {
+		token, err := getCommunityTokenFunc(ctx, app)
+		if err != nil {
+			return fmt.Errorf("failed to load OAuth token for provider revocation: %w", err)
+		}
+		if err := revokeProviderTokenFunc(ctx, dcrClient, token); err != nil {
+			return fmt.Errorf("failed to revoke OAuth access: %w", err)
+		}
+		providerRevoked = true
+	} else {
+		fmt.Printf("Note: OAuth provider for %s does not advertise revocation; deleting local token only\n", app)
 	}
 
-	// Delete OAuth token from docker pass only after provider revocation.
+	// Delete the local token after provider revocation succeeds, or immediately
+	// when the provider does not support remote revocation.
 	if err := deleteOAuthTokenFunc(ctx, appID); err != nil {
-		return fmt.Errorf("provider token revoked but failed to delete local OAuth token: %w", err)
+		if providerRevoked {
+			return fmt.Errorf("provider token revoked but failed to delete local OAuth token: %w", err)
+		}
+		return fmt.Errorf("failed to delete local OAuth token: %w", err)
 	}
 
 	// Delete DCR client from docker pass (soft failure -- entry may not exist

--- a/cmd/docker-mcp/oauth/revoke_test.go
+++ b/cmd/docker-mcp/oauth/revoke_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -13,6 +14,19 @@ import (
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
+
+type stubCERevokeManager struct {
+	revokeErr         error
+	deleteDCRClientFn func(string) error
+}
+
+func (m *stubCERevokeManager) RevokeToken(_ context.Context, _ string) error {
+	return m.revokeErr
+}
+
+func (m *stubCERevokeManager) DeleteDCRClient(app string) error {
+	return m.deleteDCRClientFn(app)
+}
 
 // mockRevokeRouting overrides the function pointers so Revoke() does not
 // contact Docker Desktop, credential helpers, or the catalog. The returned
@@ -128,6 +142,27 @@ func TestRevoke_CEMode_CommunityServer(t *testing.T) {
 	assert.Equal(t, "ce", *called)
 }
 
+func TestRevokeCEMode_FailsHardWhenProviderRevocationFails(t *testing.T) {
+	oldNewManager := newCERevokeManagerFunc
+	t.Cleanup(func() { newCERevokeManagerFunc = oldNewManager })
+
+	deleteCalled := false
+	newCERevokeManagerFunc = func() ceRevokeManager {
+		return &stubCERevokeManager{
+			revokeErr: errors.New("provider unavailable"),
+			deleteDCRClientFn: func(_ string) error {
+				deleteCalled = true
+				return nil
+			},
+		}
+	}
+
+	err := revokeCEMode(t.Context(), "ce-server")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider unavailable")
+	assert.False(t, deleteCalled, "DCR client must be preserved when provider revocation fails")
+}
+
 // TestRevokeCommunityMode_CleansDesktopEntries verifies that the real
 // revokeCommunityMode function cleans up stale Desktop Secrets Engine
 // entries in addition to docker pass entries.
@@ -169,6 +204,47 @@ func TestRevokeCommunityMode_CleansDesktopEntries(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-community-server", desktopCleanupCalled,
 		"community revoke should clean stale Desktop entries")
+}
+
+func TestRevokeCommunityMode_DeletesLocalTokenWhenProviderDoesNotAdvertiseRevocation(t *testing.T) {
+	oldDesktopCleanup := cleanStaleDesktopEntriesFunc
+	oldDeleteToken := deleteOAuthTokenFunc
+	oldDeleteDCR := deleteDCRClientFunc
+	oldGetDCR := getCommunityDCRClientFunc
+	oldGetToken := getCommunityTokenFunc
+	oldRevokeProvider := revokeProviderTokenFunc
+	t.Cleanup(func() {
+		cleanStaleDesktopEntriesFunc = oldDesktopCleanup
+		deleteOAuthTokenFunc = oldDeleteToken
+		deleteDCRClientFunc = oldDeleteDCR
+		getCommunityDCRClientFunc = oldGetDCR
+		getCommunityTokenFunc = oldGetToken
+		revokeProviderTokenFunc = oldRevokeProvider
+	})
+
+	getCommunityDCRClientFunc = func(_ context.Context, app string) (dcr.Client, error) {
+		return dcr.Client{ServerName: app}, nil
+	}
+	providerCallMade := false
+	getCommunityTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		providerCallMade = true
+		return &oauth2.Token{}, nil
+	}
+	revokeProviderTokenFunc = func(_ context.Context, _ dcr.Client, _ *oauth2.Token) error {
+		providerCallMade = true
+		return nil
+	}
+	localDeleteCalled := false
+	deleteOAuthTokenFunc = func(_ context.Context, _ seclient.ID) error {
+		localDeleteCalled = true
+		return nil
+	}
+	deleteDCRClientFunc = func(_ context.Context, _ seclient.ID) error { return nil }
+	cleanStaleDesktopEntriesFunc = func(_ context.Context, _ string) {}
+
+	require.NoError(t, revokeCommunityMode(t.Context(), "my-community-server"))
+	assert.True(t, localDeleteCalled)
+	assert.False(t, providerCallMade)
 }
 
 func TestRevokeCommunityMode_PreservesLocalCredentialsWhenProviderRevokeFails(t *testing.T) {

--- a/cmd/docker-mcp/oauth/revoke_test.go
+++ b/cmd/docker-mcp/oauth/revoke_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/docker/mcp-gateway/cmd/docker-mcp/secret-management/secret"
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
@@ -290,6 +291,57 @@ func TestRevokeCommunityMode_PreservesLocalCredentialsWhenProviderRevokeFails(t 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "provider unavailable")
 	assert.False(t, localDeleteCalled, "local credentials must remain available for a safe retry")
+}
+
+func TestRevokeCommunityMode_MissingDCRClientIsIdempotent(t *testing.T) {
+	oldDesktopCleanup := cleanStaleDesktopEntriesFunc
+	oldDeleteToken := deleteOAuthTokenFunc
+	oldDeleteDCR := deleteDCRClientFunc
+	oldGetDCR := getCommunityDCRClientFunc
+	oldGetToken := getCommunityTokenFunc
+	oldRevokeProvider := revokeProviderTokenFunc
+	t.Cleanup(func() {
+		cleanStaleDesktopEntriesFunc = oldDesktopCleanup
+		deleteOAuthTokenFunc = oldDeleteToken
+		deleteDCRClientFunc = oldDeleteDCR
+		getCommunityDCRClientFunc = oldGetDCR
+		getCommunityTokenFunc = oldGetToken
+		revokeProviderTokenFunc = oldRevokeProvider
+	})
+
+	getCommunityDCRClientFunc = func(_ context.Context, app string) (dcr.Client, error) {
+		return dcr.Client{}, fmt.Errorf("DCR client not found for %s: %w", app, secret.ErrSecretNotFound)
+	}
+	providerCallMade := false
+	getCommunityTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		providerCallMade = true
+		return &oauth2.Token{}, nil
+	}
+	revokeProviderTokenFunc = func(_ context.Context, _ dcr.Client, _ *oauth2.Token) error {
+		providerCallMade = true
+		return nil
+	}
+
+	localTokenDeleteCalled := false
+	deleteOAuthTokenFunc = func(_ context.Context, _ seclient.ID) error {
+		localTokenDeleteCalled = true
+		return errors.New("local token not found")
+	}
+	localDCRDeleteCalled := false
+	deleteDCRClientFunc = func(_ context.Context, _ seclient.ID) error {
+		localDCRDeleteCalled = true
+		return errors.New("local DCR client not found")
+	}
+	desktopCleanupCalled := false
+	cleanStaleDesktopEntriesFunc = func(_ context.Context, _ string) {
+		desktopCleanupCalled = true
+	}
+
+	require.NoError(t, revokeCommunityMode(t.Context(), "never-authorized-server"))
+	assert.False(t, providerCallMade)
+	assert.True(t, localTokenDeleteCalled)
+	assert.True(t, localDCRDeleteCalled)
+	assert.True(t, desktopCleanupCalled)
 }
 
 // TestRevokeDesktopMode_CleansDockerPassEntries verifies that the real

--- a/cmd/docker-mcp/oauth/revoke_test.go
+++ b/cmd/docker-mcp/oauth/revoke_test.go
@@ -8,8 +8,10 @@ import (
 	seclient "github.com/docker/secrets-engine/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
+	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
 
 // mockRevokeRouting overrides the function pointers so Revoke() does not
@@ -134,15 +136,28 @@ func TestRevokeCommunityMode_CleansDesktopEntries(t *testing.T) {
 	oldDesktopCleanup := cleanStaleDesktopEntriesFunc
 	oldDeleteToken := deleteOAuthTokenFunc
 	oldDeleteDCR := deleteDCRClientFunc
+	oldGetDCR := getCommunityDCRClientFunc
+	oldGetToken := getCommunityTokenFunc
+	oldRevokeProvider := revokeProviderTokenFunc
 	t.Cleanup(func() {
 		cleanStaleDesktopEntriesFunc = oldDesktopCleanup
 		deleteOAuthTokenFunc = oldDeleteToken
 		deleteDCRClientFunc = oldDeleteDCR
+		getCommunityDCRClientFunc = oldGetDCR
+		getCommunityTokenFunc = oldGetToken
+		revokeProviderTokenFunc = oldRevokeProvider
 	})
 
 	// Mock the docker pass operations so the real handler doesn't shell out.
 	deleteOAuthTokenFunc = func(_ context.Context, _ seclient.ID) error { return nil }
 	deleteDCRClientFunc = func(_ context.Context, _ seclient.ID) error { return nil }
+	getCommunityDCRClientFunc = func(_ context.Context, app string) (dcr.Client, error) {
+		return dcr.Client{ServerName: app, RevocationEndpoint: "https://auth.example/revoke"}, nil
+	}
+	getCommunityTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		return &oauth2.Token{AccessToken: "access"}, nil
+	}
+	revokeProviderTokenFunc = func(_ context.Context, _ dcr.Client, _ *oauth2.Token) error { return nil }
 
 	var desktopCleanupCalled string
 	cleanStaleDesktopEntriesFunc = func(_ context.Context, app string) {
@@ -154,6 +169,51 @@ func TestRevokeCommunityMode_CleansDesktopEntries(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-community-server", desktopCleanupCalled,
 		"community revoke should clean stale Desktop entries")
+}
+
+func TestRevokeCommunityMode_PreservesLocalCredentialsWhenProviderRevokeFails(t *testing.T) {
+	oldDesktopCleanup := cleanStaleDesktopEntriesFunc
+	oldDeleteToken := deleteOAuthTokenFunc
+	oldDeleteDCR := deleteDCRClientFunc
+	oldGetDCR := getCommunityDCRClientFunc
+	oldGetToken := getCommunityTokenFunc
+	oldRevokeProvider := revokeProviderTokenFunc
+	t.Cleanup(func() {
+		cleanStaleDesktopEntriesFunc = oldDesktopCleanup
+		deleteOAuthTokenFunc = oldDeleteToken
+		deleteDCRClientFunc = oldDeleteDCR
+		getCommunityDCRClientFunc = oldGetDCR
+		getCommunityTokenFunc = oldGetToken
+		revokeProviderTokenFunc = oldRevokeProvider
+	})
+
+	getCommunityDCRClientFunc = func(_ context.Context, app string) (dcr.Client, error) {
+		return dcr.Client{ServerName: app, RevocationEndpoint: "https://auth.example/revoke"}, nil
+	}
+	getCommunityTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		return &oauth2.Token{AccessToken: "access"}, nil
+	}
+	revokeProviderTokenFunc = func(_ context.Context, _ dcr.Client, _ *oauth2.Token) error {
+		return fmt.Errorf("provider unavailable")
+	}
+
+	localDeleteCalled := false
+	deleteOAuthTokenFunc = func(_ context.Context, _ seclient.ID) error {
+		localDeleteCalled = true
+		return nil
+	}
+	deleteDCRClientFunc = func(_ context.Context, _ seclient.ID) error {
+		localDeleteCalled = true
+		return nil
+	}
+	cleanStaleDesktopEntriesFunc = func(_ context.Context, _ string) {
+		localDeleteCalled = true
+	}
+
+	err := revokeCommunityMode(t.Context(), "my-community-server")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider unavailable")
+	assert.False(t, localDeleteCalled, "local credentials must remain available for a safe retry")
 }
 
 // TestRevokeDesktopMode_CleansDockerPassEntries verifies that the real

--- a/docs/feature-specs/dynamic_servers.md
+++ b/docs/feature-specs/dynamic_servers.md
@@ -20,6 +20,12 @@ When enabled, the gateway adds five internal management tools to the available t
 
 **Note**: Dynamic tools are automatically disabled when using the `--servers` flag to explicitly specify which servers to run. This is because explicit server configuration indicates a manual mode where automatic server management tools are not needed.
 
+### Security boundary
+
+The registry is the gateway's current active set, not an authorization allowlist. When dynamic tools are enabled, `mcp-add` is intentionally allowed to activate another server from the configured catalog. Every activation is evaluated with the policy client's `load` action before the server is added.
+
+Deployments that require a fixed server allowlist should pass the allowed names with `--servers`, which disables dynamic tools. Deployments that keep dynamic tools enabled should use policy rules to restrict which catalog servers may be loaded.
+
 ## Available Tools
 
 ### 1. mcp-find

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -76,7 +76,7 @@ When clients query available capabilities:
 
 #### Tool Calls
 - **`mcp.tool.calls`** - Counter of tool invocations
-- **`mcp.tool.duration`** - Histogram of tool execution time (milliseconds)
+- **`mcp.tool.duration`** - Histogram of end-to-end tool call handling time, including validation and policy checks (milliseconds)
 - **`mcp.tool.errors`** - Counter of tool execution failures
 
 #### Prompt Operations

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -285,7 +285,7 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 				capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 					ServerName: serverName,
 					Tool:       &mcpTool,
-					Handler:    g.mcpToolHandler(tool),
+					Handler:    g.mcpToolHandler(serverName, tool),
 				})
 			}
 

--- a/pkg/gateway/clientpool.go
+++ b/pkg/gateway/clientpool.go
@@ -242,7 +242,7 @@ func (cp *clientPool) InvalidateOAuthClients(provider string) {
 	}
 }
 
-func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, params *mcp.CallToolParams) *mcp.CallToolResult {
 	args := cp.baseArgs(tool.Name)
 
 	// Attach the MCP servers to the same network as the gateway.
@@ -272,7 +272,7 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 					Text: fmt.Sprintf("validate volume for %s: %v", tool.Name, err),
 				}},
 				IsError: true,
-			}, nil
+			}
 		}
 
 		args = append(args, "-v", mount)
@@ -310,7 +310,7 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 				Text: string(out),
 			}},
 			IsError: true,
-		}, nil
+		}
 	}
 
 	return &mcp.CallToolResult{
@@ -318,7 +318,7 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 			Text: string(out),
 		}},
 		IsError: false,
-	}, nil
+	}
 }
 
 func (cp *clientPool) baseArgs(name string) []string {

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -54,13 +54,17 @@ func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolH
 			attribute.String("mcp.server.image", tool.Container.Image),
 		}
 		ctx, span := telemetry.StartToolCallSpan(ctx, req.Params.Name, spanAttrs...)
-		defer span.End()
-		telemetry.ToolCallCounter.Add(ctx, 1, metric.WithAttributes(
+		metricAttrs := []attribute.KeyValue{
 			attribute.String("mcp.server.name", serverName),
 			attribute.String("mcp.server.type", "docker"),
 			attribute.String("mcp.tool.name", req.Params.Name),
 			attribute.String("mcp.client.name", clientName),
-		))
+		}
+		defer func() {
+			telemetry.ToolCallDuration.Record(ctx, float64(time.Since(startTime).Milliseconds()), metric.WithAttributes(metricAttrs...))
+			span.End()
+		}()
+		telemetry.ToolCallCounter.Add(ctx, 1, metric.WithAttributes(metricAttrs...))
 
 		if g.policyClient != nil {
 			policyReq := g.configuration.policyRequest(serverName, tool.Name, policy.ActionInvoke)
@@ -94,12 +98,6 @@ func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolH
 			Arguments: args,
 		}
 		result := g.clientPool.runToolContainer(ctx, tool, params)
-		telemetry.ToolCallDuration.Record(ctx, float64(time.Since(startTime).Milliseconds()), metric.WithAttributes(
-			attribute.String("mcp.server.name", serverName),
-			attribute.String("mcp.server.type", "docker"),
-			attribute.String("mcp.tool.name", req.Params.Name),
-			attribute.String("mcp.client.name", clientName),
-		))
 		if result != nil && result.IsError {
 			telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
 			span.SetStatus(codes.Error, "Tool execution failed")

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -41,12 +41,47 @@ func inferServerTransportType(serverConfig *catalog.ServerConfig) string {
 	return "unknown"
 }
 
-func (g *Gateway) mcpToolHandler(tool catalog.Tool) mcp.ToolHandler {
+func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if g.policyClient != nil {
+			policyReq := g.configuration.policyRequest(serverName, tool.Name, policy.ActionInvoke)
+			decision, err := g.policyClient.Evaluate(ctx, policyReq)
+			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
+			submitAuditEvent(g.policyClient, event)
+			if err != nil {
+				telemetry.RecordToolError(ctx, nil, serverName, "docker", req.Params.Name)
+				return nil, fmt.Errorf("policy check failed for %s/%s: %w", serverName, tool.Name, err)
+			}
+			if !decision.Allowed {
+				return nil, fmt.Errorf("policy denied tool %s on server %s: %s", tool.Name, serverName, decision.Reason)
+			}
+		}
+
+		clientName := ""
+		if clientInfo := auditClientInfoFromSession(req.Session); clientInfo != nil {
+			clientName = clientInfo.Name
+		}
+		startTime := time.Now()
+		spanAttrs := []attribute.KeyValue{
+			attribute.String("mcp.server.name", serverName),
+			attribute.String("mcp.server.type", "docker"),
+			attribute.String("mcp.server.image", tool.Container.Image),
+		}
+		ctx, span := telemetry.StartToolCallSpan(ctx, req.Params.Name, spanAttrs...)
+		defer span.End()
+		telemetry.ToolCallCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("mcp.server.name", serverName),
+			attribute.String("mcp.server.type", "docker"),
+			attribute.String("mcp.tool.name", req.Params.Name),
+			attribute.String("mcp.client.name", clientName),
+		))
+
 		// Convert CallToolParamsRaw to CallToolParams
 		var args any
 		if len(req.Params.Arguments) > 0 {
 			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
+				span.SetStatus(codes.Error, "Failed to unmarshal arguments")
 				return nil, fmt.Errorf("failed to unmarshal arguments: %w", err)
 			}
 		}
@@ -55,7 +90,20 @@ func (g *Gateway) mcpToolHandler(tool catalog.Tool) mcp.ToolHandler {
 			Name:      req.Params.Name,
 			Arguments: args,
 		}
-		return g.clientPool.runToolContainer(ctx, tool, params)
+		result := g.clientPool.runToolContainer(ctx, tool, params)
+		telemetry.ToolCallDuration.Record(ctx, float64(time.Since(startTime).Milliseconds()), metric.WithAttributes(
+			attribute.String("mcp.server.name", serverName),
+			attribute.String("mcp.server.type", "docker"),
+			attribute.String("mcp.tool.name", req.Params.Name),
+			attribute.String("mcp.client.name", clientName),
+		))
+		if result != nil && result.IsError {
+			telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
+			span.SetStatus(codes.Error, "Tool execution failed")
+			return result, nil
+		}
+		span.SetStatus(codes.Ok, "")
+		return result, nil
 	}
 }
 

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -43,20 +43,6 @@ func inferServerTransportType(serverConfig *catalog.ServerConfig) string {
 
 func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		if g.policyClient != nil {
-			policyReq := g.configuration.policyRequest(serverName, tool.Name, policy.ActionInvoke)
-			decision, err := g.policyClient.Evaluate(ctx, policyReq)
-			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
-			submitAuditEvent(g.policyClient, event)
-			if err != nil {
-				telemetry.RecordToolError(ctx, nil, serverName, "docker", req.Params.Name)
-				return nil, fmt.Errorf("policy check failed for %s/%s: %w", serverName, tool.Name, err)
-			}
-			if !decision.Allowed {
-				return nil, fmt.Errorf("policy denied tool %s on server %s: %s", tool.Name, serverName, decision.Reason)
-			}
-		}
-
 		clientName := ""
 		if clientInfo := auditClientInfoFromSession(req.Session); clientInfo != nil {
 			clientName = clientInfo.Name
@@ -75,6 +61,23 @@ func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolH
 			attribute.String("mcp.tool.name", req.Params.Name),
 			attribute.String("mcp.client.name", clientName),
 		))
+
+		if g.policyClient != nil {
+			policyReq := g.configuration.policyRequest(serverName, tool.Name, policy.ActionInvoke)
+			decision, err := g.policyClient.Evaluate(ctx, policyReq)
+			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
+			submitAuditEvent(g.policyClient, event)
+			if err != nil {
+				telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
+				span.SetStatus(codes.Error, "Policy evaluation failed")
+				return nil, fmt.Errorf("policy check failed for %s/%s: %w", serverName, tool.Name, err)
+			}
+			if !decision.Allowed {
+				telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
+				span.SetStatus(codes.Error, "Policy denied tool call")
+				return nil, fmt.Errorf("policy denied tool %s on server %s: %s", tool.Name, serverName, decision.Reason)
+			}
+		}
 
 		// Convert CallToolParamsRaw to CallToolParams
 		var args any

--- a/pkg/gateway/handlers_telemetry_test.go
+++ b/pkg/gateway/handlers_telemetry_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -17,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/config"
+	"github.com/docker/mcp-gateway/pkg/policy"
 	"github.com/docker/mcp-gateway/pkg/telemetry"
 )
 
@@ -275,6 +278,33 @@ func TestTelemetryErrorRecording(t *testing.T) {
 		}
 	}
 	assert.True(t, foundErrorCounter, "Error counter not found")
+}
+
+func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
+	spanRecorder, _ := setupTestTelemetry(t)
+	policyClient := newMockPolicyClient()
+	policyClient.deny("poci-server", "dangerous-tool", policy.ActionInvoke, "blocked")
+	gateway := &Gateway{
+		policyClient: policyClient,
+		configuration: Configuration{
+			serverNames: []string{"poci-server"},
+			servers: map[string]catalog.Server{
+				"poci-server": {Type: "poci"},
+			},
+			tools: config.ToolsConfig{ServerTools: map[string][]string{}},
+		},
+	}
+	handler := gateway.mcpToolHandler("poci-server", catalog.Tool{Name: "dangerous-tool"})
+
+	_, err := handler(t.Context(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: "dangerous-tool"},
+	})
+	require.Error(t, err)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "mcp.tool.call", spans[0].Name())
+	assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
 }
 
 // TestHandlerInstrumentationIntegration is a placeholder for full integration test

--- a/pkg/gateway/handlers_telemetry_test.go
+++ b/pkg/gateway/handlers_telemetry_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -281,7 +282,7 @@ func TestTelemetryErrorRecording(t *testing.T) {
 }
 
 func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
-	spanRecorder, _ := setupTestTelemetry(t)
+	spanRecorder, metricReader := setupTestTelemetry(t)
 	policyClient := newMockPolicyClient()
 	policyClient.deny("poci-server", "dangerous-tool", policy.ActionInvoke, "blocked")
 	gateway := &Gateway{
@@ -305,6 +306,27 @@ func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
 	require.Len(t, spans, 1)
 	assert.Equal(t, "mcp.tool.call", spans[0].Name())
 	assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
+	assertToolDurationMetric(t, metricReader, "poci-server", "dangerous-tool")
+}
+
+func TestPOCIInvalidArgumentsRecordDuration(t *testing.T) {
+	spanRecorder, metricReader := setupTestTelemetry(t)
+	gateway := &Gateway{}
+	handler := gateway.mcpToolHandler("poci-server", catalog.Tool{Name: "malformed-tool"})
+
+	_, err := handler(t.Context(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "malformed-tool",
+			Arguments: json.RawMessage("{"),
+		},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to unmarshal arguments")
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
+	assertToolDurationMetric(t, metricReader, "poci-server", "malformed-tool")
 }
 
 // TestHandlerInstrumentationIntegration is a placeholder for full integration test
@@ -380,4 +402,27 @@ func assertMetricAttribute(t *testing.T, set attribute.Set, key string, expected
 	value, found := set.Value(attribute.Key(key))
 	assert.True(t, found, "Attribute %s not found", key)
 	assert.Equal(t, expectedValue, value.AsString())
+}
+
+func assertToolDurationMetric(t *testing.T, metricReader *sdkmetric.ManualReader, serverName, toolName string) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, metricReader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "mcp.tool.duration" {
+				continue
+			}
+			histogram, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok)
+			require.Len(t, histogram.DataPoints, 1)
+			assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
+			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.server.name", serverName)
+			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.server.type", "docker")
+			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.tool.name", toolName)
+			return
+		}
+	}
+	t.Fatal("Tool duration histogram not found")
 }

--- a/pkg/gateway/policy_test.go
+++ b/pkg/gateway/policy_test.go
@@ -265,6 +265,32 @@ func TestMcpServerToolHandler_PolicyEnforcement(t *testing.T) {
 	})
 }
 
+func TestPOCIToolHandler_PolicyEnforcement(t *testing.T) {
+	mock := newMockPolicyClient()
+	mock.deny("poci-server", "dangerous-tool", policy.ActionInvoke, "tool blocked by admin")
+
+	g := &Gateway{
+		policyClient: mock,
+		configuration: Configuration{
+			serverNames: []string{"poci-server"},
+			servers: map[string]catalog.Server{
+				"poci-server": {
+					Type:  "poci",
+					Tools: []catalog.Tool{{Name: "dangerous-tool"}},
+				},
+			},
+		},
+	}
+	handler := g.mcpToolHandler("poci-server", catalog.Tool{Name: "dangerous-tool"})
+	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "dangerous-tool"}}
+
+	result, err := handler(t.Context(), req)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "policy denied")
+	assert.Contains(t, err.Error(), "tool blocked by admin")
+}
+
 // =============================================================================
 // R3: McpExec Tests
 // =============================================================================

--- a/pkg/mcp/remote.go
+++ b/pkg/mcp/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	urlpkg "net/url"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -53,6 +54,10 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	}
 	if err := remoteurl.Validate(ctx, url); err != nil {
 		return fmt.Errorf("unsafe remote MCP URL for %s: %w", c.config.Name, err)
+	}
+	remoteOrigin, err := urlpkg.Parse(url)
+	if err != nil {
+		return fmt.Errorf("invalid remote MCP URL for %s: %w", c.config.Name, err)
 	}
 
 	// Secrets to env
@@ -114,7 +119,6 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 	}
 
 	var mcpTransport mcp.Transport
-	var err error
 
 	baseTransport := remoteurl.GuardDirectTransport()
 	if proxyDialer := desktop.DockerDesktopProxySocketDialer(ctx); proxyDialer != nil {
@@ -126,7 +130,9 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeParam
 		Transport: &headerRoundTripper{
 			base:    baseTransport,
 			headers: headers,
+			origin:  remoteOrigin,
 		},
+		CheckRedirect: sameOriginRedirectPolicy(remoteOrigin),
 	}
 
 	switch strings.ToLower(transport) {
@@ -220,9 +226,14 @@ func maskSecret(value string) string {
 type headerRoundTripper struct {
 	base    http.RoundTripper
 	headers map[string]string
+	origin  *urlpkg.URL
 }
 
 func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if h.origin != nil && !sameOrigin(h.origin, req.URL) {
+		return nil, fmt.Errorf("refusing to forward remote MCP request from %s to different origin %s", h.origin.Redacted(), req.URL.Redacted())
+	}
+
 	// Clone the request to avoid modifying the original
 	newReq := req.Clone(req.Context())
 	// Add custom headers
@@ -234,4 +245,34 @@ func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 		newReq.Header.Set(key, value)
 	}
 	return h.base.RoundTrip(newReq)
+}
+
+func sameOriginRedirectPolicy(origin *urlpkg.URL) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, _ []*http.Request) error {
+		if !sameOrigin(origin, req.URL) {
+			return fmt.Errorf("refusing cross-origin remote MCP redirect from %s to %s", origin.Redacted(), req.URL.Redacted())
+		}
+		return nil
+	}
+}
+
+func sameOrigin(a, b *urlpkg.URL) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(canonicalHost(a), canonicalHost(b))
+}
+
+func canonicalHost(u *urlpkg.URL) string {
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	return host + ":" + port
 }

--- a/pkg/mcp/remote_test.go
+++ b/pkg/mcp/remote_test.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -143,6 +145,53 @@ func TestHeaderRoundTripper_EmptyHeaders(t *testing.T) {
 	require.NotNil(t, capturedReq)
 	assert.Empty(t, capturedReq.Header.Get("Authorization"),
 		"no Authorization header when headers map is empty")
+}
+
+func TestHeaderRoundTripper_RejectsCrossOriginRequest(t *testing.T) {
+	origin, err := url.Parse("https://mcp.example.com/service")
+	require.NoError(t, err)
+
+	baseCalled := false
+	rt := &headerRoundTripper{
+		base: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			baseCalled = true
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+		headers: map[string]string{"Authorization": "Bearer secret"},
+		origin:  origin,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://attacker.example/steal", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different origin")
+	assert.False(t, baseCalled, "cross-origin request must be rejected before credentials can be attached")
+}
+
+func TestSameOriginRedirectPolicy(t *testing.T) {
+	origin, err := url.Parse("https://mcp.example.com/service")
+	require.NoError(t, err)
+	policy := sameOriginRedirectPolicy(origin)
+
+	t.Run("allows same origin and default port", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://mcp.example.com:443/redirected", nil)
+		require.NoError(t, err)
+		require.NoError(t, policy(req, nil))
+	})
+
+	for _, target := range []string{
+		"https://attacker.example/steal",
+		"http://mcp.example.com/steal",
+		"https://mcp.example.com:8443/steal",
+	} {
+		t.Run(fmt.Sprintf("rejects_%s", target), func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+			require.NoError(t, err)
+			require.Error(t, policy(req, nil))
+		})
+	}
 }
 
 func TestRemoteMCPClientRejectsUnsafeRemoteURL(t *testing.T) {

--- a/pkg/oauth/credhelper.go
+++ b/pkg/oauth/credhelper.go
@@ -96,9 +96,7 @@ func (h *CredentialHelper) getOAuthTokenCE(serverName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("no DCR client found for %s: %w", serverName, err)
 	}
-	credentialKey := fmt.Sprintf("%s/%s", client.AuthorizationEndpoint, client.ProviderName)
-
-	_, tokenSecret, err := h.credentialHelper.Get(credentialKey)
+	tokenSecret, err := getTokenCredential(h.credentialHelper, client)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			return "", fmt.Errorf("OAuth token not found for %s. Run 'docker mcp oauth authorize %s' to authenticate", serverName, serverName)
@@ -179,8 +177,7 @@ func (h *CredentialHelper) tokenExistsCE(serverID seclient.ID) (bool, error) {
 	if err != nil {
 		return false, nil // No DCR client = no token
 	}
-	credentialKey := fmt.Sprintf("%s/%s", client.AuthorizationEndpoint, client.ProviderName)
-	_, tokenSecret, err := h.credentialHelper.Get(credentialKey)
+	tokenSecret, err := getTokenCredential(h.credentialHelper, client)
 	if err != nil || tokenSecret == "" {
 		return false, nil
 	}
@@ -281,9 +278,7 @@ func (h *CredentialHelper) getTokenStatusCE(serverID seclient.ID) (TokenStatus, 
 	if err != nil {
 		return TokenStatus{Valid: false}, fmt.Errorf("no DCR client found for %s: %w", serverName, err)
 	}
-	credentialKey := fmt.Sprintf("%s/%s", client.AuthorizationEndpoint, client.ProviderName)
-
-	_, tokenSecret, err := h.credentialHelper.Get(credentialKey)
+	tokenSecret, err := getTokenCredential(h.credentialHelper, client)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			return TokenStatus{Valid: false}, fmt.Errorf("OAuth token not found for %s", serverName)

--- a/pkg/oauth/credhelper.go
+++ b/pkg/oauth/credhelper.go
@@ -96,7 +96,7 @@ func (h *CredentialHelper) getOAuthTokenCE(serverName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("no DCR client found for %s: %w", serverName, err)
 	}
-	tokenSecret, err := getTokenCredential(h.credentialHelper, client)
+	tokenSecret, err := getTokenCredential(h.credentialHelper, client, false)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			return "", fmt.Errorf("OAuth token not found for %s. Run 'docker mcp oauth authorize %s' to authenticate", serverName, serverName)
@@ -177,7 +177,7 @@ func (h *CredentialHelper) tokenExistsCE(serverID seclient.ID) (bool, error) {
 	if err != nil {
 		return false, nil // No DCR client = no token
 	}
-	tokenSecret, err := getTokenCredential(h.credentialHelper, client)
+	tokenSecret, err := getTokenCredential(h.credentialHelper, client, false)
 	if err != nil || tokenSecret == "" {
 		return false, nil
 	}
@@ -278,7 +278,7 @@ func (h *CredentialHelper) getTokenStatusCE(serverID seclient.ID) (TokenStatus, 
 	if err != nil {
 		return TokenStatus{Valid: false}, fmt.Errorf("no DCR client found for %s: %w", serverName, err)
 	}
-	tokenSecret, err := getTokenCredential(h.credentialHelper, client)
+	tokenSecret, err := getTokenCredential(h.credentialHelper, client, false)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			return TokenStatus{Valid: false}, fmt.Errorf("OAuth token not found for %s", serverName)

--- a/pkg/oauth/dcr/credentials.go
+++ b/pkg/oauth/dcr/credentials.go
@@ -21,18 +21,20 @@ const (
 // Client represents a dynamically registered OAuth client
 // Simplified from Pinata - removed State field (not needed for CE mode)
 type Client struct {
-	AuthorizationEndpoint string    `json:"authorizationEndpoint,omitempty"`
-	AuthorizationServer   string    `json:"authorizationServer,omitempty"`
-	ClientID              string    `json:"clientId,omitempty"`
-	ClientName            string    `json:"clientName,omitempty"`
-	ProviderName          string    `json:"providerName"`
-	RedirectURI           string    `json:"redirectUri,omitempty"`
-	RegisteredAt          time.Time `json:"registeredAt"`
-	RequiredScopes        []string  `json:"requiredScopes,omitempty"`
-	ResourceURL           string    `json:"resourceUrl,omitempty"`
-	ScopesSupported       []string  `json:"scopesSupported,omitempty"`
-	ServerName            string    `json:"serverName"`
-	TokenEndpoint         string    `json:"tokenEndpoint,omitempty"`
+	AuthorizationEndpoint                  string    `json:"authorizationEndpoint,omitempty"`
+	AuthorizationServer                    string    `json:"authorizationServer,omitempty"`
+	ClientID                               string    `json:"clientId,omitempty"`
+	ClientName                             string    `json:"clientName,omitempty"`
+	ProviderName                           string    `json:"providerName"`
+	RevocationEndpoint                     string    `json:"revocationEndpoint,omitempty"`
+	RevocationEndpointAuthMethodsSupported []string  `json:"revocationEndpointAuthMethodsSupported,omitempty"`
+	RedirectURI                            string    `json:"redirectUri,omitempty"`
+	RegisteredAt                           time.Time `json:"registeredAt"`
+	RequiredScopes                         []string  `json:"requiredScopes,omitempty"`
+	ResourceURL                            string    `json:"resourceUrl,omitempty"`
+	ScopesSupported                        []string  `json:"scopesSupported,omitempty"`
+	ServerName                             string    `json:"serverName"`
+	TokenEndpoint                          string    `json:"tokenEndpoint,omitempty"`
 }
 
 // Credentials provides storage for DCR client metadata via credential helper

--- a/pkg/oauth/dcr/manager.go
+++ b/pkg/oauth/dcr/manager.go
@@ -89,17 +89,20 @@ func DiscoverAndRegister(ctx context.Context, serverName string, scopes string, 
 	log.Logf("- Registration successful for: %s, clientID: %s", serverName, creds.ClientID)
 
 	return Client{
-		ServerName:            serverName,
-		ProviderName:          serverName, // For DCR, provider name = server name
-		ClientID:              creds.ClientID,
-		ClientName:            fmt.Sprintf("MCP Gateway - %s", serverName),
-		AuthorizationEndpoint: creds.AuthorizationEndpoint,
-		TokenEndpoint:         creds.TokenEndpoint,
-		ResourceURL:           creds.ServerURL,
-		RedirectURI:           redirectURI,
-		ScopesSupported:       discovery.ScopesSupported,
-		RequiredScopes:        discovery.Scopes,
-		RegisteredAt:          time.Now(),
+		ServerName:                             serverName,
+		ProviderName:                           serverName, // For DCR, provider name = server name
+		ClientID:                               creds.ClientID,
+		ClientName:                             fmt.Sprintf("MCP Gateway - %s", serverName),
+		AuthorizationEndpoint:                  creds.AuthorizationEndpoint,
+		AuthorizationServer:                    discovery.AuthorizationServer,
+		TokenEndpoint:                          creds.TokenEndpoint,
+		RevocationEndpoint:                     discovery.RevocationEndpoint,
+		RevocationEndpointAuthMethodsSupported: discovery.RevocationEndpointAuthMethodsSupported,
+		ResourceURL:                            creds.ServerURL,
+		RedirectURI:                            redirectURI,
+		ScopesSupported:                        discovery.ScopesSupported,
+		RequiredScopes:                         discovery.Scopes,
+		RegisteredAt:                           time.Now(),
 	}, nil
 }
 

--- a/pkg/oauth/dcr_registration.go
+++ b/pkg/oauth/dcr_registration.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	oauthhelpers "github.com/docker/mcp-gateway-oauth-helpers"
-
 	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	"github.com/docker/mcp-gateway/pkg/log"
@@ -21,13 +19,13 @@ type dcrRegistrationClient interface {
 
 // oauthProber abstracts OAuth discovery to enable testing.
 type oauthProber interface {
-	DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhelpers.Discovery, error)
+	DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthdiscovery.Discovery, error)
 }
 
 // defaultOAuthProber wraps the package-level function.
 type defaultOAuthProber struct{}
 
-func (defaultOAuthProber) DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhelpers.Discovery, error) {
+func (defaultOAuthProber) DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthdiscovery.Discovery, error) {
 	return oauthdiscovery.DiscoverOAuthRequirements(ctx, serverURL)
 }
 

--- a/pkg/oauth/dcr_registration_test.go
+++ b/pkg/oauth/dcr_registration_test.go
@@ -10,6 +10,7 @@ import (
 
 	oauthhelpers "github.com/docker/mcp-gateway-oauth-helpers"
 	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/oauthdiscovery"
 )
 
 // mockDCRClient implements dcrRegistrationClient for testing.
@@ -40,11 +41,11 @@ func (m *mockDCRClient) RegisterDCRClientPending(_ context.Context, app string, 
 
 // mockProber implements oauthProber for testing.
 type mockProber struct {
-	discovery *oauthhelpers.Discovery
+	discovery *oauthdiscovery.Discovery
 	err       error
 }
 
-func (m *mockProber) DiscoverOAuthRequirements(_ context.Context, _ string) (*oauthhelpers.Discovery, error) {
+func (m *mockProber) DiscoverOAuthRequirements(_ context.Context, _ string) (*oauthdiscovery.Discovery, error) {
 	return m.discovery, m.err
 }
 
@@ -62,7 +63,7 @@ func TestRegisterProviderForDynamicDiscovery_SkipsAlreadyRegistered(t *testing.T
 func TestRegisterProviderForDynamicDiscovery_RegistersWhenOAuthRequired(t *testing.T) {
 	client := newMockDCRClient()
 	prober := &mockProber{
-		discovery: &oauthhelpers.Discovery{RequiresOAuth: true},
+		discovery: &oauthdiscovery.Discovery{Discovery: oauthhelpers.Discovery{RequiresOAuth: true}},
 	}
 
 	err := registerProviderForDynamicDiscovery(t.Context(), "ai-kubit-mcp-server", "https://mcp.kubit.ai/mcp", client, prober)
@@ -76,7 +77,7 @@ func TestRegisterProviderForDynamicDiscovery_RegistersWhenOAuthRequired(t *testi
 func TestRegisterProviderForDynamicDiscovery_SkipsWhenNoOAuthRequired(t *testing.T) {
 	client := newMockDCRClient()
 	prober := &mockProber{
-		discovery: &oauthhelpers.Discovery{RequiresOAuth: false},
+		discovery: &oauthdiscovery.Discovery{Discovery: oauthhelpers.Discovery{RequiresOAuth: false}},
 	}
 
 	err := registerProviderForDynamicDiscovery(t.Context(), "my-server", "https://example.com/mcp", client, prober)

--- a/pkg/oauth/dockerpass.go
+++ b/pkg/oauth/dockerpass.go
@@ -244,7 +244,7 @@ func GetDCRClientFromDockerPass(ctx context.Context, serverName string) (dcr.Cli
 	}
 	env, err := secret.GetSecret(ctx, dcrID)
 	if errors.Is(err, secret.ErrSecretNotFound) {
-		return dcr.Client{}, fmt.Errorf("DCR client not found for %s", serverName)
+		return dcr.Client{}, fmt.Errorf("DCR client not found for %s: %w", serverName, secret.ErrSecretNotFound)
 	}
 	if err != nil {
 		return dcr.Client{}, fmt.Errorf("failed to query Secrets Engine for DCR client %s: %w", serverName, err)

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -28,6 +28,7 @@ func validateOutboundDCRClientEndpoints(ctx context.Context, client dcr.Client) 
 		rawURL string
 	}{
 		{name: "token endpoint", rawURL: client.TokenEndpoint},
+		{name: "revocation endpoint", rawURL: client.RevocationEndpoint},
 		{name: "resource URL", rawURL: client.ResourceURL},
 	} {
 		if endpoint.rawURL == "" {

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -184,12 +184,16 @@ func (m *Manager) RevokeToken(ctx context.Context, serverName string) error {
 		return fmt.Errorf("DCR client not found for %s: %w", serverName, err)
 	}
 
-	token, err := m.tokenStore.Retrieve(dcrClient)
-	if err != nil {
-		return err
-	}
-	if err := RevokeTokenAtProvider(ctx, dcrClient, token); err != nil {
-		return err
+	if dcrClient.RevocationEndpoint != "" {
+		token, err := m.tokenStore.Retrieve(dcrClient)
+		if err != nil {
+			return err
+		}
+		if err := RevokeTokenAtProvider(ctx, dcrClient, token); err != nil {
+			return err
+		}
+	} else {
+		log.Logf("- OAuth provider for %s does not advertise revocation; deleting local token only", serverName)
 	}
 	return m.tokenStore.Delete(dcrClient)
 }

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -178,12 +178,19 @@ func (m *Manager) ExchangeCode(ctx context.Context, code string, state string) e
 }
 
 // RevokeToken revokes an OAuth token for a server
-func (m *Manager) RevokeToken(_ context.Context, serverName string) error {
+func (m *Manager) RevokeToken(ctx context.Context, serverName string) error {
 	dcrClient, err := m.dcrManager.GetDCRClient(serverName)
 	if err != nil {
 		return fmt.Errorf("DCR client not found for %s: %w", serverName, err)
 	}
 
+	token, err := m.tokenStore.Retrieve(dcrClient)
+	if err != nil {
+		return err
+	}
+	if err := RevokeTokenAtProvider(ctx, dcrClient, token); err != nil {
+		return err
+	}
 	return m.tokenStore.Delete(dcrClient)
 }
 

--- a/pkg/oauth/revoke.go
+++ b/pkg/oauth/revoke.go
@@ -13,9 +13,17 @@ import (
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
 
-// RevokeTokenAtProvider invalidates the refresh and access tokens at the
-// provider before callers remove their local copy. Redirects are deliberately
-// not followed because the request body contains bearer credentials.
+// RevokeTokenAtProvider invalidates the provider-side refresh and access tokens
+// per RFC 7009 before the caller performs local cleanup.
+//
+// On any non-nil return, provider-side revocation was not confirmed; callers
+// must preserve the local token so the user can retry. Redirects are not
+// followed because the request body contains bearer credentials, and any 3xx
+// response is reported as an error by the status validation below.
+//
+// MCP Gateway registers public DCR clients with token_endpoint_auth_method=none
+// and stores no client secret, so revocation identifies the client with
+// client_id only; confidential-client authentication is not supported here.
 func RevokeTokenAtProvider(ctx context.Context, client dcr.Client, token *oauth2.Token) error {
 	if client.RevocationEndpoint == "" {
 		return fmt.Errorf("OAuth provider for %s does not advertise a revocation endpoint; local token was preserved", client.ServerName)
@@ -72,7 +80,7 @@ func RevokeTokenAtProvider(ctx context.Context, client dcr.Client, token *oauth2
 			return fmt.Errorf("revoking %s for %s: %w", item.hint, client.ServerName, err)
 		}
 		_ = resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 			return fmt.Errorf("revoking %s for %s: provider returned HTTP %d", item.hint, client.ServerName, resp.StatusCode)
 		}
 	}

--- a/pkg/oauth/revoke.go
+++ b/pkg/oauth/revoke.go
@@ -1,0 +1,81 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
+)
+
+// RevokeTokenAtProvider invalidates the refresh and access tokens at the
+// provider before callers remove their local copy. Redirects are deliberately
+// not followed because the request body contains bearer credentials.
+func RevokeTokenAtProvider(ctx context.Context, client dcr.Client, token *oauth2.Token) error {
+	if client.RevocationEndpoint == "" {
+		return fmt.Errorf("OAuth provider for %s does not advertise a revocation endpoint; local token was preserved", client.ServerName)
+	}
+	if token == nil {
+		return fmt.Errorf("OAuth token not found for %s", client.ServerName)
+	}
+	if err := validateOutboundDCRClientEndpoints(ctx, client); err != nil {
+		return err
+	}
+
+	requests := make([]struct {
+		token string
+		hint  string
+	}, 0, 2)
+	if token.RefreshToken != "" {
+		requests = append(requests, struct {
+			token string
+			hint  string
+		}{token: token.RefreshToken, hint: "refresh_token"})
+	}
+	if token.AccessToken != "" && token.AccessToken != token.RefreshToken {
+		requests = append(requests, struct {
+			token string
+			hint  string
+		}{token: token.AccessToken, hint: "access_token"})
+	}
+	if len(requests) == 0 {
+		return fmt.Errorf("OAuth token for %s contains no access or refresh token", client.ServerName)
+	}
+
+	httpClient := guardedOAuthHTTPClient(ctx, 30*time.Second)
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	for _, item := range requests {
+		form := url.Values{
+			"token":           {item.token},
+			"token_type_hint": {item.hint},
+		}
+		if client.ClientID != "" {
+			form.Set("client_id", client.ClientID)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, client.RevocationEndpoint, strings.NewReader(form.Encode()))
+		if err != nil {
+			return fmt.Errorf("creating %s revocation request for %s: %w", item.hint, client.ServerName, err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("revoking %s for %s: %w", item.hint, client.ServerName, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("revoking %s for %s: provider returned HTTP %d", item.hint, client.ServerName, resp.StatusCode)
+		}
+	}
+
+	return nil
+}

--- a/pkg/oauth/revoke_test.go
+++ b/pkg/oauth/revoke_test.go
@@ -32,7 +32,7 @@ func TestRevokeTokenAtProviderRevokesRefreshAndAccessTokens(t *testing.T) {
 		mu.Lock()
 		requests = append(requests, r.PostForm)
 		mu.Unlock()
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
 
@@ -77,7 +77,7 @@ func TestRevokeTokenAtProviderDoesNotFollowRedirects(t *testing.T) {
 	assert.False(t, redirectTargetCalled, "bearer credential must not be forwarded to a redirect target")
 }
 
-func TestManagerRevokePreservesLocalTokenWithoutProviderEndpoint(t *testing.T) {
+func TestManagerRevokeDeletesLocalTokenWithoutProviderEndpoint(t *testing.T) {
 	manager := setupTestManager(t)
 	serverName := "test-server"
 	setupTestDCRClient(t, manager, serverName)
@@ -86,11 +86,8 @@ func TestManagerRevokePreservesLocalTokenWithoutProviderEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, manager.tokenStore.Save(dcrClient, &oauth2.Token{AccessToken: "access-secret"}))
 
-	err = manager.RevokeToken(t.Context(), serverName)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not advertise a revocation endpoint")
-
-	token, retrieveErr := manager.tokenStore.Retrieve(dcrClient)
-	require.NoError(t, retrieveErr)
-	assert.Equal(t, "access-secret", token.AccessToken)
+	require.NoError(t, manager.RevokeToken(t.Context(), serverName))
+	_, retrieveErr := manager.tokenStore.Retrieve(dcrClient)
+	require.Error(t, retrieveErr)
+	assert.Contains(t, retrieveErr.Error(), "token not found")
 }

--- a/pkg/oauth/revoke_test.go
+++ b/pkg/oauth/revoke_test.go
@@ -1,0 +1,96 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
+)
+
+func TestRevokeTokenAtProviderRevokesRefreshAndAccessTokens(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	var (
+		mu       sync.Mutex
+		requests []url.Values
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse revocation form: %v", err)
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		requests = append(requests, r.PostForm)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := dcr.Client{
+		ServerName:         "test-server",
+		ClientID:           "public-client",
+		RevocationEndpoint: server.URL,
+	}
+	token := &oauth2.Token{AccessToken: "access-secret", RefreshToken: "refresh-secret"}
+
+	require.NoError(t, RevokeTokenAtProvider(t.Context(), client, token))
+	require.Len(t, requests, 2)
+	assert.Equal(t, "refresh-secret", requests[0].Get("token"))
+	assert.Equal(t, "refresh_token", requests[0].Get("token_type_hint"))
+	assert.Equal(t, "public-client", requests[0].Get("client_id"))
+	assert.Equal(t, "access-secret", requests[1].Get("token"))
+	assert.Equal(t, "access_token", requests[1].Get("token_type_hint"))
+}
+
+func TestRevokeTokenAtProviderDoesNotFollowRedirects(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	redirectTargetCalled := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetCalled = true
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	revocationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", redirectTarget.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(revocationServer.Close)
+
+	err := RevokeTokenAtProvider(t.Context(), dcr.Client{
+		ServerName:         "test-server",
+		ClientID:           "public-client",
+		RevocationEndpoint: revocationServer.URL,
+	}, &oauth2.Token{AccessToken: "access-secret"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 307")
+	assert.False(t, redirectTargetCalled, "bearer credential must not be forwarded to a redirect target")
+}
+
+func TestManagerRevokePreservesLocalTokenWithoutProviderEndpoint(t *testing.T) {
+	manager := setupTestManager(t)
+	serverName := "test-server"
+	setupTestDCRClient(t, manager, serverName)
+
+	dcrClient, err := manager.dcrManager.GetDCRClient(serverName)
+	require.NoError(t, err)
+	require.NoError(t, manager.tokenStore.Save(dcrClient, &oauth2.Token{AccessToken: "access-secret"}))
+
+	err = manager.RevokeToken(t.Context(), serverName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not advertise a revocation endpoint")
+
+	token, retrieveErr := manager.tokenStore.Retrieve(dcrClient)
+	require.NoError(t, retrieveErr)
+	assert.Equal(t, "access-secret", token.AccessToken)
+}

--- a/pkg/oauth/token_store.go
+++ b/pkg/oauth/token_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker-credential-helpers/credentials"
 	"golang.org/x/oauth2"
@@ -11,6 +12,53 @@ import (
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
+
+const tokenCredentialKeyPrefix = "https://oauth-token.mcp/v2/"
+
+func tokenCredentialKey(dcrClient dcr.Client) string {
+	endpoint := base64.RawURLEncoding.EncodeToString([]byte(dcrClient.AuthorizationEndpoint))
+	provider := base64.RawURLEncoding.EncodeToString([]byte(dcrClient.ProviderName))
+	return tokenCredentialKeyPrefix + endpoint + "/" + provider
+}
+
+func legacyTokenCredentialKey(dcrClient dcr.Client) string {
+	return fmt.Sprintf("%s/%s", dcrClient.AuthorizationEndpoint, dcrClient.ProviderName)
+}
+
+func canUseLegacyTokenCredentialKey(dcrClient dcr.Client) bool {
+	// A slash-bearing provider name can alias another provider's legacy key.
+	// Never read or delete the ambiguous legacy form for such names.
+	return !strings.Contains(dcrClient.ProviderName, "/")
+}
+
+func getTokenCredential(helper credentials.Helper, dcrClient dcr.Client) (string, error) {
+	key := tokenCredentialKey(dcrClient)
+	_, secret, err := helper.Get(key)
+	if err == nil {
+		return secret, nil
+	}
+	if !credentials.IsErrCredentialsNotFound(err) || !canUseLegacyTokenCredentialKey(dcrClient) {
+		return "", err
+	}
+
+	legacyKey := legacyTokenCredentialKey(dcrClient)
+	username, secret, err := helper.Get(legacyKey)
+	if err != nil {
+		return "", err
+	}
+
+	// Transparently migrate unambiguous legacy entries. Migration must finish
+	// before the token is returned so a slash-bearing provider cannot read the
+	// same legacy slot through an older ambiguous key path in this process.
+	if err := helper.Add(&credentials.Credentials{ServerURL: key, Username: username, Secret: secret}); err != nil {
+		return "", fmt.Errorf("migrating OAuth token credential: %w", err)
+	}
+	if err := helper.Delete(legacyKey); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+		return "", fmt.Errorf("removing legacy OAuth token credential after migration: %w", err)
+	}
+	log.Logf("- Migrated OAuth token credential for %s to collision-resistant storage", dcrClient.ServerName)
+	return secret, nil
+}
 
 // TokenStore provides storage for OAuth tokens via credential helper
 type TokenStore struct {
@@ -25,7 +73,7 @@ func NewTokenStore(credentialHelper credentials.Helper) *TokenStore {
 }
 
 // Save stores an OAuth token in the credential helper
-// Key format: {authorizationEndpoint}/{providerName}
+// Key format: versioned base64url-encoded endpoint and provider components.
 func (t *TokenStore) Save(dcrClient dcr.Client, token *oauth2.Token) error {
 	// Marshal token to JSON
 	tokenJSON, err := json.Marshal(token)
@@ -36,8 +84,7 @@ func (t *TokenStore) Save(dcrClient dcr.Client, token *oauth2.Token) error {
 	// Base64 encode
 	encoded := base64.StdEncoding.EncodeToString(tokenJSON)
 
-	// Credential key format: {authorizationEndpoint}/{providerName}
-	key := fmt.Sprintf("%s/%s", dcrClient.AuthorizationEndpoint, dcrClient.ProviderName)
+	key := tokenCredentialKey(dcrClient)
 
 	cred := &credentials.Credentials{
 		ServerURL: key,
@@ -48,6 +95,11 @@ func (t *TokenStore) Save(dcrClient dcr.Client, token *oauth2.Token) error {
 	if err := t.credentialHelper.Add(cred); err != nil {
 		return fmt.Errorf("storing token for %s: %w", dcrClient.ServerName, err)
 	}
+	if canUseLegacyTokenCredentialKey(dcrClient) {
+		if err := t.credentialHelper.Delete(legacyTokenCredentialKey(dcrClient)); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			return fmt.Errorf("removing legacy token for %s after storing collision-resistant credential: %w", dcrClient.ServerName, err)
+		}
+	}
 
 	log.Logf("- Stored OAuth token for %s", dcrClient.ServerName)
 	return nil
@@ -55,10 +107,7 @@ func (t *TokenStore) Save(dcrClient dcr.Client, token *oauth2.Token) error {
 
 // Retrieve retrieves an OAuth token from the credential helper
 func (t *TokenStore) Retrieve(dcrClient dcr.Client) (*oauth2.Token, error) {
-	// Credential key format: {authorizationEndpoint}/{providerName}
-	key := fmt.Sprintf("%s/%s", dcrClient.AuthorizationEndpoint, dcrClient.ProviderName)
-
-	_, encoded, err := t.credentialHelper.Get(key)
+	encoded, err := getTokenCredential(t.credentialHelper, dcrClient)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			return nil, fmt.Errorf("token not found for %s", dcrClient.ServerName)
@@ -83,10 +132,23 @@ func (t *TokenStore) Retrieve(dcrClient dcr.Client) (*oauth2.Token, error) {
 
 // Delete removes an OAuth token from the credential helper
 func (t *TokenStore) Delete(dcrClient dcr.Client) error {
-	key := fmt.Sprintf("%s/%s", dcrClient.AuthorizationEndpoint, dcrClient.ProviderName)
+	keys := []string{tokenCredentialKey(dcrClient)}
+	if canUseLegacyTokenCredentialKey(dcrClient) {
+		keys = append(keys, legacyTokenCredentialKey(dcrClient))
+	}
 
-	if err := t.credentialHelper.Delete(key); err != nil {
-		return fmt.Errorf("deleting token for %s: %w", dcrClient.ServerName, err)
+	deleted := false
+	for _, key := range keys {
+		if err := t.credentialHelper.Delete(key); err != nil {
+			if credentials.IsErrCredentialsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("deleting token for %s: %w", dcrClient.ServerName, err)
+		}
+		deleted = true
+	}
+	if !deleted {
+		return fmt.Errorf("deleting token for %s: %w", dcrClient.ServerName, credentials.NewErrCredentialsNotFound())
 	}
 
 	log.Logf("- Deleted OAuth token for %s", dcrClient.ServerName)

--- a/pkg/oauth/token_store.go
+++ b/pkg/oauth/token_store.go
@@ -31,7 +31,7 @@ func canUseLegacyTokenCredentialKey(dcrClient dcr.Client) bool {
 	return !strings.Contains(dcrClient.ProviderName, "/")
 }
 
-func getTokenCredential(helper credentials.Helper, dcrClient dcr.Client) (string, error) {
+func getTokenCredential(helper credentials.Helper, dcrClient dcr.Client, migrateLegacy bool) (string, error) {
 	key := tokenCredentialKey(dcrClient)
 	_, secret, err := helper.Get(key)
 	if err == nil {
@@ -45,6 +45,9 @@ func getTokenCredential(helper credentials.Helper, dcrClient dcr.Client) (string
 	username, secret, err := helper.Get(legacyKey)
 	if err != nil {
 		return "", err
+	}
+	if !migrateLegacy {
+		return secret, nil
 	}
 
 	// Transparently migrate unambiguous legacy entries. Migration must finish
@@ -107,7 +110,7 @@ func (t *TokenStore) Save(dcrClient dcr.Client, token *oauth2.Token) error {
 
 // Retrieve retrieves an OAuth token from the credential helper
 func (t *TokenStore) Retrieve(dcrClient dcr.Client) (*oauth2.Token, error) {
-	encoded, err := getTokenCredential(t.credentialHelper, dcrClient)
+	encoded, err := getTokenCredential(t.credentialHelper, dcrClient, true)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			return nil, fmt.Errorf("token not found for %s", dcrClient.ServerName)

--- a/pkg/oauth/token_store_test.go
+++ b/pkg/oauth/token_store_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/docker/docker-credential-helpers/credentials"
@@ -12,6 +13,18 @@ import (
 
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
+
+type readOnlyCredentialHelper struct {
+	credentials.Helper
+}
+
+func (readOnlyCredentialHelper) Add(_ *credentials.Credentials) error {
+	return errors.New("credential helper is read-only")
+}
+
+func (readOnlyCredentialHelper) Delete(_ string) error {
+	return errors.New("credential helper is read-only")
+}
 
 func TestTokenCredentialKeySeparatesEndpointAndProvider(t *testing.T) {
 	victim := dcr.Client{
@@ -72,6 +85,26 @@ func TestTokenStoreMigratesUnambiguousLegacyKey(t *testing.T) {
 	assert.Equal(t, token.AccessToken, retrieved.AccessToken)
 	assert.Contains(t, helper.store, tokenCredentialKey(client))
 	assert.NotContains(t, helper.store, legacyTokenCredentialKey(client))
+}
+
+func TestGetTokenCredentialReadsLegacyKeyWithoutMigratingThroughReadOnlyHelper(t *testing.T) {
+	helper := newFakeCredentialHelper()
+	client := dcr.Client{
+		ServerName:            "victim",
+		ProviderName:          "victim",
+		AuthorizationEndpoint: "https://auth.example/oauth",
+	}
+	require.NoError(t, helper.Add(&credentials.Credentials{
+		ServerURL: legacyTokenCredentialKey(client),
+		Username:  "oauth2_victim",
+		Secret:    "legacy-token",
+	}))
+
+	secret, err := getTokenCredential(readOnlyCredentialHelper{Helper: helper}, client, false)
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-token", secret)
+	assert.Contains(t, helper.store, legacyTokenCredentialKey(client))
+	assert.NotContains(t, helper.store, tokenCredentialKey(client))
 }
 
 func TestTokenStoreRoundTripWithSlashBearingProvider(t *testing.T) {

--- a/pkg/oauth/token_store_test.go
+++ b/pkg/oauth/token_store_test.go
@@ -1,0 +1,111 @@
+package oauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
+)
+
+func TestTokenCredentialKeySeparatesEndpointAndProvider(t *testing.T) {
+	victim := dcr.Client{
+		AuthorizationEndpoint: "https://auth.example/oauth",
+		ProviderName:          "victim",
+	}
+	attacker := dcr.Client{
+		AuthorizationEndpoint: "https://auth.example",
+		ProviderName:          "oauth/victim",
+	}
+
+	require.Equal(t, legacyTokenCredentialKey(victim), legacyTokenCredentialKey(attacker), "test setup must reproduce the legacy collision")
+	assert.NotEqual(t, tokenCredentialKey(victim), tokenCredentialKey(attacker))
+}
+
+func TestTokenStoreDoesNotReadAmbiguousLegacyKey(t *testing.T) {
+	helper := newFakeCredentialHelper()
+	store := NewTokenStore(helper)
+	victimToken := &oauth2.Token{AccessToken: "victim-secret", RefreshToken: "victim-refresh"}
+	tokenJSON, err := json.Marshal(victimToken)
+	require.NoError(t, err)
+
+	attacker := dcr.Client{
+		ServerName:            "oauth/victim",
+		ProviderName:          "oauth/victim",
+		AuthorizationEndpoint: "https://auth.example",
+	}
+	require.NoError(t, helper.Add(&credentials.Credentials{
+		ServerURL: legacyTokenCredentialKey(attacker),
+		Username:  "oauth2_victim",
+		Secret:    base64.StdEncoding.EncodeToString(tokenJSON),
+	}))
+
+	_, err = store.Retrieve(attacker)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token not found")
+}
+
+func TestTokenStoreMigratesUnambiguousLegacyKey(t *testing.T) {
+	helper := newFakeCredentialHelper()
+	store := NewTokenStore(helper)
+	client := dcr.Client{
+		ServerName:            "victim",
+		ProviderName:          "victim",
+		AuthorizationEndpoint: "https://auth.example/oauth",
+	}
+	token := &oauth2.Token{AccessToken: "access", RefreshToken: "refresh"}
+	tokenJSON, err := json.Marshal(token)
+	require.NoError(t, err)
+	require.NoError(t, helper.Add(&credentials.Credentials{
+		ServerURL: legacyTokenCredentialKey(client),
+		Username:  "oauth2_victim",
+		Secret:    base64.StdEncoding.EncodeToString(tokenJSON),
+	}))
+
+	retrieved, err := store.Retrieve(client)
+	require.NoError(t, err)
+	assert.Equal(t, token.AccessToken, retrieved.AccessToken)
+	assert.Contains(t, helper.store, tokenCredentialKey(client))
+	assert.NotContains(t, helper.store, legacyTokenCredentialKey(client))
+}
+
+func TestTokenStoreRoundTripWithSlashBearingProvider(t *testing.T) {
+	helper := newFakeCredentialHelper()
+	store := NewTokenStore(helper)
+	client := dcr.Client{
+		ServerName:            "team/provider",
+		ProviderName:          "team/provider",
+		AuthorizationEndpoint: "https://auth.example/oauth",
+	}
+	token := &oauth2.Token{AccessToken: "access", RefreshToken: "refresh"}
+
+	require.NoError(t, store.Save(client, token))
+	retrieved, err := store.Retrieve(client)
+	require.NoError(t, err)
+	assert.Equal(t, token.AccessToken, retrieved.AccessToken)
+	assert.Equal(t, token.RefreshToken, retrieved.RefreshToken)
+}
+
+func TestTokenStoreSaveRemovesUnambiguousLegacyKey(t *testing.T) {
+	helper := newFakeCredentialHelper()
+	store := NewTokenStore(helper)
+	client := dcr.Client{
+		ServerName:            "victim",
+		ProviderName:          "victim",
+		AuthorizationEndpoint: "https://auth.example/oauth",
+	}
+	require.NoError(t, helper.Add(&credentials.Credentials{
+		ServerURL: legacyTokenCredentialKey(client),
+		Username:  "oauth2_victim",
+		Secret:    "stale-token",
+	}))
+
+	require.NoError(t, store.Save(client, &oauth2.Token{AccessToken: "fresh-access"}))
+	assert.Contains(t, helper.store, tokenCredentialKey(client))
+	assert.NotContains(t, helper.store, legacyTokenCredentialKey(client))
+}

--- a/pkg/oauthdiscovery/discovery.go
+++ b/pkg/oauthdiscovery/discovery.go
@@ -18,7 +18,22 @@ import (
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
-func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhelpers.Discovery, error) {
+// Discovery contains the standard OAuth discovery result plus metadata used
+// for secure token lifecycle operations that is not represented by the
+// oauth-helpers v0.0.3 Discovery type.
+type Discovery struct {
+	oauthhelpers.Discovery
+	RevocationEndpoint                     string
+	RevocationEndpointAuthMethodsSupported []string
+}
+
+type authorizationServerMetadata struct {
+	oauthhelpers.AuthorizationServerMetadata
+	RevocationEndpoint                     string   `json:"revocation_endpoint,omitempty"`
+	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported,omitempty"`
+}
+
+func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discovery, error) {
 	if err := remoteurl.Validate(ctx, serverURL); err != nil {
 		return nil, err
 	}
@@ -82,25 +97,29 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhel
 		return nil, fmt.Errorf("fetching authorization server metadata from %s: %w", authServerURL, err)
 	}
 
-	discovery := &oauthhelpers.Discovery{
-		RequiresOAuth: true,
+	discovery := &Discovery{
+		Discovery: oauthhelpers.Discovery{
+			RequiresOAuth: true,
 
-		ResourceURL:         defaultAuthServerURL,
-		ResourceServer:      defaultAuthServerURL,
-		AuthorizationServer: authServerURL,
+			ResourceURL:         defaultAuthServerURL,
+			ResourceServer:      defaultAuthServerURL,
+			AuthorizationServer: authServerURL,
 
-		Issuer:                            authServerMetadata.Issuer,
-		AuthorizationEndpoint:             authServerMetadata.AuthorizationEndpoint,
-		TokenEndpoint:                     authServerMetadata.TokenEndpoint,
-		RegistrationEndpoint:              authServerMetadata.RegistrationEndpoint,
-		JWKSUri:                           authServerMetadata.JWKSUri,
-		ScopesSupported:                   authServerMetadata.ScopesSupported,
-		ResponseTypesSupported:            authServerMetadata.ResponseTypesSupported,
-		ResponseModesSupported:            authServerMetadata.ResponseModesSupported,
-		GrantTypesSupported:               authServerMetadata.GrantTypesSupported,
-		TokenEndpointAuthMethodsSupported: authServerMetadata.TokenEndpointAuthMethodsSupported,
-		SupportsPKCE:                      slices.Contains(authServerMetadata.CodeChallengeMethodsSupported, "S256"),
-		CodeChallengeMethod:               authServerMetadata.CodeChallengeMethodsSupported,
+			Issuer:                            authServerMetadata.Issuer,
+			AuthorizationEndpoint:             authServerMetadata.AuthorizationEndpoint,
+			TokenEndpoint:                     authServerMetadata.TokenEndpoint,
+			RegistrationEndpoint:              authServerMetadata.RegistrationEndpoint,
+			JWKSUri:                           authServerMetadata.JWKSUri,
+			ScopesSupported:                   authServerMetadata.ScopesSupported,
+			ResponseTypesSupported:            authServerMetadata.ResponseTypesSupported,
+			ResponseModesSupported:            authServerMetadata.ResponseModesSupported,
+			GrantTypesSupported:               authServerMetadata.GrantTypesSupported,
+			TokenEndpointAuthMethodsSupported: authServerMetadata.TokenEndpointAuthMethodsSupported,
+			SupportsPKCE:                      slices.Contains(authServerMetadata.CodeChallengeMethodsSupported, "S256"),
+			CodeChallengeMethod:               authServerMetadata.CodeChallengeMethodsSupported,
+		},
+		RevocationEndpoint:                     authServerMetadata.RevocationEndpoint,
+		RevocationEndpointAuthMethodsSupported: authServerMetadata.RevocationEndpointAuthMethodsSupported,
 	}
 
 	if resourceMetadata != nil {
@@ -122,7 +141,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*oauthhel
 	return discovery, nil
 }
 
-func ValidateDiscovery(ctx context.Context, discovery *oauthhelpers.Discovery) error {
+func ValidateDiscovery(ctx context.Context, discovery *Discovery) error {
 	if discovery == nil {
 		return fmt.Errorf("OAuth discovery result is empty")
 	}
@@ -137,6 +156,7 @@ func ValidateDiscovery(ctx context.Context, discovery *oauthhelpers.Discovery) e
 		{name: "authorization endpoint", rawURL: discovery.AuthorizationEndpoint},
 		{name: "token endpoint", rawURL: discovery.TokenEndpoint},
 		{name: "registration endpoint", rawURL: discovery.RegistrationEndpoint},
+		{name: "revocation endpoint", rawURL: discovery.RevocationEndpoint},
 	} {
 		if endpoint.rawURL == "" {
 			continue
@@ -149,7 +169,7 @@ func ValidateDiscovery(ctx context.Context, discovery *oauthhelpers.Discovery) e
 	return nil
 }
 
-func PerformDCR(ctx context.Context, discovery *oauthhelpers.Discovery, serverName string, redirectURI string) (*oauthhelpers.ClientCredentials, error) {
+func PerformDCR(ctx context.Context, discovery *Discovery, serverName string, redirectURI string) (*oauthhelpers.ClientCredentials, error) {
 	if discovery == nil || discovery.RegistrationEndpoint == "" {
 		return nil, fmt.Errorf("no registration endpoint found for %s", serverName)
 	}
@@ -275,7 +295,7 @@ func fetchOAuthProtectedResourceMetadata(ctx context.Context, client *http.Clien
 	return &metadata, nil
 }
 
-func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerURL string) (*oauthhelpers.AuthorizationServerMetadata, error) {
+func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerURL string) (*authorizationServerMetadata, error) {
 	metadataURL, err := buildRFC8414WellKnownURL(ctx, authServerURL)
 	if err != nil {
 		return nil, fmt.Errorf("building well-known URL: %w", err)
@@ -302,12 +322,15 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
 
-	var metadata oauthhelpers.AuthorizationServerMetadata
+	var metadata authorizationServerMetadata
 	if err := json.Unmarshal(body, &metadata); err != nil {
 		return nil, fmt.Errorf("parsing JSON response: %w", err)
 	}
 	if metadata.Issuer == "" {
 		return nil, fmt.Errorf("issuer field missing in authorization server metadata")
+	}
+	if err := validateAuthorizationServerIssuer(authServerURL, metadata.Issuer); err != nil {
+		return nil, err
 	}
 	if metadata.AuthorizationEndpoint == "" {
 		return nil, fmt.Errorf("authorization_endpoint field missing in authorization server metadata")
@@ -320,6 +343,13 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 	}
 
 	return &metadata, nil
+}
+
+func validateAuthorizationServerIssuer(expected, actual string) error {
+	if actual != expected {
+		return fmt.Errorf("authorization server metadata issuer %q does not match requested issuer %q", actual, expected)
+	}
+	return nil
 }
 
 func buildRFC8414WellKnownURL(ctx context.Context, issuerURL string) (string, error) {

--- a/pkg/oauthdiscovery/discovery_test.go
+++ b/pkg/oauthdiscovery/discovery_test.go
@@ -31,3 +31,20 @@ func TestBuildRFC8414WellKnownURLAllowsPublicHTTPSIssuer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://8.8.8.8/.well-known/oauth-authorization-server/oauth", metadataURL)
 }
+
+func TestValidateAuthorizationServerIssuer(t *testing.T) {
+	require.NoError(t, validateAuthorizationServerIssuer(
+		"https://auth.example.com/tenant",
+		"https://auth.example.com/tenant",
+	))
+
+	for _, issuer := range []string{
+		"https://attacker.example/tenant",
+		"https://auth.example.com/other-tenant",
+		"https://auth.example.com/tenant/",
+	} {
+		err := validateAuthorizationServerIssuer("https://auth.example.com/tenant", issuer)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match requested issuer")
+	}
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -116,7 +116,7 @@ func Init() {
 	}
 
 	ToolCallDuration, err = meter.Float64Histogram("mcp.tool.duration",
-		metric.WithDescription("Duration of tool call execution"),
+		metric.WithDescription("Duration of tool call handling, including validation and policy checks"),
 		metric.WithUnit("ms"))
 	if err != nil {
 		// Log error but don't fail


### PR DESCRIPTION
## Summary

This PR closes a group of security gaps across the OAuth lifecycle, remote MCP credential forwarding, and tool invocation policy. The main behavioral change is that revoking an OAuth connection now attempts RFC 7009 revocation at the authorization server before deleting the local credential, so a locally removed token is not left active at the provider.

It also binds credentials and OAuth metadata to the identity that was originally configured: remote HTTP headers cannot cross an origin boundary, credential-helper keys cannot alias through path-like provider names, and authorization-server metadata must identify the exact issuer that was requested.

## Why

The previous behavior had several independent weaknesses:

- OAuth revoke removed the local credential without invalidating refresh and access tokens at providers that support revocation.
- Configured headers, including bearer credentials, could follow a redirect to a different scheme, host, or port.
- OAuth credential keys were built by concatenating unescaped endpoint and provider strings, allowing different identities to map to the same legacy key.
- Authorization-server metadata was accepted without verifying that its `issuer` exactly matched the requested authorization server.
- POCI/container tools did not consistently pass through invoke policy, audit emission, and the standard tool telemetry path.
- The dynamic-server registry could be mistaken for an authorization allowlist even though it represents the active working set.

## What changed

### Provider-aware OAuth revocation

- Discover and retain `revocation_endpoint` metadata through DCR and token refresh.
- Revoke the refresh token first and then a distinct access token, including `token_type_hint` and the public `client_id`.
- Accept any successful 2xx provider response.
- Never follow redirects while sending bearer tokens.
- Preserve the local token and DCR metadata when provider revocation fails so the operation can be retried.
- When the provider does not advertise revocation support, emit an explicit note and perform local cleanup.
- If no community DCR registration exists, treat revoke as idempotent: skip provider calls, attempt token/DCR and stale Desktop cleanup best-effort, and return success. Other DCR lookup failures remain errors.

### OAuth identity and credential storage

- Require the authorization-server metadata `issuer` to exactly match the requested issuer.
- Validate all discovered OAuth endpoints before use.
- Store tokens under a versioned key whose authorization-endpoint and provider components are independently base64url encoded.
- Transparently migrate unambiguous legacy entries.
- Never read or delete an ambiguous legacy key for provider names containing `/`.

### Remote MCP credential forwarding

- Bind configured and OAuth-derived headers to the original URL origin.
- Reject cross-origin requests before attaching credentials.
- Allow same-origin redirects, including equivalent default ports.
- Reject redirects that change the scheme, host, or effective port.

### Tool policy and observability

- Apply `invoke` policy evaluation to POCI/container tool calls.
- Emit the standard audit event for allowed, denied, and failed policy evaluations.
- Record the existing tool-call counter, duration, error metric, and trace status for every POCI path, including policy errors/denials, argument decoding failures, and container results.
- Document that the dynamic registry is an active set, not an authorization boundary. Deployments that require a fixed allowlist should use `--servers`; deployments using dynamic tools should enforce catalog activation with policy.

## Manual testing

### 1. Build the branch

```console
make docker-mcp
./dist/docker-mcp --help
```

Expected: the plugin builds successfully and the standalone help command exits successfully.

### 2. Verify successful provider revocation

Prerequisite: configure `<server>` against an OAuth test provider that advertises an RFC 7009 `revocation_endpoint`, issues distinct refresh and access tokens, and records incoming requests.

```console
./dist/docker-mcp oauth authorize <server> --open-browser
./dist/docker-mcp oauth revoke <server>
```

Expected:

- the provider records a POST for the refresh token with `token_type_hint=refresh_token`;
- it then records a POST for the distinct access token with `token_type_hint=access_token`;
- both requests contain the registered public `client_id`;
- no redirect is followed;
- the command prints `OAuth access revoked for <server>`;
- the next use of the server requires authorization again.

### 3. Verify fail-closed cleanup and retry

1. Configure the test provider's revocation endpoint to return HTTP 500.
2. Authorize `<server>`.
3. Run:

```console
./dist/docker-mcp oauth revoke <server>
```

Expected: the command exits non-zero with a provider-revocation error, and the existing local token/DCR entry remains usable for a retry.

4. Change the endpoint to return HTTP 204 and rerun the same command.

Expected: provider revocation succeeds and local OAuth state is removed.

### 4. Verify a provider without revocation support

1. Remove `revocation_endpoint` from the provider metadata.
2. Authorize and revoke `<server>`.

Expected: the command prints a note that the provider does not advertise revocation, deletes the local token, and completes successfully.

### 5. Verify idempotent revoke before authorization

1. Choose a community server that has never been authorized and confirm it has no local token or DCR entry.
2. Run:

```console
./dist/docker-mcp oauth revoke <never-authorized-server>
```

Expected: no provider endpoint is called; missing local token/DCR deletions are reported only as notes; stale Desktop cleanup is attempted; the command prints `OAuth access revoked for <never-authorized-server>` and exits successfully. A non-not-found DCR lookup failure should still exit non-zero.

### 6. Verify issuer binding

1. Configure the requested authorization server as `https://auth.example.test/issuer-a`.
2. Return metadata whose `issuer` is `https://auth.example.test/issuer-b`.
3. Start authorization.

Expected: discovery fails with an issuer-mismatch error before DCR or token exchange. Restoring the exact requested issuer allows authorization to proceed.

### 7. Verify redirect credential isolation

1. Configure a remote MCP test server at origin A with an `Authorization` or custom secret header.
2. Have origin A redirect the MCP request to origin B, where B differs by scheme, host, or effective port.
3. Run the gateway:

```console
./dist/docker-mcp gateway run --servers <server> --verbose
```

4. Invoke any tool from `<server>`.

Expected: the request is rejected as a different-origin redirect and origin B receives no configured or OAuth header. A redirect to another path on origin A should still work and should retain the header.

### 8. Verify POCI invoke policy

1. Run a catalog server exposing a POCI/container tool with an invoke policy that denies that tool.
2. Invoke the tool through the gateway.

Expected: the container is not executed, the client receives a policy-denied error, an audit decision is emitted, the tool error metric/span status is recorded, and `mcp.tool.duration` receives exactly one sample for the denied call.

3. Send a raw call for the same POCI tool with malformed JSON arguments.

Expected: argument decoding fails before container execution; the error metric/span status is recorded; `mcp.tool.duration` still receives exactly one sample. Change the policy to allow and retry with valid arguments; the tool should execute and record normal counter/duration telemetry.

## Automated validation

- `make test`
- `make lint`
- focused OAuth revocation, discovery, token-store migration, remote transport, gateway policy, audit, and telemetry tests
- all required GitHub checks are green
