### PR TITLE
fix: preserve Windows drive roots in Docker binds

### DIFF
--- a/pkg/gateway/docker_binds.go
+++ b/pkg/gateway/docker_binds.go
@@ -201,7 +201,11 @@ func isWindowsAbsPath(p string) bool {
 func cleanDockerHostPath(p string) (string, error) {
 	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
 	if isWindowsAbsPath(p) {
-		return strings.ToLower(path.Clean(p)), nil
+		cleaned := strings.ToLower(path.Clean(p))
+		if len(cleaned) == 2 && cleaned[1] == ':' {
+			cleaned += "/"
+		}
+		return cleaned, nil
 	}
 	if strings.HasPrefix(p, "//") {
 		return "//" + path.Clean(strings.TrimPrefix(p, "//")), nil

--- a/pkg/gateway/docker_binds_test.go
+++ b/pkg/gateway/docker_binds_test.go
@@ -1,0 +1,34 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanDockerHostPathPreservesWindowsDriveRoot(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{input: `D:\`, want: "d:/"},
+		{input: "D:/", want: "d:/"},
+		{input: `D:\data`, want: "d:/data"},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := cleanDockerHostPath(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNormalizeDockerVolumeBindPreservesWindowsDriveRoot(t *testing.T) {
+	got, err := normalizeDockerVolumeBindWithRoots(
+		`D:\:/D:ro`,
+		[]string{"d:/"},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "d:/:/D:ro", got)
+}


### PR DESCRIPTION
**What I did**

- Preserve the trailing slash when a Windows absolute host path normalizes to a bare drive root.
- Add cross-platform regression coverage for both slash forms, non-root paths, and the final Docker bind string.

**Why**

`path.Clean("D:/")` returns `"D:"`. The gateway then rebuilt the volume as `d::/D:ro`, which Docker rejects. Keeping the root separator produces the valid `d:/:/D:ro` form without changing non-root Windows paths or UNC handling.

**Related issue**

Fixes #541

**Validation**

- `go test ./pkg/gateway -run 'TestCleanDockerHostPathPreservesWindowsDriveRoot|TestNormalizeDockerVolumeBindPreservesWindowsDriveRoot' -count=1`
- `go test ./... -short -count=1`
- `go vet ./...`