### PR TITLE
Harden OAuth discovery and tool dispatch

### DIFF
--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
-	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // Function pointers for testability (same pattern as pkg/workingset/oauth.go).
@@ -325,8 +324,7 @@ func authorizeCommunityMode(ctx context.Context, serverName string, scopes strin
 		exchangeOpts = append(exchangeOpts, oauth2.SetAuthURLParam("resource", provider.ResourceURL()))
 	}
 
-	exchangeCtx := context.WithValue(ctx, oauth2.HTTPClient, remoteurl.NewHTTPClient(0, nil))
-	token, err := config.Exchange(exchangeCtx, code, exchangeOpts...)
+	token, err := exchangeCommunityAuthorizationCode(ctx, config, code, exchangeOpts...)
 	if err != nil {
 		return fmt.Errorf("token exchange failed: %w", err)
 	}
@@ -346,4 +344,9 @@ func authorizeCommunityMode(ctx context.Context, serverName string, scopes strin
 	fmt.Printf("You can now use: docker mcp server start %s\n", serverName)
 
 	return nil
+}
+
+func exchangeCommunityAuthorizationCode(ctx context.Context, config *oauth2.Config, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	exchangeCtx := context.WithValue(ctx, oauth2.HTTPClient, pkgoauth.NewCredentialHTTPClient(ctx, 0))
+	return config.Exchange(exchangeCtx, code, opts...)
 }

--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/desktop"
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // Function pointers for testability (same pattern as pkg/workingset/oauth.go).
@@ -55,20 +56,39 @@ func Authorize(ctx context.Context, app string, scopes string, openBrowser bool)
 	}
 }
 
-// openBrowserURL opens the given URL in the system's default browser.
-func openBrowserURL(rawURL string) {
-	ctx := context.Background()
-	var cmd *exec.Cmd
+// openBrowserURL opens a validated authorization URL in the system's default
+// browser. Starting the platform handler remains best-effort, but an unsafe URL
+// is rejected before any process is launched.
+func openBrowserURL(rawURL string) error {
+	cmd, err := authorizationBrowserCommand(context.Background(), rawURL)
+	if err != nil {
+		return err
+	}
+	_ = cmd.Start()
+	return nil
+}
+
+func authorizationBrowserCommand(ctx context.Context, rawURL string) (*exec.Cmd, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OAuth authorization URL: %w", err)
+	}
+	if err := remoteurl.DefaultValidator().ValidateURLWithoutResolution(parsedURL); err != nil {
+		return nil, fmt.Errorf("invalid OAuth authorization URL: %w", err)
+	}
+
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.CommandContext(ctx, "open", rawURL)
+		return exec.CommandContext(ctx, "open", rawURL), nil
 	case "windows":
-		cmd = exec.CommandContext(ctx, "cmd", "/c", "start", rawURL)
+		return windowsAuthorizationBrowserCommand(ctx, rawURL), nil
 	default: // linux and others
-		cmd = exec.CommandContext(ctx, "xdg-open", rawURL)
+		return exec.CommandContext(ctx, "xdg-open", rawURL), nil
 	}
-	// Best-effort: ignore errors so a missing browser doesn't fail the auth flow.
-	_ = cmd.Start()
+}
+
+func windowsAuthorizationBrowserCommand(ctx context.Context, rawURL string) *exec.Cmd {
+	return exec.CommandContext(ctx, "rundll32.exe", "url.dll,FileProtocolHandler", rawURL)
 }
 
 // lookupIsCommunity checks the OCI catalog database to determine if a server is a community server.
@@ -158,7 +178,9 @@ func authorizeCEMode(ctx context.Context, serverName string, scopes string, open
 	// Step 4: Display authorization URL
 	if openBrowser {
 		fmt.Printf("Opening your browser for authentication. If it doesn't open automatically, please visit: %s\n", authURL)
-		openBrowserURL(authURL)
+		if err := openBrowserURL(authURL); err != nil {
+			return err
+		}
 	} else {
 		fmt.Printf("Please visit this URL to authorize:\n\n  %s\n\n", authURL)
 	}
@@ -282,7 +304,9 @@ func authorizeCommunityMode(ctx context.Context, serverName string, scopes strin
 	// Step 4: Display authorization URL (and open browser if requested)
 	if openBrowser {
 		fmt.Printf("Opening your browser for authentication. If it doesn't open automatically, please visit: %s\n", authURL)
-		openBrowserURL(authURL)
+		if err := openBrowserURL(authURL); err != nil {
+			return err
+		}
 	} else {
 		fmt.Printf("Please visit this URL to authorize:\n\n  %s\n\n", authURL)
 	}

--- a/cmd/docker-mcp/oauth/auth_test.go
+++ b/cmd/docker-mcp/oauth/auth_test.go
@@ -3,12 +3,19 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
+	"github.com/docker/mcp-gateway/pkg/desktop"
 	pkgoauth "github.com/docker/mcp-gateway/pkg/oauth"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
 // mockAuthorizeRouting overrides the function pointers so Authorize() does not
@@ -161,4 +168,59 @@ func TestAuthorizeCommunityMode_NoCleanupOnFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to create callback server")
 	assert.False(t, desktopCleanupCalled,
 		"community authorize should NOT clean Desktop entries when flow fails before token storage")
+}
+
+func TestExchangeCommunityAuthorizationCodeDoesNotFollowRedirects(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	for _, status := range []int{http.StatusTemporaryRedirect, http.StatusPermanentRedirect} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			redirectTargetCalled := make(chan struct{}, 1)
+			redirectTarget := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				redirectTargetCalled <- struct{}{}
+			}))
+			t.Cleanup(redirectTarget.Close)
+
+			requestBody := make(chan struct {
+				body string
+				err  error
+			}, 1)
+			tokenEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				requestBody <- struct {
+					body string
+					err  error
+				}{body: string(body), err: err}
+				w.Header().Set("Location", redirectTarget.URL)
+				w.WriteHeader(status)
+			}))
+			t.Cleanup(tokenEndpoint.Close)
+
+			config := &oauth2.Config{
+				ClientID:    "client-id",
+				RedirectURL: "http://127.0.0.1/callback",
+				Endpoint: oauth2.Endpoint{
+					TokenURL:  tokenEndpoint.URL,
+					AuthStyle: oauth2.AuthStyleInParams,
+				},
+			}
+
+			ctx := desktop.WithNoDockerDesktop(t.Context())
+			_, err := exchangeCommunityAuthorizationCode(ctx, config, "authorization-code", oauth2.VerifierOption("pkce-verifier"))
+			require.Error(t, err)
+
+			capturedRequest := <-requestBody
+			require.NoError(t, capturedRequest.err)
+			form, err := url.ParseQuery(capturedRequest.body)
+			require.NoError(t, err)
+			assert.Equal(t, "authorization-code", form.Get("code"))
+			assert.Equal(t, "pkce-verifier", form.Get("code_verifier"))
+
+			select {
+			case <-redirectTargetCalled:
+				t.Fatal("community token exchange replayed credentials to the redirect target")
+			default:
+			}
+		})
+	}
 }

--- a/cmd/docker-mcp/oauth/auth_test.go
+++ b/cmd/docker-mcp/oauth/auth_test.go
@@ -170,6 +170,46 @@ func TestAuthorizeCommunityMode_NoCleanupOnFailure(t *testing.T) {
 		"community authorize should NOT clean Desktop entries when flow fails before token storage")
 }
 
+func TestAuthorizationBrowserCommandWindowsDoesNotUseShell(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "")
+	rawURL := "https://example.invalid/authorize?x=1&calc.exe&y="
+
+	_, err := authorizationBrowserCommand(t.Context(), rawURL)
+	require.NoError(t, err)
+	cmd := windowsAuthorizationBrowserCommand(t.Context(), rawURL)
+	assert.Equal(t, []string{"rundll32.exe", "url.dll,FileProtocolHandler", rawURL}, cmd.Args)
+	assert.NotEqual(t, "cmd", cmd.Path)
+	assert.NotEqual(t, "cmd.exe", cmd.Path)
+}
+
+func TestAuthorizationBrowserCommandRejectsUnsafeURLs(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "")
+
+	for _, rawURL := range []string{
+		"example.invalid/authorize",
+		"http://example.invalid/authorize",
+		"file:///tmp/authorize",
+		"https://user:password@example.invalid/authorize",
+		"https://127.0.0.1/authorize",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			_, err := authorizationBrowserCommand(t.Context(), rawURL)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid OAuth authorization URL")
+		})
+	}
+}
+
+func TestAuthorizationBrowserCommandAllowsLocalHTTPWithExplicitOptIn(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+	rawURL := "http://127.0.0.1:8080/authorize?client_id=local"
+
+	_, err := authorizationBrowserCommand(t.Context(), rawURL)
+	require.NoError(t, err)
+	cmd := windowsAuthorizationBrowserCommand(t.Context(), rawURL)
+	assert.Equal(t, []string{"rundll32.exe", "url.dll,FileProtocolHandler", rawURL}, cmd.Args)
+}
+
 func TestExchangeCommunityAuthorizationCodeDoesNotFollowRedirects(t *testing.T) {
 	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
 

--- a/cmd/docker-mcp/oauth/revoke.go
+++ b/cmd/docker-mcp/oauth/revoke.go
@@ -95,10 +95,14 @@ func revokeDesktopMode(ctx context.Context, app string) error {
 func revokeCEMode(ctx context.Context, app string) error {
 	manager := newCERevokeManagerFunc()
 
-	// Revoke at the provider before deleting local credentials. If remote
-	// revocation fails, preserve both the token and DCR metadata for retry.
+	// Revoke at the provider before deleting local credentials. Provider and
+	// transport failures preserve the DCR metadata for retry. An already-missing
+	// local token is idempotent and must not prevent DCR cleanup.
 	if err := manager.RevokeToken(ctx, app); err != nil {
-		return fmt.Errorf("failed to revoke OAuth access: %w", err)
+		if !pkgoauth.IsTokenNotFound(err) {
+			return fmt.Errorf("failed to revoke OAuth access: %w", err)
+		}
+		fmt.Printf("Note: OAuth token for %s is already absent; deleting DCR client\n", app)
 	}
 
 	// Delete DCR client (matches Desktop behavior)

--- a/cmd/docker-mcp/oauth/revoke_test.go
+++ b/cmd/docker-mcp/oauth/revoke_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/docker-credential-helpers/credentials"
 	seclient "github.com/docker/secrets-engine/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -162,6 +163,25 @@ func TestRevokeCEMode_FailsHardWhenProviderRevocationFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "provider unavailable")
 	assert.False(t, deleteCalled, "DCR client must be preserved when provider revocation fails")
+}
+
+func TestRevokeCEMode_MissingTokenStillDeletesDCRClient(t *testing.T) {
+	oldNewManager := newCERevokeManagerFunc
+	t.Cleanup(func() { newCERevokeManagerFunc = oldNewManager })
+
+	deletedDCRClient := ""
+	newCERevokeManagerFunc = func() ceRevokeManager {
+		return &stubCERevokeManager{
+			revokeErr: fmt.Errorf("token not found: %w", credentials.NewErrCredentialsNotFound()),
+			deleteDCRClientFn: func(app string) error {
+				deletedDCRClient = app
+				return nil
+			},
+		}
+	}
+
+	require.NoError(t, revokeCEMode(t.Context(), "ce-server"))
+	assert.Equal(t, "ce-server", deletedDCRClient)
 }
 
 // TestRevokeCommunityMode_CleansDesktopEntries verifies that the real

--- a/docs/feature-specs/dynamic_servers.md
+++ b/docs/feature-specs/dynamic_servers.md
@@ -22,9 +22,9 @@ When enabled, the gateway adds five internal management tools to the available t
 
 ### Security boundary
 
-The registry is the gateway's current active set, not an authorization allowlist. When dynamic tools are enabled, `mcp-add` is intentionally allowed to activate another server from the configured catalog. Every activation is evaluated with the policy client's `load` action before the server is added.
+The registry is the gateway's operator-enabled active set. Servers already in that set can be managed without an external policy provider. A catalog-only server can be activated or configured by a dynamic tool only when a non-noop policy provider explicitly allows its `load` action. The self-hosted/no-governance noop client is not treated as authorization to cross from the catalog into the active set.
 
-Deployments that require a fixed server allowlist should pass the allowed names with `--servers`, which disables dynamic tools. Deployments that keep dynamic tools enabled should use policy rules to restrict which catalog servers may be loaded.
+Deployments that need catalog-wide dynamic activation must configure governance policy rules for the servers that may be loaded. Deployments requiring a fixed server set can pass the allowed names with `--servers`, which disables dynamic tools entirely.
 
 ## Available Tools
 
@@ -68,6 +68,7 @@ Deployments that require a fixed server allowlist should pass the allowed names 
 
 **Behavior**:
 - Checks if the server exists in the catalog
+- Requires the server to be enabled already or explicitly allowed by an enforcing policy provider
 - Adds the server to the active server list (avoiding duplicates)
 - Fetches updated secrets for the new server
 - Reloads the gateway configuration
@@ -148,6 +149,7 @@ Deployments that require a fixed server allowlist should pass the allowed names 
 ```
 
 **Behavior**:
+- Requires the server to be enabled already or explicitly allowed by an enforcing policy provider
 - Creates or updates server configuration
 - Reloads the gateway configuration to apply changes
 - Returns success message with old/new values
@@ -204,7 +206,8 @@ AI: Configuration updated. The server now has restricted access.
 
 ## Security Considerations
 
-- **Catalog validation**: Only servers that exist in the catalog can be added
+- **Catalog validation**: Only servers that exist in the catalog can be considered
+- **Activation authorization**: Catalog-only servers require an enforcing policy provider; a noop or missing policy cannot authorize activation or configuration
 - **Secret management**: Secrets are fetched securely through Docker Desktop's secrets API
 - **Configuration isolation**: Server configurations are isolated and validated
 - **URL validation**: Official registry imports require valid HTTP/HTTPS URLs

--- a/docs/feature-specs/dynamic_servers.md
+++ b/docs/feature-specs/dynamic_servers.md
@@ -22,7 +22,7 @@ When enabled, the gateway adds five internal management tools to the available t
 
 ### Security boundary
 
-The registry is the gateway's operator-enabled active set. Servers already in that set can be managed without an external policy provider. A catalog-only server can be activated or configured by a dynamic tool only when a non-noop policy provider explicitly allows its `load` action. The self-hosted/no-governance noop client is not treated as authorization to cross from the catalog into the active set.
+The registry is the gateway's operator-enabled active set. Servers already in that set can be managed without an external policy provider. A catalog-only server can be activated or configured—individually or through a profile—only when a non-noop policy provider explicitly allows its `load` action. The self-hosted/no-governance noop client is not treated as authorization to cross from the catalog into the active set.
 
 Deployments that need catalog-wide dynamic activation must configure governance policy rules for the servers that may be loaded. Deployments requiring a fixed server set can pass the allowed names with `--servers`, which disables dynamic tools entirely.
 
@@ -207,7 +207,7 @@ AI: Configuration updated. The server now has restricted access.
 ## Security Considerations
 
 - **Catalog validation**: Only servers that exist in the catalog can be considered
-- **Activation authorization**: Catalog-only servers require an enforcing policy provider; a noop or missing policy cannot authorize activation or configuration
+- **Activation authorization**: Catalog-only servers require an enforcing policy provider; a noop or missing policy cannot authorize individual, profile-based, or configuration-driven activation
 - **Secret management**: Secrets are fetched securely through Docker Desktop's secrets API
 - **Configuration isolation**: Server configurations are isolated and validated
 - **URL validation**: Official registry imports require valid HTTP/HTTPS URLs

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/docker-credential-helpers v0.9.3
-	github.com/docker/mcp-gateway-oauth-helpers v0.0.6
+	github.com/docker/mcp-gateway-oauth-helpers v0.0.7
 	github.com/docker/secrets-engine/client v0.0.30
 	github.com/docker/secrets-engine/x v0.2.2-do.not.use
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/docker-credential-helpers v0.9.3
-	github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab
+	github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5
 	github.com/docker/secrets-engine/client v0.0.30
 	github.com/docker/secrets-engine/x v0.2.2-do.not.use
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/docker-credential-helpers v0.9.3
-	github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0
+	github.com/docker/mcp-gateway-oauth-helpers v0.0.6
 	github.com/docker/secrets-engine/client v0.0.30
 	github.com/docker/secrets-engine/x v0.2.2-do.not.use
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/docker-credential-helpers v0.9.3
-	github.com/docker/mcp-gateway-oauth-helpers v0.0.3
+	github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab
 	github.com/docker/secrets-engine/client v0.0.30
 	github.com/docker/secrets-engine/x v0.2.2-do.not.use
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/docker-credential-helpers v0.9.3
-	github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5
+	github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0
 	github.com/docker/secrets-engine/client v0.0.30
 	github.com/docker/secrets-engine/x v0.2.2-do.not.use
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421 h1:18Ut0n3NwDXDyCc4vHE03Wcl3LhzOltstayBsg8QqtM=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421/go.mod h1:TDsRGHqTXW9BykauHTOGUL5xQ74PH7zB9iK5HatW1Bg=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab h1:x302sYKCgPDSBB3vOgeyWZDviweVaVmgyvaQK5uhmJg=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5 h1:UuUW6fCkbZImfZG+ax8JH9n9HD6LS/tBadsP10Xkt68=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
 github.com/docker/secrets-engine/client v0.0.30 h1:B5ZbFUqb9yTcmKY+9w5qJx57CIelemnl3XFuQwqoPVc=
 github.com/docker/secrets-engine/client v0.0.30/go.mod h1:wmcZNlV4LbZdiXgJQ9vNRiXaU7yjYp62M3X/fJXywjQ=
 github.com/docker/secrets-engine/x v0.2.2-do.not.use h1:Xzd+dcp3/3HeWYleAXe+XfgyO276gV4d9Lzjzr1RLsI=

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421 h1:18Ut0n3NwDXDyCc4vHE03Wcl3LhzOltstayBsg8QqtM=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421/go.mod h1:TDsRGHqTXW9BykauHTOGUL5xQ74PH7zB9iK5HatW1Bg=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.3 h1:TgXk/DFaXFYpDhduN3l7LCjdjo6doTHXoEg2P43NZT0=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.3/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab h1:x302sYKCgPDSBB3vOgeyWZDviweVaVmgyvaQK5uhmJg=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
 github.com/docker/secrets-engine/client v0.0.30 h1:B5ZbFUqb9yTcmKY+9w5qJx57CIelemnl3XFuQwqoPVc=
 github.com/docker/secrets-engine/client v0.0.30/go.mod h1:wmcZNlV4LbZdiXgJQ9vNRiXaU7yjYp62M3X/fJXywjQ=
 github.com/docker/secrets-engine/x v0.2.2-do.not.use h1:Xzd+dcp3/3HeWYleAXe+XfgyO276gV4d9Lzjzr1RLsI=

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421 h1:18Ut0n3NwDXDyCc4vHE03Wcl3LhzOltstayBsg8QqtM=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421/go.mod h1:TDsRGHqTXW9BykauHTOGUL5xQ74PH7zB9iK5HatW1Bg=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0 h1:BT9hx0PoFbhcyhnoWhuadF/9nzsFCd0ACVzi1nPk/y0=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6 h1:ey4WxS+Gz9dSuqOoeLC4S51GVOtY1TvZiTUKhq9cFd4=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
 github.com/docker/secrets-engine/client v0.0.30 h1:B5ZbFUqb9yTcmKY+9w5qJx57CIelemnl3XFuQwqoPVc=
 github.com/docker/secrets-engine/client v0.0.30/go.mod h1:wmcZNlV4LbZdiXgJQ9vNRiXaU7yjYp62M3X/fJXywjQ=
 github.com/docker/secrets-engine/x v0.2.2-do.not.use h1:Xzd+dcp3/3HeWYleAXe+XfgyO276gV4d9Lzjzr1RLsI=

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421 h1:18Ut0n3NwDXDyCc4vHE03Wcl3LhzOltstayBsg8QqtM=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421/go.mod h1:TDsRGHqTXW9BykauHTOGUL5xQ74PH7zB9iK5HatW1Bg=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6 h1:ey4WxS+Gz9dSuqOoeLC4S51GVOtY1TvZiTUKhq9cFd4=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.7 h1:u1yl4fAg2NxQ+fWR0bo741deAeMxYj/sIaZAZ1fU8SM=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.7/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
 github.com/docker/secrets-engine/client v0.0.30 h1:B5ZbFUqb9yTcmKY+9w5qJx57CIelemnl3XFuQwqoPVc=
 github.com/docker/secrets-engine/client v0.0.30/go.mod h1:wmcZNlV4LbZdiXgJQ9vNRiXaU7yjYp62M3X/fJXywjQ=
 github.com/docker/secrets-engine/x v0.2.2-do.not.use h1:Xzd+dcp3/3HeWYleAXe+XfgyO276gV4d9Lzjzr1RLsI=

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421 h1:18Ut0n3NwDXDyCc4vHE03Wcl3LhzOltstayBsg8QqtM=
 github.com/docker/mcp-community-registry v0.0.0-20251024214917-21000e320421/go.mod h1:TDsRGHqTXW9BykauHTOGUL5xQ74PH7zB9iK5HatW1Bg=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5 h1:UuUW6fCkbZImfZG+ax8JH9n9HD6LS/tBadsP10Xkt68=
-github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0 h1:BT9hx0PoFbhcyhnoWhuadF/9nzsFCd0ACVzi1nPk/y0=
+github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0/go.mod h1:IK0jk+ZNYW/yy5yotveLFcU9Jgk3pMpNasX4X1hheZM=
 github.com/docker/secrets-engine/client v0.0.30 h1:B5ZbFUqb9yTcmKY+9w5qJx57CIelemnl3XFuQwqoPVc=
 github.com/docker/secrets-engine/client v0.0.30/go.mod h1:wmcZNlV4LbZdiXgJQ9vNRiXaU7yjYp62M3X/fJXywjQ=
 github.com/docker/secrets-engine/x v0.2.2-do.not.use h1:Xzd+dcp3/3HeWYleAXe+XfgyO276gV4d9Lzjzr1RLsI=

--- a/pkg/codemode/codemode.go
+++ b/pkg/codemode/codemode.go
@@ -84,7 +84,7 @@ func (c *tool) Tools(ctx context.Context) ([]*ToolWithHandler, error) {
 				return nil, fmt.Errorf("parsing arguments: %w", err)
 			}
 
-			output, err := c.runJavascript(ctx, args.Script)
+			output, err := c.runJavascript(ctx, args.Script, request)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/codemode/exec.go
+++ b/pkg/codemode/exec.go
@@ -10,7 +10,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func (c *tool) runJavascript(ctx context.Context, script string) (string, error) {
+func (c *tool) runJavascript(ctx context.Context, script string, request *mcp.CallToolRequest) (string, error) {
 	vm := goja.New()
 
 	// Inject console object to the help the LLM debug its own code.
@@ -24,7 +24,7 @@ func (c *tool) runJavascript(ctx context.Context, script string) (string, error)
 		}
 
 		for _, toolWithHandler := range allTools {
-			_ = vm.Set(toolWithHandler.Tool.Name, callTool(ctx, toolWithHandler))
+			_ = vm.Set(toolWithHandler.Tool.Name, callTool(ctx, toolWithHandler, request))
 		}
 	}
 
@@ -47,7 +47,7 @@ func (c *tool) runJavascript(ctx context.Context, script string) (string, error)
 	return fmt.Sprintf("%v", result), nil
 }
 
-func callTool(ctx context.Context, toolWithHandler *ToolWithHandler) func(args map[string]any) (string, error) {
+func callTool(ctx context.Context, toolWithHandler *ToolWithHandler, request *mcp.CallToolRequest) func(args map[string]any) (string, error) {
 	return func(args map[string]any) (string, error) {
 		// Extract required fields from InputSchema
 		var required []string
@@ -78,10 +78,13 @@ func callTool(ctx context.Context, toolWithHandler *ToolWithHandler) func(args m
 		}
 
 		result, err := toolWithHandler.Handler(ctx, &mcp.CallToolRequest{
+			Session: request.Session,
 			Params: &mcp.CallToolParamsRaw{
+				Meta:      request.Params.Meta,
 				Name:      toolWithHandler.Tool.Name,
 				Arguments: arguments,
 			},
+			Extra: request.Extra,
 		})
 		if err != nil {
 			return "", err

--- a/pkg/gateway/activateprofile.go
+++ b/pkg/gateway/activateprofile.go
@@ -131,7 +131,7 @@ func (g *Gateway) ActivateProfile(ctx context.Context, ws workingset.WorkingSet)
 	var validationErrors []serverValidation
 
 	for _, serverName := range serversToActivate {
-		if err := g.checkServerLoadPolicy(ctx, profileConfig.policyRequest(serverName, "", policy.ActionLoad), nil); err != nil {
+		if err := g.checkServerManagementAccess(ctx, profileConfig.policyRequest(serverName, "", policy.ActionLoad), nil); err != nil {
 			return err
 		}
 		serverConfig := profileConfig.servers[serverName]

--- a/pkg/gateway/capabilities_test.go
+++ b/pkg/gateway/capabilities_test.go
@@ -1,0 +1,38 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsToolEnabledUsesExactCase(t *testing.T) {
+	configuration := Configuration{}
+
+	tests := []struct {
+		name         string
+		serverName   string
+		serverImage  string
+		toolName     string
+		enabledTools []string
+		want         bool
+	}{
+		{name: "exact bare tool", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"ReadFile"}, want: true},
+		{name: "case variant bare tool", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"readfile"}, want: false},
+		{name: "exact server and tool", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"Server:ReadFile"}, want: true},
+		{name: "case variant server", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"server:ReadFile"}, want: false},
+		{name: "case variant scoped tool", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"Server:readfile"}, want: false},
+		{name: "exact server wildcard", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"Server:*"}, want: true},
+		{name: "case variant server wildcard", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"server:*"}, want: false},
+		{name: "exact image and tool", serverName: "Server", serverImage: "Registry/Image", toolName: "ReadFile", enabledTools: []string{"Registry/Image:ReadFile"}, want: true},
+		{name: "case variant image", serverName: "Server", serverImage: "Registry/Image", toolName: "ReadFile", enabledTools: []string{"registry/image:ReadFile"}, want: false},
+		{name: "exact image wildcard", serverName: "Server", serverImage: "Registry/Image", toolName: "ReadFile", enabledTools: []string{"Registry/Image:*"}, want: true},
+		{name: "global wildcard", serverName: "Server", toolName: "ReadFile", enabledTools: []string{"*"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isToolEnabled(configuration, tt.serverName, tt.serverImage, tt.toolName, tt.enabledTools))
+		})
+	}
+}

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -177,10 +177,13 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 						capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 							ServerName: serverConfig.Name,
 							Tool:       &prefixedTool,
-							Handler: g.withInvokePolicy(
-								serverConfig.Name,
-								tool.Name,
-								g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations, tool.Name),
+							Handler: withMCPServerPolicyErrorTelemetry(
+								serverConfig,
+								g.withInvokePolicy(
+									serverConfig.Name,
+									tool.Name,
+									g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations, tool.Name),
+								),
 							),
 						})
 					}

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"runtime"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -358,18 +357,17 @@ func isToolEnabled(configuration Configuration, serverName, serverImage, toolNam
 
 	for _, enabled := range enabledTools {
 		if enabled == "*" ||
-			strings.EqualFold(enabled, toolName) ||
-			strings.EqualFold(enabled, serverName+":"+toolName) ||
-			strings.EqualFold(enabled, serverName+":*") ||
-			strings.EqualFold(enabled, "*") {
+			enabled == toolName ||
+			enabled == serverName+":"+toolName ||
+			enabled == serverName+":*" {
 			return true
 		}
 	}
 
 	if serverImage != "" {
 		for _, enabled := range enabledTools {
-			if strings.EqualFold(enabled, serverImage+":"+toolName) ||
-				strings.EqualFold(enabled, serverImage+":*") {
+			if enabled == serverImage+":"+toolName ||
+				enabled == serverImage+":*" {
 				return true
 			}
 		}

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -176,7 +176,7 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 						capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 							ServerName: serverConfig.Name,
 							Tool:       &prefixedTool,
-							Handler: withMCPServerPolicyErrorTelemetry(
+							Handler: withMCPServerToolTelemetry(
 								serverConfig,
 								g.withInvokePolicy(
 									serverConfig.Name,

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -177,7 +177,11 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 						capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 							ServerName: serverConfig.Name,
 							Tool:       &prefixedTool,
-							Handler:    g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations, tool.Name),
+							Handler: g.withInvokePolicy(
+								serverConfig.Name,
+								tool.Name,
+								g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations, tool.Name),
+							),
 						})
 					}
 				}
@@ -285,7 +289,11 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 				capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 					ServerName: serverName,
 					Tool:       &mcpTool,
-					Handler:    g.mcpToolHandler(serverName, tool),
+					Handler: g.withPOCIToolTelemetry(
+						serverName,
+						tool,
+						g.withInvokePolicy(serverName, tool.Name, g.pociToolHandler(tool)),
+					),
 				})
 			}
 

--- a/pkg/gateway/codemode.go
+++ b/pkg/gateway/codemode.go
@@ -16,8 +16,6 @@ import (
 type serverToolSetAdapter struct {
 	gateway    *Gateway
 	serverName string
-	session    *mcp.ServerSession
-	extra      *mcp.RequestExtra
 }
 
 func (a *serverToolSetAdapter) Tools(_ context.Context) ([]*codemode.ToolWithHandler, error) {
@@ -38,17 +36,9 @@ func (a *serverToolSetAdapter) Tools(_ context.Context) ([]*codemode.ToolWithHan
 
 	result := make([]*codemode.ToolWithHandler, 0, len(registrations))
 	for _, registration := range registrations {
-		registeredHandler := registration.Handler
 		result = append(result, &codemode.ToolWithHandler{
-			Tool: registration.Tool,
-			Handler: func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				// Code mode creates an internal request for each JavaScript function.
-				// Preserve the originating request context while reusing the handler
-				// that passed allowlist and ActionLoad filtering at registration.
-				req.Session = a.session
-				req.Extra = a.extra
-				return registeredHandler(ctx, req)
-			},
+			Tool:    registration.Tool,
+			Handler: registration.Handler,
 		})
 	}
 
@@ -102,8 +92,6 @@ func addCodemodeHandler(g *Gateway) mcp.ToolHandler {
 			toolSets = append(toolSets, &serverToolSetAdapter{
 				gateway:    g,
 				serverName: serverName,
-				session:    req.Session,
-				extra:      req.Extra,
 			})
 		}
 

--- a/pkg/gateway/codemode.go
+++ b/pkg/gateway/codemode.go
@@ -4,58 +4,51 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/codemode"
 )
 
 // serverToolSetAdapter adapts a gateway server to the codemode.ToolSet interface
 type serverToolSetAdapter struct {
-	gateway      *Gateway
-	serverName   string
-	serverConfig *catalog.ServerConfig
-	session      *mcp.ServerSession
+	gateway    *Gateway
+	serverName string
+	session    *mcp.ServerSession
+	extra      *mcp.RequestExtra
 }
 
-func (a *serverToolSetAdapter) Tools(ctx context.Context) ([]*codemode.ToolWithHandler, error) {
-	// Get a client for this server
-	clientConfig := &clientConfig{
-		serverSession: a.session,
-		server:        a.gateway.mcpServer,
+func (a *serverToolSetAdapter) Tools(_ context.Context) ([]*codemode.ToolWithHandler, error) {
+	a.gateway.capabilitiesMu.RLock()
+	registrations := make([]ToolRegistration, 0)
+	for _, registration := range a.gateway.toolRegistrations {
+		if registration.ServerName == a.serverName {
+			registrations = append(registrations, registration)
+		}
 	}
+	a.gateway.capabilitiesMu.RUnlock()
 
-	client, err := a.gateway.clientPool.AcquireClient(ctx, a.serverConfig, clientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to acquire client for server %s: %w", a.serverName, err)
-	}
+	// Registration order comes from a map. Keep generated documentation and
+	// function installation deterministic without changing tool-name identity.
+	slices.SortFunc(registrations, func(left, right ToolRegistration) int {
+		return strings.Compare(left.Tool.Name, right.Tool.Name)
+	})
 
-	// List tools from the server
-	listResult, err := client.Session().ListTools(ctx, &mcp.ListToolsParams{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list tools from server %s: %w", a.serverName, err)
-	}
-
-	// Convert MCP tools to ToolWithHandler
-	var result []*codemode.ToolWithHandler
-	for _, tool := range listResult.Tools {
-		// Create a handler that calls the tool on the remote server
-		handler := func(tool *mcp.Tool) mcp.ToolHandler {
-			baseHandler := mcp.ToolHandler(func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				// Forward the tool call to the actual server
-				return client.Session().CallTool(ctx, &mcp.CallToolParams{
-					Name:      tool.Name,
-					Arguments: req.Params.Arguments,
-				})
-			})
-			return a.gateway.withInvokePolicy(a.serverConfig.Name, tool.Name, baseHandler)
-		}(tool)
-
+	result := make([]*codemode.ToolWithHandler, 0, len(registrations))
+	for _, registration := range registrations {
+		registeredHandler := registration.Handler
 		result = append(result, &codemode.ToolWithHandler{
-			Tool:    tool,
-			Handler: handler,
+			Tool: registration.Tool,
+			Handler: func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				// Code mode creates an internal request for each JavaScript function.
+				// Preserve the originating request context while reusing the handler
+				// that passed allowlist and ActionLoad filtering at registration.
+				req.Session = a.session
+				req.Extra = a.extra
+				return registeredHandler(ctx, req)
+			},
 		})
 	}
 
@@ -91,12 +84,13 @@ func addCodemodeHandler(g *Gateway) mcp.ToolHandler {
 			return nil, fmt.Errorf("name parameter is required")
 		}
 
-		// Validate that all requested servers exist
+		// Validate against the enabled-server set, not the full catalog. In
+		// profile mode configuration.servers includes catalog-only entries.
 		for _, serverName := range params.Servers {
-			if _, _, found := g.configuration.Find(serverName); !found {
+			if !slices.Contains(g.configuration.ServerNames(), serverName) {
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{
-						Text: fmt.Sprintf("Error: Server '%s' not found in configuration. Use mcp-find to search for available servers.", serverName),
+						Text: fmt.Sprintf("Error: Server '%s' is not enabled for this gateway session.", serverName),
 					}},
 				}, nil
 			}
@@ -105,12 +99,11 @@ func addCodemodeHandler(g *Gateway) mcp.ToolHandler {
 		// Create a tool set adapter for each server
 		var toolSets []codemode.ToolSet
 		for _, serverName := range params.Servers {
-			serverConfig, _, _ := g.configuration.Find(serverName)
 			toolSets = append(toolSets, &serverToolSetAdapter{
-				gateway:      g,
-				serverName:   serverName,
-				serverConfig: serverConfig,
-				session:      req.Session,
+				gateway:    g,
+				serverName: serverName,
+				session:    req.Session,
+				extra:      req.Extra,
 			})
 		}
 

--- a/pkg/gateway/codemode.go
+++ b/pkg/gateway/codemode.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/codemode"
-	"github.com/docker/mcp-gateway/pkg/policy"
 )
 
 // serverToolSetAdapter adapts a gateway server to the codemode.ToolSet interface
@@ -44,16 +43,14 @@ func (a *serverToolSetAdapter) Tools(ctx context.Context) ([]*codemode.ToolWithH
 	for _, tool := range listResult.Tools {
 		// Create a handler that calls the tool on the remote server
 		handler := func(tool *mcp.Tool) mcp.ToolHandler {
-			return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				if err := a.checkInvokePolicy(ctx, tool.Name, req.Session); err != nil {
-					return nil, err
-				}
+			baseHandler := mcp.ToolHandler(func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				// Forward the tool call to the actual server
 				return client.Session().CallTool(ctx, &mcp.CallToolParams{
 					Name:      tool.Name,
 					Arguments: req.Params.Arguments,
 				})
-			}
+			})
+			return a.gateway.withInvokePolicy(a.serverConfig.Name, tool.Name, baseHandler)
 		}(tool)
 
 		result = append(result, &codemode.ToolWithHandler{
@@ -63,26 +60,6 @@ func (a *serverToolSetAdapter) Tools(ctx context.Context) ([]*codemode.ToolWithH
 	}
 
 	return result, nil
-}
-
-// checkInvokePolicy enforces the ActionInvoke policy for a backend tool before
-// code-mode dispatches it, matching the gate applied on the direct tool-call and
-// mcp-exec paths so code-mode cannot bypass an operator-configured policy.
-func (a *serverToolSetAdapter) checkInvokePolicy(ctx context.Context, toolName string, session *mcp.ServerSession) error {
-	if a.gateway.policyClient == nil {
-		return nil
-	}
-	policyReq := a.gateway.configuration.policyRequest(a.serverConfig.Name, toolName, policy.ActionInvoke)
-	decision, err := a.gateway.policyClient.Evaluate(ctx, policyReq)
-	event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(session))
-	submitAuditEvent(a.gateway.policyClient, event)
-	if err != nil {
-		return fmt.Errorf("policy check failed for %s/%s: %w", a.serverConfig.Name, toolName, err)
-	}
-	if !decision.Allowed {
-		return fmt.Errorf("policy denied tool %s on server %s: %s", toolName, a.serverConfig.Name, decision.Reason)
-	}
-	return nil
 }
 
 func addCodemodeHandler(g *Gateway) mcp.ToolHandler {

--- a/pkg/gateway/codemode_test.go
+++ b/pkg/gateway/codemode_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func TestCodeModeUsesRegisteredServerTools(t *testing.T) {
-	session := &mcp.ServerSession{}
-	extra := &mcp.RequestExtra{}
 	var called []string
+	var sessions []*mcp.ServerSession
+	var extras []*mcp.RequestExtra
 
 	registration := func(serverName, toolName string) ToolRegistration {
 		return ToolRegistration{
@@ -29,9 +29,9 @@ func TestCodeModeUsesRegisteredServerTools(t *testing.T) {
 				InputSchema: map[string]any{"type": "object"},
 			},
 			Handler: func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				require.Same(t, session, req.Session)
-				require.Same(t, extra, req.Extra)
 				called = append(called, req.Params.Name)
+				sessions = append(sessions, req.Session)
+				extras = append(extras, req.Extra)
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{Text: req.Params.Name}},
 				}, nil
@@ -48,8 +48,6 @@ func TestCodeModeUsesRegisteredServerTools(t *testing.T) {
 	adapter := &serverToolSetAdapter{
 		gateway:    g,
 		serverName: "backend-server",
-		session:    session,
-		extra:      extra,
 	}
 
 	registeredTools, err := adapter.Tools(context.Background())
@@ -66,23 +64,46 @@ func TestCodeModeUsesRegisteredServerTools(t *testing.T) {
 
 	arguments, err := json.Marshal(codemode.RunToolsWithJavascriptArgs{Script: "return ReadFile({});"})
 	require.NoError(t, err)
+	firstSession := &mcp.ServerSession{}
+	firstExtra := &mcp.RequestExtra{}
 	result, err := generatedTools[0].Handler(context.Background(), &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{Arguments: arguments},
+		Session: firstSession,
+		Params:  &mcp.CallToolParamsRaw{Arguments: arguments},
+		Extra:   firstExtra,
 	})
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 	assert.Equal(t, "ReadFile", result.Content[0].(*mcp.TextContent).Text)
-	assert.Equal(t, []string{"ReadFile"}, called)
+
+	secondSession := &mcp.ServerSession{}
+	secondExtra := &mcp.RequestExtra{}
+	result, err = generatedTools[0].Handler(context.Background(), &mcp.CallToolRequest{
+		Session: secondSession,
+		Params:  &mcp.CallToolParamsRaw{Arguments: arguments},
+		Extra:   secondExtra,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "ReadFile", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, []string{"ReadFile", "ReadFile"}, called)
+	require.Len(t, sessions, 2)
+	assert.Same(t, firstSession, sessions[0])
+	assert.Same(t, secondSession, sessions[1])
+	require.Len(t, extras, 2)
+	assert.Same(t, firstExtra, extras[0])
+	assert.Same(t, secondExtra, extras[1])
 
 	caseVariantArguments, err := json.Marshal(codemode.RunToolsWithJavascriptArgs{Script: "return readfile({});"})
 	require.NoError(t, err)
 	result, err = generatedTools[0].Handler(context.Background(), &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{Arguments: caseVariantArguments},
+		Session: secondSession,
+		Params:  &mcp.CallToolParamsRaw{Arguments: caseVariantArguments},
+		Extra:   secondExtra,
 	})
 	require.NoError(t, err)
 	require.Len(t, result.Content, 1)
 	assert.Contains(t, result.Content[0].(*mcp.TextContent).Text, "readfile")
-	assert.Equal(t, []string{"ReadFile"}, called, "case-variant tool must not reach a backend handler")
+	assert.Equal(t, []string{"ReadFile", "ReadFile"}, called, "case-variant tool must not reach a backend handler")
 }
 
 func TestCodeModeRejectsServersOutsideEnabledSet(t *testing.T) {

--- a/pkg/gateway/codemode_test.go
+++ b/pkg/gateway/codemode_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -10,8 +11,108 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/codemode"
 	"github.com/docker/mcp-gateway/pkg/policy"
 )
+
+func TestCodeModeUsesRegisteredServerTools(t *testing.T) {
+	session := &mcp.ServerSession{}
+	extra := &mcp.RequestExtra{}
+	var called []string
+
+	registration := func(serverName, toolName string) ToolRegistration {
+		return ToolRegistration{
+			ServerName: serverName,
+			Tool: &mcp.Tool{
+				Name:        toolName,
+				Description: "registered " + toolName,
+				InputSchema: map[string]any{"type": "object"},
+			},
+			Handler: func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				require.Same(t, session, req.Session)
+				require.Same(t, extra, req.Extra)
+				called = append(called, req.Params.Name)
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: req.Params.Name}},
+				}, nil
+			},
+		}
+	}
+
+	g := &Gateway{
+		toolRegistrations: map[string]ToolRegistration{
+			"ReadFile":  registration("backend-server", "ReadFile"),
+			"OtherTool": registration("other-server", "OtherTool"),
+		},
+	}
+	adapter := &serverToolSetAdapter{
+		gateway:    g,
+		serverName: "backend-server",
+		session:    session,
+		extra:      extra,
+	}
+
+	registeredTools, err := adapter.Tools(context.Background())
+	require.NoError(t, err)
+	require.Len(t, registeredTools, 1)
+	assert.Equal(t, "ReadFile", registeredTools[0].Tool.Name)
+
+	generatedTools, err := codemode.Wrap([]codemode.ToolSet{adapter}).Tools(context.Background())
+	require.NoError(t, err)
+	require.Len(t, generatedTools, 1)
+	assert.Contains(t, generatedTools[0].Tool.Description, "ReadFile")
+	assert.NotContains(t, generatedTools[0].Tool.Description, "readfile")
+	assert.NotContains(t, generatedTools[0].Tool.Description, "OtherTool")
+
+	arguments, err := json.Marshal(codemode.RunToolsWithJavascriptArgs{Script: "return ReadFile({});"})
+	require.NoError(t, err)
+	result, err := generatedTools[0].Handler(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: arguments},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "ReadFile", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, []string{"ReadFile"}, called)
+
+	caseVariantArguments, err := json.Marshal(codemode.RunToolsWithJavascriptArgs{Script: "return readfile({});"})
+	require.NoError(t, err)
+	result, err = generatedTools[0].Handler(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: caseVariantArguments},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	assert.Contains(t, result.Content[0].(*mcp.TextContent).Text, "readfile")
+	assert.Equal(t, []string{"ReadFile"}, called, "case-variant tool must not reach a backend handler")
+}
+
+func TestCodeModeRejectsServersOutsideEnabledSet(t *testing.T) {
+	g := &Gateway{
+		configuration: Configuration{
+			serverNames: []string{"enabled-server"},
+			servers: map[string]catalog.Server{
+				"enabled-server": {Image: "enabled-image"},
+				"catalog-only":   {Image: "catalog-image"},
+			},
+		},
+	}
+
+	for _, serverName := range []string{"catalog-only", "Enabled-Server"} {
+		t.Run(serverName, func(t *testing.T) {
+			arguments, err := json.Marshal(map[string]any{
+				"servers": []string{serverName},
+				"name":    "test",
+			})
+			require.NoError(t, err)
+
+			result, err := addCodemodeHandler(g)(context.Background(), &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{Arguments: arguments},
+			})
+			require.NoError(t, err)
+			require.Len(t, result.Content, 1)
+			assert.Contains(t, result.Content[0].(*mcp.TextContent).Text, "is not enabled")
+		})
+	}
+}
 
 func TestInvokePolicyMiddleware(t *testing.T) {
 	newHandler := func(mock policy.Client, called *bool) mcp.ToolHandler {

--- a/pkg/gateway/codemode_test.go
+++ b/pkg/gateway/codemode_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -12,11 +13,8 @@ import (
 	"github.com/docker/mcp-gateway/pkg/policy"
 )
 
-// TestCodemodeAdapter_PolicyEnforcement verifies that code-mode evaluates the
-// ActionInvoke policy for the target backend tool before dispatching it, so a
-// code-mode script cannot reach a tool that direct invocation / mcp-exec deny.
-func TestCodemodeAdapter_PolicyEnforcement(t *testing.T) {
-	newAdapter := func(mock *mockPolicyClient) *serverToolSetAdapter {
+func TestInvokePolicyMiddleware(t *testing.T) {
+	newHandler := func(mock policy.Client, called *bool) mcp.ToolHandler {
 		g := &Gateway{
 			policyClient: mock,
 			configuration: Configuration{
@@ -24,42 +22,45 @@ func TestCodemodeAdapter_PolicyEnforcement(t *testing.T) {
 				servers:     map[string]catalog.Server{"backend-server": {Image: "img"}},
 			},
 		}
-		sc, _, ok := g.configuration.Find("backend-server")
-		require.True(t, ok)
-		return &serverToolSetAdapter{gateway: g, serverName: "backend-server", serverConfig: sc}
+		return g.withInvokePolicy("backend-server", "dangerous-tool", func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			*called = true
+			return &mcp.CallToolResult{}, nil
+		})
 	}
 
 	t.Run("blocks_denied_tool", func(t *testing.T) {
 		mock := newMockPolicyClient()
 		mock.deny("backend-server", "dangerous-tool", policy.ActionInvoke, "tool blocked for safety")
-		err := newAdapter(mock).checkInvokePolicy(context.Background(), "dangerous-tool", nil)
+		called := false
+		_, err := newHandler(mock, &called)(context.Background(), &mcp.CallToolRequest{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "policy denied")
 		assert.Contains(t, err.Error(), "dangerous-tool")
 		assert.Contains(t, err.Error(), "tool blocked for safety")
+		assert.False(t, called)
 	})
 
 	t.Run("denies_on_error", func(t *testing.T) {
 		mock := newMockPolicyClient()
 		mock.failWith("backend-server", "dangerous-tool", policy.ActionInvoke, errors.New("policy service down"))
-		err := newAdapter(mock).checkInvokePolicy(context.Background(), "dangerous-tool", nil)
+		called := false
+		_, err := newHandler(mock, &called)(context.Background(), &mcp.CallToolRequest{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "policy")
+		assert.False(t, called)
 	})
 
 	t.Run("allows_permitted_tool", func(t *testing.T) {
-		err := newAdapter(newMockPolicyClient()).checkInvokePolicy(context.Background(), "safe-tool", nil)
+		called := false
+		_, err := newHandler(newMockPolicyClient(), &called)(context.Background(), &mcp.CallToolRequest{})
 		require.NoError(t, err)
+		assert.True(t, called)
 	})
 
 	t.Run("nil_policy_client_allows", func(t *testing.T) {
-		g := &Gateway{configuration: Configuration{
-			serverNames: []string{"backend-server"},
-			servers:     map[string]catalog.Server{"backend-server": {Image: "img"}},
-		}}
-		sc, _, ok := g.configuration.Find("backend-server")
-		require.True(t, ok)
-		a := &serverToolSetAdapter{gateway: g, serverName: "backend-server", serverConfig: sc}
-		require.NoError(t, a.checkInvokePolicy(context.Background(), "any-tool", nil))
+		called := false
+		_, err := newHandler(nil, &called)(context.Background(), &mcp.CallToolRequest{})
+		require.NoError(t, err)
+		assert.True(t, called)
 	})
 }

--- a/pkg/gateway/config_validation_test.go
+++ b/pkg/gateway/config_validation_test.go
@@ -106,7 +106,7 @@ func TestActivateProfileRejectsMissingRequiredConfig(t *testing.T) {
 		},
 	}
 
-	g := &Gateway{}
+	g := &Gateway{policyClient: newMockPolicyClient()}
 	err := g.ActivateProfile(t.Context(), workingset.WorkingSet{
 		ID:   "test",
 		Name: "test",

--- a/pkg/gateway/configset.go
+++ b/pkg/gateway/configset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -59,7 +60,7 @@ func configSetHandler(g *Gateway) mcp.ToolHandler {
 			}, nil
 		}
 
-		if err := g.checkServerLoadPolicy(ctx, g.configuration.policyRequest(serverName, "", policy.ActionLoad), req.Session); err != nil {
+		if err := g.checkServerManagementAccess(ctx, serverName, req.Session); err != nil {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: " + err.Error()}},
 				IsError: true,
@@ -159,6 +160,35 @@ func configSetHandler(g *Gateway) mcp.ToolHandler {
 				Text: resultMessage,
 			}},
 		}, nil
+	}
+}
+
+// checkServerManagementAccess protects dynamic state changes to catalog
+// servers. An operator-enabled server is already inside the configured trust
+// boundary. A catalog-only server requires an enforcing policy provider; the
+// self-hosted/no-governance noop client is not an authorization decision.
+func (g *Gateway) checkServerManagementAccess(ctx context.Context, serverName string, session *mcp.ServerSession) error {
+	if !slices.Contains(g.configuration.ServerNames(), serverName) && !hasEnforcingPolicy(g.policyClient) {
+		return fmt.Errorf("server %q is not enabled and no enforcing policy is available to authorize catalog access", serverName)
+	}
+
+	return g.checkServerLoadPolicy(
+		ctx,
+		g.configuration.policyRequest(serverName, "", policy.ActionLoad),
+		session,
+	)
+}
+
+func hasEnforcingPolicy(client policy.Client) bool {
+	if client == nil {
+		return false
+	}
+
+	switch client.(type) {
+	case policy.NoopClient, *policy.NoopClient:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/pkg/gateway/configset.go
+++ b/pkg/gateway/configset.go
@@ -60,7 +60,11 @@ func configSetHandler(g *Gateway) mcp.ToolHandler {
 			}, nil
 		}
 
-		if err := g.checkServerManagementAccess(ctx, serverName, req.Session); err != nil {
+		if err := g.checkServerManagementAccess(
+			ctx,
+			g.configuration.policyRequest(serverName, "", policy.ActionLoad),
+			req.Session,
+		); err != nil {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: " + err.Error()}},
 				IsError: true,
@@ -167,16 +171,13 @@ func configSetHandler(g *Gateway) mcp.ToolHandler {
 // servers. An operator-enabled server is already inside the configured trust
 // boundary. A catalog-only server requires an enforcing policy provider; the
 // self-hosted/no-governance noop client is not an authorization decision.
-func (g *Gateway) checkServerManagementAccess(ctx context.Context, serverName string, session *mcp.ServerSession) error {
+func (g *Gateway) checkServerManagementAccess(ctx context.Context, policyReq policy.Request, session *mcp.ServerSession) error {
+	serverName := policyReq.Server
 	if !slices.Contains(g.configuration.ServerNames(), serverName) && !hasEnforcingPolicy(g.policyClient) {
 		return fmt.Errorf("server %q is not enabled and no enforcing policy is available to authorize catalog access", serverName)
 	}
 
-	return g.checkServerLoadPolicy(
-		ctx,
-		g.configuration.policyRequest(serverName, "", policy.ActionLoad),
-		session,
-	)
+	return g.checkServerLoadPolicy(ctx, policyReq, session)
 }
 
 func hasEnforcingPolicy(client policy.Client) bool {

--- a/pkg/gateway/dynamic_mcps.go
+++ b/pkg/gateway/dynamic_mcps.go
@@ -50,7 +50,7 @@ func (g *Gateway) createMcpAddTool(clientConfig *clientConfig) *ToolRegistration
 	tool := &mcp.Tool{
 		Name: "mcp-add",
 		Description: `Add a new MCP server to the session. 
-The server must exist in the catalog.`,
+The server must already be enabled or be authorized by an enforcing policy provider.`,
 		InputSchema: &jsonschema.Schema{
 			Type: "object",
 			Properties: map[string]*jsonschema.Schema{
@@ -79,6 +79,7 @@ func (g *Gateway) createMcpConfigSetTool(_ *clientConfig) *ToolRegistration {
 	tool := &mcp.Tool{
 		Name: "mcp-config-set",
 		Description: `Set configuration for an MCP server. 
+The server must already be enabled or be authorized by an enforcing policy provider.
 The config object will be validated against the server's config schema. If validation fails, the error message will include the correct schema.`,
 		InputSchema: &jsonschema.Schema{
 			Type: "object",

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -41,7 +41,24 @@ func inferServerTransportType(serverConfig *catalog.ServerConfig) string {
 	return "unknown"
 }
 
-func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolHandler {
+func (g *Gateway) pociToolHandler(tool catalog.Tool) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args any
+		if len(req.Params.Arguments) > 0 {
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal arguments: %w", err)
+			}
+		}
+		params := &mcp.CallToolParams{
+			Meta:      req.Params.Meta,
+			Name:      req.Params.Name,
+			Arguments: args,
+		}
+		return g.clientPool.runToolContainer(ctx, tool, params), nil
+	}
+}
+
+func (g *Gateway) withPOCIToolTelemetry(serverName string, tool catalog.Tool, next mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		clientName := ""
 		if clientInfo := auditClientInfoFromSession(req.Session); clientInfo != nil {
@@ -66,38 +83,12 @@ func (g *Gateway) mcpToolHandler(serverName string, tool catalog.Tool) mcp.ToolH
 		}()
 		telemetry.ToolCallCounter.Add(ctx, 1, metric.WithAttributes(metricAttrs...))
 
-		if g.policyClient != nil {
-			policyReq := g.configuration.policyRequest(serverName, tool.Name, policy.ActionInvoke)
-			decision, err := g.policyClient.Evaluate(ctx, policyReq)
-			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
-			submitAuditEvent(g.policyClient, event)
-			if err != nil {
-				telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
-				span.SetStatus(codes.Error, "Policy evaluation failed")
-				return nil, fmt.Errorf("policy check failed for %s/%s: %w", serverName, tool.Name, err)
-			}
-			if !decision.Allowed {
-				telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
-				span.SetStatus(codes.Error, "Policy denied tool call")
-				return nil, fmt.Errorf("policy denied tool %s on server %s: %s", tool.Name, serverName, decision.Reason)
-			}
+		result, err := next(ctx, req)
+		if err != nil {
+			telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
+			span.SetStatus(codes.Error, "Tool call failed")
+			return nil, err
 		}
-
-		// Convert CallToolParamsRaw to CallToolParams
-		var args any
-		if len(req.Params.Arguments) > 0 {
-			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
-				telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
-				span.SetStatus(codes.Error, "Failed to unmarshal arguments")
-				return nil, fmt.Errorf("failed to unmarshal arguments: %w", err)
-			}
-		}
-		params := &mcp.CallToolParams{
-			Meta:      req.Params.Meta,
-			Name:      req.Params.Name,
-			Arguments: args,
-		}
-		result := g.clientPool.runToolContainer(ctx, tool, params)
 		if result != nil && result.IsError {
 			telemetry.RecordToolError(ctx, span, serverName, "docker", req.Params.Name)
 			span.SetStatus(codes.Error, "Tool execution failed")
@@ -114,24 +105,6 @@ func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, _ 
 		serverConfig, _, ok := g.configuration.Find(serverName)
 		if !ok {
 			return nil, fmt.Errorf("server %q not found in configuration", serverName)
-		}
-
-		if g.policyClient != nil {
-			policyReq := g.configuration.policyRequest(
-				serverConfig.Name,
-				originalToolName,
-				policy.ActionInvoke,
-			)
-			decision, err := g.policyClient.Evaluate(ctx, policyReq)
-			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
-			submitAuditEvent(g.policyClient, event)
-			if err != nil {
-				telemetry.RecordToolError(ctx, nil, serverConfig.Name, inferServerTransportType(serverConfig), req.Params.Name)
-				return nil, fmt.Errorf("policy check failed for %s/%s: %w", serverConfig.Name, originalToolName, err)
-			}
-			if !decision.Allowed {
-				return nil, fmt.Errorf("policy denied tool %s on server %s: %s", originalToolName, serverConfig.Name, decision.Reason)
-			}
 		}
 
 		// Debug logging to stderr

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -112,44 +112,8 @@ func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, _ 
 			fmt.Fprintf(os.Stderr, "[MCP-HANDLER] Tool call received: %s from server: %s\n", req.Params.Name, serverConfig.Name)
 		}
 
-		// Start telemetry span for tool call
-		startTime := time.Now()
-		serverTransportType := inferServerTransportType(serverConfig)
-
-		// Build span attributes
-		spanAttrs := []attribute.KeyValue{
-			attribute.String("mcp.server.name", serverConfig.Name),
-			attribute.String("mcp.server.type", serverTransportType),
-		}
-
-		// Add additional server-specific attributes
-		if serverConfig.Spec.Image != "" {
-			spanAttrs = append(spanAttrs, attribute.String("mcp.server.image", serverConfig.Spec.Image))
-		}
-		if serverConfig.Spec.SSEEndpoint != "" {
-			spanAttrs = append(spanAttrs, attribute.String("mcp.server.endpoint", serverConfig.Spec.SSEEndpoint))
-		} else if serverConfig.Spec.Remote.URL != "" {
-			spanAttrs = append(spanAttrs, attribute.String("mcp.server.endpoint", serverConfig.Spec.Remote.URL))
-		}
-
-		ctx, span := telemetry.StartToolCallSpan(ctx, req.Params.Name, spanAttrs...)
-		defer span.End()
-
-		// Record tool call counter with server attribution
-		telemetry.ToolCallCounter.Add(ctx, 1,
-			metric.WithAttributes(
-				attribute.String("mcp.server.name", serverConfig.Name),
-				attribute.String("mcp.server.type", serverTransportType),
-				attribute.String("mcp.tool.name", req.Params.Name),
-				attribute.String("mcp.client.name", req.Session.InitializeParams().ClientInfo.Name),
-			),
-		)
-
 		client, err := g.clientPool.AcquireClient(ctx, serverConfig, getClientConfig(req.Session, server))
 		if err != nil {
-			// Record error in telemetry
-			telemetry.RecordToolError(ctx, span, serverConfig.Name, serverTransportType, req.Params.Name)
-			span.SetStatus(codes.Error, "Failed to acquire client")
 			return nil, err
 		}
 		defer g.clientPool.ReleaseClient(client)
@@ -158,8 +122,6 @@ func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, _ 
 		var args any
 		if len(req.Params.Arguments) > 0 {
 			if jsonErr := json.Unmarshal(req.Params.Arguments, &args); jsonErr != nil {
-				telemetry.RecordToolError(ctx, span, serverConfig.Name, serverTransportType, req.Params.Name)
-				span.SetStatus(codes.Error, "Failed to unmarshal arguments")
 				return nil, fmt.Errorf("failed to unmarshal arguments: %w", jsonErr)
 			}
 		}
@@ -171,26 +133,10 @@ func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, _ 
 
 		// Execute the tool call
 		result, err := client.Session().CallTool(ctx, params)
-
-		// Record duration
-		duration := time.Since(startTime).Milliseconds()
-		telemetry.ToolCallDuration.Record(ctx, float64(duration),
-			metric.WithAttributes(
-				attribute.String("mcp.server.name", serverConfig.Name),
-				attribute.String("mcp.server.type", serverTransportType),
-				attribute.String("mcp.tool.name", req.Params.Name),
-				attribute.String("mcp.client.name", req.Session.InitializeParams().ClientInfo.Name),
-			),
-		)
-
 		if err != nil {
-			// Record error in telemetry
-			telemetry.RecordToolError(ctx, span, serverConfig.Name, serverTransportType, req.Params.Name)
-			span.SetStatus(codes.Error, "Tool execution failed")
 			return nil, err
 		}
 
-		span.SetStatus(codes.Ok, "")
 		return result, nil
 	}
 }

--- a/pkg/gateway/handlers_telemetry_test.go
+++ b/pkg/gateway/handlers_telemetry_test.go
@@ -314,6 +314,40 @@ func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
 	assertToolDurationMetric(t, metricReader, "poci-server", "dangerous-tool")
 }
 
+func TestMCPServerPolicyEvaluationFailureRecordsErrorMetric(t *testing.T) {
+	_, metricReader := setupTestTelemetry(t)
+	policyClient := newMockPolicyClient()
+	policyClient.failWith("remote-server", "dangerous-tool", policy.ActionInvoke, assert.AnError)
+	serverConfig := &catalog.ServerConfig{
+		Name: "remote-server",
+		Spec: catalog.Server{Remote: catalog.Remote{
+			Transport: "sse",
+		}},
+	}
+	gateway := &Gateway{
+		policyClient: policyClient,
+		configuration: Configuration{
+			serverNames: []string{serverConfig.Name},
+			servers:     map[string]catalog.Server{serverConfig.Name: serverConfig.Spec},
+		},
+	}
+	nextCalled := false
+	handler := withMCPServerPolicyErrorTelemetry(
+		serverConfig,
+		gateway.withInvokePolicy(serverConfig.Name, "dangerous-tool", func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			nextCalled = true
+			return &mcp.CallToolResult{}, nil
+		}),
+	)
+
+	_, err := handler(t.Context(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: "remote-server-dangerous-tool"},
+	})
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, nextCalled)
+	assertToolErrorMetric(t, metricReader, "remote-server", "sse", "remote-server-dangerous-tool")
+}
+
 func TestPOCIInvalidArgumentsRecordDuration(t *testing.T) {
 	spanRecorder, metricReader := setupTestTelemetry(t)
 	gateway := &Gateway{}
@@ -435,4 +469,27 @@ func assertToolDurationMetric(t *testing.T, metricReader *sdkmetric.ManualReader
 		}
 	}
 	t.Fatal("Tool duration histogram not found")
+}
+
+func assertToolErrorMetric(t *testing.T, metricReader *sdkmetric.ManualReader, serverName, serverType, toolName string) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, metricReader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "mcp.tool.errors" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			assert.Equal(t, int64(1), sum.DataPoints[0].Value)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "mcp.server.name", serverName)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "mcp.server.type", serverType)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "mcp.tool.name", toolName)
+			return
+		}
+	}
+	t.Fatal("Tool error counter not found")
 }

--- a/pkg/gateway/handlers_telemetry_test.go
+++ b/pkg/gateway/handlers_telemetry_test.go
@@ -295,7 +295,12 @@ func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
 			tools: config.ToolsConfig{ServerTools: map[string][]string{}},
 		},
 	}
-	handler := gateway.mcpToolHandler("poci-server", catalog.Tool{Name: "dangerous-tool"})
+	tool := catalog.Tool{Name: "dangerous-tool"}
+	handler := gateway.withPOCIToolTelemetry(
+		"poci-server",
+		tool,
+		gateway.withInvokePolicy("poci-server", tool.Name, gateway.pociToolHandler(tool)),
+	)
 
 	_, err := handler(t.Context(), &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{Name: "dangerous-tool"},
@@ -312,7 +317,12 @@ func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
 func TestPOCIInvalidArgumentsRecordDuration(t *testing.T) {
 	spanRecorder, metricReader := setupTestTelemetry(t)
 	gateway := &Gateway{}
-	handler := gateway.mcpToolHandler("poci-server", catalog.Tool{Name: "malformed-tool"})
+	tool := catalog.Tool{Name: "malformed-tool"}
+	handler := gateway.withPOCIToolTelemetry(
+		"poci-server",
+		tool,
+		gateway.withInvokePolicy("poci-server", tool.Name, gateway.pociToolHandler(tool)),
+	)
 
 	_, err := handler(t.Context(), &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{

--- a/pkg/gateway/handlers_telemetry_test.go
+++ b/pkg/gateway/handlers_telemetry_test.go
@@ -311,41 +311,69 @@ func TestPOCIPolicyDenialCreatesErrorSpan(t *testing.T) {
 	require.Len(t, spans, 1)
 	assert.Equal(t, "mcp.tool.call", spans[0].Name())
 	assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
-	assertToolDurationMetric(t, metricReader, "poci-server", "dangerous-tool")
+	assertToolDurationMetric(t, metricReader, "poci-server", "docker", "dangerous-tool")
 }
 
-func TestMCPServerPolicyEvaluationFailureRecordsErrorMetric(t *testing.T) {
-	_, metricReader := setupTestTelemetry(t)
-	policyClient := newMockPolicyClient()
-	policyClient.failWith("remote-server", "dangerous-tool", policy.ActionInvoke, assert.AnError)
-	serverConfig := &catalog.ServerConfig{
-		Name: "remote-server",
-		Spec: catalog.Server{Remote: catalog.Remote{
-			Transport: "sse",
-		}},
-	}
-	gateway := &Gateway{
-		policyClient: policyClient,
-		configuration: Configuration{
-			serverNames: []string{serverConfig.Name},
-			servers:     map[string]catalog.Server{serverConfig.Name: serverConfig.Spec},
-		},
-	}
-	nextCalled := false
-	handler := withMCPServerPolicyErrorTelemetry(
-		serverConfig,
-		gateway.withInvokePolicy(serverConfig.Name, "dangerous-tool", func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			nextCalled = true
-			return &mcp.CallToolResult{}, nil
-		}),
-	)
+func TestMCPServerPolicyFailuresRecordCompleteTelemetry(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		evaluationError bool
+	}{
+		{name: "denial"},
+		{name: "evaluation_error", evaluationError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spanRecorder, metricReader := setupTestTelemetry(t)
+			policyClient := newMockPolicyClient()
+			if tc.evaluationError {
+				policyClient.failWith("remote-server", "dangerous-tool", policy.ActionInvoke, assert.AnError)
+			} else {
+				policyClient.deny("remote-server", "dangerous-tool", policy.ActionInvoke, "blocked")
+			}
+			serverConfig := &catalog.ServerConfig{
+				Name: "remote-server",
+				Spec: catalog.Server{Remote: catalog.Remote{
+					Transport: "sse",
+				}},
+			}
+			gateway := &Gateway{
+				policyClient: policyClient,
+				configuration: Configuration{
+					serverNames: []string{serverConfig.Name},
+					servers:     map[string]catalog.Server{serverConfig.Name: serverConfig.Spec},
+				},
+			}
+			nextCalled := false
+			handler := withMCPServerToolTelemetry(
+				serverConfig,
+				gateway.withInvokePolicy(serverConfig.Name, "dangerous-tool", func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					nextCalled = true
+					return &mcp.CallToolResult{}, nil
+				}),
+			)
 
-	_, err := handler(t.Context(), &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{Name: "remote-server-dangerous-tool"},
-	})
-	require.ErrorIs(t, err, assert.AnError)
-	assert.False(t, nextCalled)
-	assertToolErrorMetric(t, metricReader, "remote-server", "sse", "remote-server-dangerous-tool")
+			_, err := handler(t.Context(), &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{Name: "remote-server-dangerous-tool"},
+			})
+			if tc.evaluationError {
+				require.ErrorIs(t, err, assert.AnError)
+			} else {
+				require.ErrorContains(t, err, "policy denied")
+			}
+			assert.False(t, nextCalled)
+
+			spans := spanRecorder.Ended()
+			require.Len(t, spans, 1)
+			assert.Equal(t, "mcp.tool.call", spans[0].Name())
+			assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
+			assertAttribute(t, spans[0].Attributes(), "mcp.server.name", "remote-server")
+			assertAttribute(t, spans[0].Attributes(), "mcp.server.type", "sse")
+			assertAttribute(t, spans[0].Attributes(), "mcp.tool.name", "remote-server-dangerous-tool")
+			assertToolCallMetric(t, metricReader, "remote-server", "sse", "remote-server-dangerous-tool")
+			assertToolDurationMetric(t, metricReader, "remote-server", "sse", "remote-server-dangerous-tool")
+			assertToolErrorMetric(t, metricReader, "remote-server", "sse", "remote-server-dangerous-tool")
+		})
+	}
 }
 
 func TestPOCIInvalidArgumentsRecordDuration(t *testing.T) {
@@ -370,7 +398,7 @@ func TestPOCIInvalidArgumentsRecordDuration(t *testing.T) {
 	spans := spanRecorder.Ended()
 	require.Len(t, spans, 1)
 	assert.Equal(t, otelcodes.Error, spans[0].Status().Code)
-	assertToolDurationMetric(t, metricReader, "poci-server", "malformed-tool")
+	assertToolDurationMetric(t, metricReader, "poci-server", "docker", "malformed-tool")
 }
 
 // TestHandlerInstrumentationIntegration is a placeholder for full integration test
@@ -448,7 +476,30 @@ func assertMetricAttribute(t *testing.T, set attribute.Set, key string, expected
 	assert.Equal(t, expectedValue, value.AsString())
 }
 
-func assertToolDurationMetric(t *testing.T, metricReader *sdkmetric.ManualReader, serverName, toolName string) {
+func assertToolCallMetric(t *testing.T, metricReader *sdkmetric.ManualReader, serverName, serverType, toolName string) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, metricReader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "mcp.tool.calls" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			assert.Equal(t, int64(1), sum.DataPoints[0].Value)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "mcp.server.name", serverName)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "mcp.server.type", serverType)
+			assertMetricAttribute(t, sum.DataPoints[0].Attributes, "mcp.tool.name", toolName)
+			return
+		}
+	}
+	t.Fatal("Tool call counter not found")
+}
+
+func assertToolDurationMetric(t *testing.T, metricReader *sdkmetric.ManualReader, serverName, serverType, toolName string) {
 	t.Helper()
 
 	var rm metricdata.ResourceMetrics
@@ -463,7 +514,7 @@ func assertToolDurationMetric(t *testing.T, metricReader *sdkmetric.ManualReader
 			require.Len(t, histogram.DataPoints, 1)
 			assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
 			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.server.name", serverName)
-			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.server.type", "docker")
+			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.server.type", serverType)
 			assertMetricAttribute(t, histogram.DataPoints[0].Attributes, "mcp.tool.name", toolName)
 			return
 		}

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 	"github.com/docker/mcp-gateway/pkg/oci"
+	"github.com/docker/mcp-gateway/pkg/policy"
 )
 
 func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
@@ -66,7 +67,11 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 			}, nil
 		}
 
-		if err := g.checkServerManagementAccess(ctx, serverName, req.Session); err != nil {
+		if err := g.checkServerManagementAccess(
+			ctx,
+			g.configuration.policyRequest(serverName, "", policy.ActionLoad),
+			req.Session,
+		); err != nil {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: " + err.Error()}},
 				IsError: true,

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/mcp-gateway/pkg/oauth"
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 	"github.com/docker/mcp-gateway/pkg/oci"
-	"github.com/docker/mcp-gateway/pkg/policy"
 )
 
 func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
@@ -67,27 +66,11 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 			}, nil
 		}
 
-		// Check if server is allowed by policy before adding
-		if g.policyClient != nil {
-			policyReq := g.configuration.policyRequest(serverName, "", policy.ActionLoad)
-			decision, err := g.policyClient.Evaluate(ctx, policyReq)
-			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
-			submitAuditEvent(g.policyClient, event)
-			if err != nil {
-				log.Logf("policy check failed for server %s: %v (denying)", serverName, err)
-				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{
-						Text: fmt.Sprintf("Error: Server '%s' blocked by policy check error: %v", serverName, err),
-					}},
-				}, nil
-			}
-			if !decision.Allowed {
-				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{
-						Text: fmt.Sprintf("Error: Server '%s' is blocked by policy: %s", serverName, decision.Reason),
-					}},
-				}, nil
-			}
+		if err := g.checkServerManagementAccess(ctx, serverName, req.Session); err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: " + err.Error()}},
+				IsError: true,
+			}, nil
 		}
 
 		// Append the new server to the current serverNames if not already present

--- a/pkg/gateway/mcpexec.go
+++ b/pkg/gateway/mcpexec.go
@@ -3,13 +3,13 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/mcp-gateway/pkg/log"
-	"github.com/docker/mcp-gateway/pkg/policy"
 )
 
 func addMcpExecHandler(g *Gateway) mcp.ToolHandler {
@@ -79,32 +79,21 @@ func addMcpExecHandler(g *Gateway) mcp.ToolHandler {
 			Extra: req.Extra,
 		}
 
-		// Policy check before executing the tool
-		if g.policyClient != nil {
-			policyReq := g.configuration.policyRequest(toolReg.ServerName, toolName, policy.ActionInvoke)
-			decision, err := g.policyClient.Evaluate(ctx, policyReq)
-			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
-			submitAuditEvent(g.policyClient, event)
-			if err != nil {
-				log.Logf("policy check failed for mcp-exec %s: %v (denying)", toolName, err)
-				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{
-						Text: fmt.Sprintf("Error: Tool '%s' blocked due to policy check error: %v", toolName, err),
-					}},
-				}, nil
-			}
-			if !decision.Allowed {
-				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{
-						Text: fmt.Sprintf("Error: Tool '%s' blocked by policy: %s", toolName, decision.Reason),
-					}},
-				}, nil
-			}
-		}
-
 		// Execute the tool using its registered handler
 		result, err := toolReg.Handler(ctx, toolCallRequest)
 		if err != nil {
+			var policyErr *invokePolicyError
+			if errors.As(err, &policyErr) {
+				if policyErr.cause != nil {
+					log.Logf("policy check failed for mcp-exec %s: %v (denying)", toolName, policyErr.cause)
+					return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{
+						Text: fmt.Sprintf("Error: Tool '%s' blocked due to policy check error: %v", toolName, policyErr.cause),
+					}}}, nil
+				}
+				return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{
+					Text: fmt.Sprintf("Error: Tool '%s' blocked by policy: %s", toolName, policyErr.reason),
+				}}}, nil
+			}
 			return nil, fmt.Errorf("tool execution failed: %w", err)
 		}
 

--- a/pkg/gateway/policy_authz_test.go
+++ b/pkg/gateway/policy_authz_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/policy"
+	"github.com/docker/mcp-gateway/pkg/workingset"
 )
 
 func newServerLoadPolicyGateway(mock *mockPolicyClient) *Gateway {
@@ -42,7 +43,11 @@ func newCatalogManagementGateway(client policy.Client) *Gateway {
 func TestCheckServerManagementAccess(t *testing.T) {
 	t.Run("enabled_server_does_not_require_policy_provider", func(t *testing.T) {
 		g := newCatalogManagementGateway(nil)
-		require.NoError(t, g.checkServerManagementAccess(context.Background(), "enabled-server", nil))
+		require.NoError(t, g.checkServerManagementAccess(
+			context.Background(),
+			g.configuration.policyRequest("enabled-server", "", policy.ActionLoad),
+			nil,
+		))
 	})
 
 	for _, tc := range []struct {
@@ -55,7 +60,11 @@ func TestCheckServerManagementAccess(t *testing.T) {
 	} {
 		t.Run(tc.name+"_cannot_authorize_catalog_only_server", func(t *testing.T) {
 			g := newCatalogManagementGateway(tc.client)
-			err := g.checkServerManagementAccess(context.Background(), "catalog-only", nil)
+			err := g.checkServerManagementAccess(
+				context.Background(),
+				g.configuration.policyRequest("catalog-only", "", policy.ActionLoad),
+				nil,
+			)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "no enforcing policy")
 		})
@@ -63,14 +72,22 @@ func TestCheckServerManagementAccess(t *testing.T) {
 
 	t.Run("enforcing_policy_can_authorize_catalog_only_server", func(t *testing.T) {
 		g := newCatalogManagementGateway(newMockPolicyClient())
-		require.NoError(t, g.checkServerManagementAccess(context.Background(), "catalog-only", nil))
+		require.NoError(t, g.checkServerManagementAccess(
+			context.Background(),
+			g.configuration.policyRequest("catalog-only", "", policy.ActionLoad),
+			nil,
+		))
 	})
 
 	t.Run("enforcing_policy_denial_blocks_catalog_only_server", func(t *testing.T) {
 		mock := newMockPolicyClient()
 		mock.deny("catalog-only", "", policy.ActionLoad, "server blocked by admin")
 		g := newCatalogManagementGateway(mock)
-		err := g.checkServerManagementAccess(context.Background(), "catalog-only", nil)
+		err := g.checkServerManagementAccess(
+			context.Background(),
+			g.configuration.policyRequest("catalog-only", "", policy.ActionLoad),
+			nil,
+		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "blocked by policy")
 	})
@@ -102,6 +119,55 @@ func TestNoopPolicyCannotMutateCatalogOnlyServer(t *testing.T) {
 	assert.True(t, configResult.IsError)
 	assert.Contains(t, configResult.Content[0].(*mcp.TextContent).Text, "no enforcing policy")
 	assert.Empty(t, g.configuration.config)
+}
+
+func TestActivateProfileCannotActivateCatalogOnlyServerWithoutEnforcingPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		client policy.Client
+	}{
+		{name: "missing_policy", client: nil},
+		{name: "noop_policy", client: policy.NoopClient{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &Gateway{
+				policyClient: tc.client,
+				configuration: Configuration{
+					serverNames: []string{"enabled-server"},
+					servers: map[string]catalog.Server{
+						"enabled-server": {Image: "enabled-image"},
+					},
+					config: map[string]map[string]any{},
+				},
+			}
+			profile := workingset.WorkingSet{
+				Version: workingset.CurrentWorkingSetVersion,
+				ID:      "catalog-profile",
+				Name:    "catalog-profile",
+				Servers: []workingset.Server{
+					{
+						Type:     workingset.ServerTypeRemote,
+						Endpoint: "https://mcp.example.test/mcp",
+						Snapshot: &workingset.ServerSnapshot{Server: catalog.Server{
+							Name: "catalog-only",
+							Type: "remote",
+							Remote: catalog.Remote{
+								URL:       "https://mcp.example.test/mcp",
+								Transport: "http",
+							},
+						}},
+					},
+				},
+			}
+
+			err := g.ActivateProfile(t.Context(), profile)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no enforcing policy")
+			assert.Equal(t, []string{"enabled-server"}, g.configuration.serverNames)
+			assert.NotContains(t, g.configuration.servers, "catalog-only")
+			assert.Empty(t, g.configuration.config)
+		})
+	}
 }
 
 // TestCheckServerLoadPolicy covers the shared ActionLoad gate used by the

--- a/pkg/gateway/policy_authz_test.go
+++ b/pkg/gateway/policy_authz_test.go
@@ -25,6 +25,85 @@ func newServerLoadPolicyGateway(mock *mockPolicyClient) *Gateway {
 	}
 }
 
+func newCatalogManagementGateway(client policy.Client) *Gateway {
+	return &Gateway{
+		policyClient: client,
+		configuration: Configuration{
+			serverNames: []string{"enabled-server"},
+			servers: map[string]catalog.Server{
+				"enabled-server": {Image: "enabled-image"},
+				"catalog-only":   {Image: "catalog-image"},
+			},
+			config: map[string]map[string]any{},
+		},
+	}
+}
+
+func TestCheckServerManagementAccess(t *testing.T) {
+	t.Run("enabled_server_does_not_require_policy_provider", func(t *testing.T) {
+		g := newCatalogManagementGateway(nil)
+		require.NoError(t, g.checkServerManagementAccess(context.Background(), "enabled-server", nil))
+	})
+
+	for _, tc := range []struct {
+		name   string
+		client policy.Client
+	}{
+		{name: "missing_policy", client: nil},
+		{name: "noop_policy", client: policy.NoopClient{}},
+		{name: "noop_policy_pointer", client: &policy.NoopClient{}},
+	} {
+		t.Run(tc.name+"_cannot_authorize_catalog_only_server", func(t *testing.T) {
+			g := newCatalogManagementGateway(tc.client)
+			err := g.checkServerManagementAccess(context.Background(), "catalog-only", nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no enforcing policy")
+		})
+	}
+
+	t.Run("enforcing_policy_can_authorize_catalog_only_server", func(t *testing.T) {
+		g := newCatalogManagementGateway(newMockPolicyClient())
+		require.NoError(t, g.checkServerManagementAccess(context.Background(), "catalog-only", nil))
+	})
+
+	t.Run("enforcing_policy_denial_blocks_catalog_only_server", func(t *testing.T) {
+		mock := newMockPolicyClient()
+		mock.deny("catalog-only", "", policy.ActionLoad, "server blocked by admin")
+		g := newCatalogManagementGateway(mock)
+		err := g.checkServerManagementAccess(context.Background(), "catalog-only", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "blocked by policy")
+	})
+}
+
+func TestNoopPolicyCannotMutateCatalogOnlyServer(t *testing.T) {
+	g := newCatalogManagementGateway(policy.NoopClient{})
+
+	addResult, err := addServerHandler(g, nil)(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "mcp-add",
+			Arguments: json.RawMessage(`{"name":"catalog-only"}`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, addResult)
+	assert.True(t, addResult.IsError)
+	assert.Contains(t, addResult.Content[0].(*mcp.TextContent).Text, "no enforcing policy")
+	assert.Equal(t, []string{"enabled-server"}, g.configuration.serverNames)
+
+	configResult, err := configSetHandler(g)(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "mcp-config-set",
+			Arguments: json.RawMessage(`{"server":"catalog-only","config":{"k":"v"}}`),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, configResult)
+	assert.True(t, configResult.IsError)
+	assert.Contains(t, configResult.Content[0].(*mcp.TextContent).Text, "no enforcing policy")
+	assert.Empty(t, g.configuration.config)
+}
+
 // TestCheckServerLoadPolicy covers the shared ActionLoad gate used by the
 // dynamic management tools (mcp-config-set / activate-profile).
 func TestCheckServerLoadPolicy(t *testing.T) {

--- a/pkg/gateway/policy_test.go
+++ b/pkg/gateway/policy_test.go
@@ -219,7 +219,11 @@ func TestMcpServerToolHandler_PolicyEnforcement(t *testing.T) {
 		}
 
 		// Get handler
-		handler := g.mcpServerToolHandler("test-server", nil, nil, "test-tool")
+		handler := g.withInvokePolicy(
+			"test-server",
+			"test-tool",
+			g.mcpServerToolHandler("test-server", nil, nil, "test-tool"),
+		)
 
 		// Execute
 		req := &mcp.CallToolRequest{
@@ -251,7 +255,11 @@ func TestMcpServerToolHandler_PolicyEnforcement(t *testing.T) {
 			policyClient: mock,
 		}
 
-		handler := g.mcpServerToolHandler("test-server", nil, nil, "test-tool")
+		handler := g.withInvokePolicy(
+			"test-server",
+			"test-tool",
+			g.mcpServerToolHandler("test-server", nil, nil, "test-tool"),
+		)
 
 		req := &mcp.CallToolRequest{
 			Params: &mcp.CallToolParamsRaw{
@@ -281,7 +289,7 @@ func TestPOCIToolHandler_PolicyEnforcement(t *testing.T) {
 			},
 		},
 	}
-	handler := g.mcpToolHandler("poci-server", catalog.Tool{Name: "dangerous-tool"})
+	handler := g.withInvokePolicy("poci-server", "dangerous-tool", g.pociToolHandler(catalog.Tool{Name: "dangerous-tool"}))
 	req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{Name: "dangerous-tool"}}
 
 	result, err := handler(t.Context(), req)
@@ -325,7 +333,7 @@ func TestMcpExec_PolicyEnforcement(t *testing.T) {
 		g.toolRegistrations["dangerous-tool"] = ToolRegistration{
 			ServerName: "backend-server",
 			Tool:       &mcp.Tool{Name: "dangerous-tool"},
-			Handler:    mockToolHandler,
+			Handler:    g.withInvokePolicy("backend-server", "dangerous-tool", mockToolHandler),
 		}
 
 		// Get mcp-exec handler
@@ -395,7 +403,7 @@ func TestMcpExec_PolicyEnforcement(t *testing.T) {
 		g.toolRegistrations["test-tool"] = ToolRegistration{
 			ServerName: "backend-server",
 			Tool:       &mcp.Tool{Name: "test-tool"},
-			Handler:    mockToolHandler,
+			Handler:    g.withInvokePolicy("backend-server", "test-tool", mockToolHandler),
 		}
 
 		mcpExecHandler := addMcpExecHandler(g)

--- a/pkg/gateway/tool_names.go
+++ b/pkg/gateway/tool_names.go
@@ -77,25 +77,50 @@ func validateToolNameCollisions(registrations []ToolRegistration, existing map[s
 		}
 
 		if rejectReserved {
-			if _, reserved := reservedGatewayToolNames[toolName]; reserved {
-				return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes reserved gateway tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolName)}
+			if reservedName, _, reserved := findEqualFoldMapEntry(reservedGatewayToolNames, toolName); reserved {
+				if reservedName == toolName {
+					return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes reserved gateway tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolName)}
+				}
+				return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes tool name %q, which differs only by case from reserved gateway tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolName, reservedName)}
 			}
 		}
 
-		if previous, ok := seen[toolName]; ok {
-			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s and %s both expose tool name %q; enable tool-name-prefix or set unique catalog prefixes", toolOwner(previous), toolOwner(registration), toolName)}
+		if previousName, previous, ok := findEqualFoldMapEntry(seen, toolName); ok {
+			if previousName == toolName {
+				return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s and %s both expose tool name %q; enable tool-name-prefix or set unique catalog prefixes", toolOwner(previous), toolOwner(registration), toolName)}
+			}
+			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes tool name %q and %s exposes case-variant tool name %q; enable tool-name-prefix or set unique catalog prefixes", toolOwner(previous), previousName, toolOwner(registration), toolName)}
 		}
 		seen[toolName] = registration
 
 		if existing == nil {
 			continue
 		}
-		if previous, ok := existing[toolName]; ok {
-			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s would shadow %s for tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolOwner(previous), toolName)}
+		if previousName, previous, ok := findEqualFoldMapEntry(existing, toolName); ok {
+			if previousName == toolName {
+				return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s would shadow %s for tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolOwner(previous), toolName)}
+			}
+			return toolNameCollisionError{message: fmt.Sprintf("tool name collision: %s exposes tool name %q, which differs only by case from %s tool name %q; enable tool-name-prefix or set a unique catalog prefix", toolOwner(registration), toolName, toolOwner(previous), previousName)}
 		}
 	}
 
 	return nil
+}
+
+func findEqualFoldMapEntry[V any](entries map[string]V, candidate string) (string, V, bool) {
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if strings.EqualFold(key, candidate) {
+			return key, entries[key], true
+		}
+	}
+
+	var zero V
+	return "", zero, false
 }
 
 func sortedToolRegistrations(registrations []ToolRegistration) []ToolRegistration {
@@ -295,19 +320,31 @@ func (g *Gateway) catalogToolNameWarnings(serverName string, server catalog.Serv
 		}
 
 		exposedName := prefixToolName(prefix, toolName)
-		if previousRawName, ok := seen[exposedName]; ok {
-			warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which duplicates tool %q in this server", toolName, exposedName, previousRawName))
+		if previousExposedName, previousRawName, ok := findEqualFoldMapEntry(seen, exposedName); ok {
+			if previousExposedName == exposedName {
+				warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which duplicates tool %q in this server", toolName, exposedName, previousRawName))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which differs only by case from tool %q exposed as %q in this server", toolName, exposedName, previousRawName, previousExposedName))
+			}
 			continue
 		}
 		seen[exposedName] = toolName
 
-		if _, reserved := reservedGatewayToolNames[exposedName]; reserved {
-			warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which is reserved for a gateway internal tool", toolName, exposedName))
+		if reservedName, _, reserved := findEqualFoldMapEntry(reservedGatewayToolNames, exposedName); reserved {
+			if reservedName == exposedName {
+				warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which is reserved for a gateway internal tool", toolName, exposedName))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which differs only by case from reserved gateway internal tool %q", toolName, exposedName, reservedName))
+			}
 			continue
 		}
 
-		if previous, ok := existing[exposedName]; ok && previous.ServerName != serverName {
-			warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which conflicts with %s", toolName, exposedName, toolOwner(previous)))
+		if previousName, previous, ok := findEqualFoldMapEntry(existing, exposedName); ok && previous.ServerName != serverName {
+			if previousName == exposedName {
+				warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which conflicts with %s", toolName, exposedName, toolOwner(previous)))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("tool %q would be exposed as %q, which differs only by case from %s tool name %q", toolName, exposedName, toolOwner(previous), previousName))
+			}
 		}
 	}
 

--- a/pkg/gateway/tool_names_test.go
+++ b/pkg/gateway/tool_names_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -57,6 +58,71 @@ func TestValidateExternalToolNameCollisionsRejectsReservedGatewayToolName(t *tes
 	require.ErrorIs(t, err, errToolNameCollision)
 	assert.Contains(t, err.Error(), "reserved gateway tool name")
 	assert.Contains(t, err.Error(), "mcp-exec")
+}
+
+func TestValidateExternalToolNameCollisionsRejectsCaseVariantReservedGatewayToolName(t *testing.T) {
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "untrusted",
+			Tool:       &mcp.Tool{Name: "MCP-EXEC"},
+		},
+	}, nil)
+
+	require.ErrorIs(t, err, errToolNameCollision)
+	assert.Contains(t, err.Error(), "differs only by case")
+	assert.Contains(t, err.Error(), "mcp-exec")
+}
+
+func TestValidateExternalToolNameCollisionsRejectsCaseVariantDuplicates(t *testing.T) {
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "alpha",
+			Tool:       &mcp.Tool{Name: "Search"},
+		},
+		{
+			ServerName: "beta",
+			Tool:       &mcp.Tool{Name: "search"},
+		},
+	}, nil)
+
+	require.ErrorIs(t, err, errToolNameCollision)
+	assert.Contains(t, err.Error(), "case-variant tool name")
+	assert.Contains(t, err.Error(), `"Search"`)
+	assert.Contains(t, err.Error(), `"search"`)
+}
+
+func TestValidateExternalToolNameCollisionsRejectsCaseVariantExistingTool(t *testing.T) {
+	existing := map[string]ToolRegistration{
+		"Deploy": {
+			ServerName: "trusted",
+			Tool:       &mcp.Tool{Name: "Deploy"},
+		},
+	}
+
+	err := validateExternalToolNameCollisions([]ToolRegistration{
+		{
+			ServerName: "untrusted",
+			Tool:       &mcp.Tool{Name: "deploy"},
+		},
+	}, existing)
+
+	require.ErrorIs(t, err, errToolNameCollision)
+	assert.Contains(t, err.Error(), "differs only by case")
+	assert.Contains(t, err.Error(), `server "trusted"`)
+}
+
+func TestToolAndPromptNamesUseSeparateCollisionNamespaces(t *testing.T) {
+	tools := []ToolRegistration{
+		{ServerName: "tool-server", Tool: &mcp.Tool{Name: "Summarize"}},
+	}
+	prompts := &Capabilities{
+		Prompts: []PromptRegistration{
+			{ServerName: "prompt-server", Prompt: &mcp.Prompt{Name: "summarize"}},
+		},
+	}
+
+	require.NoError(t, validateExternalToolNameCollisions(tools, nil))
+	require.NoError(t, validateExternalCapabilityNameCollisions(prompts, capabilityNameIndexes{}, true))
 }
 
 func TestValidateExternalToolNameCollisionsRejectsDynamicMcpExecShadow(t *testing.T) {
@@ -194,6 +260,23 @@ func TestValidateExternalCapabilityNameCollisionsRejectsResourceURIShadow(t *tes
 	assert.Contains(t, err.Error(), "file://shared/readme")
 }
 
+func TestValidateExternalCapabilityNameCollisionsKeepsResourceURICaseSignificant(t *testing.T) {
+	err := validateExternalCapabilityNameCollisions(&Capabilities{
+		Resources: []ResourceRegistration{
+			{
+				ServerName: "alpha",
+				Resource:   &mcp.Resource{URI: "file://shared/Readme"},
+			},
+			{
+				ServerName: "beta",
+				Resource:   &mcp.Resource{URI: "file://shared/readme"},
+			},
+		},
+	}, capabilityNameIndexes{}, false)
+
+	require.NoError(t, err)
+}
+
 func TestValidateExternalCapabilityNameCollisionsRejectsDuplicateResourceTemplates(t *testing.T) {
 	err := validateExternalCapabilityNameCollisions(&Capabilities{
 		ResourceTemplates: []ResourceTemplateRegistration{
@@ -315,6 +398,32 @@ func TestCatalogToolNameWarningsReportPotentialMcpFindCollisions(t *testing.T) {
 	assert.Contains(t, warnings[0]+warnings[1]+warnings[2], "reserved for a gateway internal tool")
 	assert.Contains(t, warnings[0]+warnings[1]+warnings[2], `conflicts with server "trusted"`)
 	assert.Contains(t, warnings[0]+warnings[1]+warnings[2], "duplicates tool")
+}
+
+func TestCatalogToolNameWarningsReportCaseVariantCollisions(t *testing.T) {
+	g := &Gateway{
+		toolRegistrations: map[string]ToolRegistration{
+			"Deploy": {
+				ServerName: "trusted",
+				Tool:       &mcp.Tool{Name: "Deploy"},
+			},
+		},
+	}
+
+	warnings := g.catalogToolNameWarnings("candidate", catalog.Server{
+		Tools: []catalog.Tool{
+			{Name: "MCP-ADD"},
+			{Name: "deploy"},
+			{Name: "Search"},
+			{Name: "search"},
+		},
+	})
+
+	require.Len(t, warnings, 3)
+	combined := strings.Join(warnings, "\n")
+	assert.Contains(t, combined, "differs only by case from reserved gateway internal tool")
+	assert.Contains(t, combined, `differs only by case from server "trusted" tool name "Deploy"`)
+	assert.Contains(t, combined, `differs only by case from tool "Search"`)
 }
 
 func TestBM25StrategyIncludesToolNameWarnings(t *testing.T) {

--- a/pkg/gateway/tool_policy.go
+++ b/pkg/gateway/tool_policy.go
@@ -2,10 +2,13 @@ package gateway
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/policy"
@@ -53,17 +56,52 @@ func (g *Gateway) withInvokePolicy(serverName, toolName string, next mcp.ToolHan
 	}
 }
 
-// withMCPServerPolicyErrorTelemetry preserves the error signal for policy
-// evaluator failures that occur before the MCP server handler starts its tool
-// telemetry. The server handler remains responsible for execution failures,
-// while POCI registrations use their existing outer telemetry middleware.
-func withMCPServerPolicyErrorTelemetry(serverConfig *catalog.ServerConfig, next mcp.ToolHandler) mcp.ToolHandler {
+// withMCPServerToolTelemetry records the complete tool-call telemetry envelope
+// outside policy enforcement, so policy denials and evaluator failures are
+// observable without double-counting calls that reach the backend handler.
+func withMCPServerToolTelemetry(serverConfig *catalog.ServerConfig, next mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		result, err := next(ctx, req)
-		var policyErr *invokePolicyError
-		if errors.As(err, &policyErr) && policyErr.cause != nil {
-			telemetry.RecordToolError(ctx, nil, serverConfig.Name, inferServerTransportType(serverConfig), req.Params.Name)
+		clientName := ""
+		if clientInfo := auditClientInfoFromSession(req.Session); clientInfo != nil {
+			clientName = clientInfo.Name
 		}
-		return result, err
+
+		startTime := time.Now()
+		serverType := inferServerTransportType(serverConfig)
+		spanAttrs := []attribute.KeyValue{
+			attribute.String("mcp.server.name", serverConfig.Name),
+			attribute.String("mcp.server.type", serverType),
+		}
+		if serverConfig.Spec.Image != "" {
+			spanAttrs = append(spanAttrs, attribute.String("mcp.server.image", serverConfig.Spec.Image))
+		}
+		if serverConfig.Spec.SSEEndpoint != "" {
+			spanAttrs = append(spanAttrs, attribute.String("mcp.server.endpoint", serverConfig.Spec.SSEEndpoint))
+		} else if serverConfig.Spec.Remote.URL != "" {
+			spanAttrs = append(spanAttrs, attribute.String("mcp.server.endpoint", serverConfig.Spec.Remote.URL))
+		}
+
+		ctx, span := telemetry.StartToolCallSpan(ctx, req.Params.Name, spanAttrs...)
+		metricAttrs := []attribute.KeyValue{
+			attribute.String("mcp.server.name", serverConfig.Name),
+			attribute.String("mcp.server.type", serverType),
+			attribute.String("mcp.tool.name", req.Params.Name),
+			attribute.String("mcp.client.name", clientName),
+		}
+		defer func() {
+			telemetry.ToolCallDuration.Record(ctx, float64(time.Since(startTime).Milliseconds()), metric.WithAttributes(metricAttrs...))
+			span.End()
+		}()
+		telemetry.ToolCallCounter.Add(ctx, 1, metric.WithAttributes(metricAttrs...))
+
+		result, err := next(ctx, req)
+		if err != nil {
+			telemetry.RecordToolError(ctx, span, serverConfig.Name, serverType, req.Params.Name)
+			span.SetStatus(codes.Error, "Tool call failed")
+			return result, err
+		}
+
+		span.SetStatus(codes.Ok, "")
+		return result, nil
 	}
 }

--- a/pkg/gateway/tool_policy.go
+++ b/pkg/gateway/tool_policy.go
@@ -1,0 +1,51 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/mcp-gateway/pkg/policy"
+)
+
+type invokePolicyError struct {
+	server string
+	tool   string
+	reason string
+	cause  error
+}
+
+func (e *invokePolicyError) Error() string {
+	if e.cause != nil {
+		return fmt.Sprintf("policy check failed for %s/%s: %v", e.server, e.tool, e.cause)
+	}
+	return fmt.Sprintf("policy denied tool %s on server %s: %s", e.tool, e.server, e.reason)
+}
+
+func (e *invokePolicyError) Unwrap() error {
+	return e.cause
+}
+
+// withInvokePolicy applies the fail-closed ActionInvoke gate to a backend tool
+// handler. Backend dispatch paths wrap handlers with this middleware when the
+// handler is registered, so direct calls, mcp-exec, and code-mode share the
+// same policy and audit behavior.
+func (g *Gateway) withInvokePolicy(serverName, toolName string, next mcp.ToolHandler) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if g.policyClient != nil {
+			policyReq := g.configuration.policyRequest(serverName, toolName, policy.ActionInvoke)
+			decision, err := g.policyClient.Evaluate(ctx, policyReq)
+			event := buildAuditEvent(policyReq, decision, err, auditClientInfoFromSession(req.Session))
+			submitAuditEvent(g.policyClient, event)
+			if err != nil {
+				return nil, &invokePolicyError{server: serverName, tool: toolName, cause: err}
+			}
+			if !decision.Allowed {
+				return nil, &invokePolicyError{server: serverName, tool: toolName, reason: decision.Reason}
+			}
+		}
+
+		return next(ctx, req)
+	}
+}

--- a/pkg/gateway/tool_policy.go
+++ b/pkg/gateway/tool_policy.go
@@ -2,11 +2,14 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/policy"
+	"github.com/docker/mcp-gateway/pkg/telemetry"
 )
 
 type invokePolicyError struct {
@@ -47,5 +50,20 @@ func (g *Gateway) withInvokePolicy(serverName, toolName string, next mcp.ToolHan
 		}
 
 		return next(ctx, req)
+	}
+}
+
+// withMCPServerPolicyErrorTelemetry preserves the error signal for policy
+// evaluator failures that occur before the MCP server handler starts its tool
+// telemetry. The server handler remains responsible for execution failures,
+// while POCI registrations use their existing outer telemetry middleware.
+func withMCPServerPolicyErrorTelemetry(serverConfig *catalog.ServerConfig, next mcp.ToolHandler) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		result, err := next(ctx, req)
+		var policyErr *invokePolicyError
+		if errors.As(err, &policyErr) && policyErr.cause != nil {
+			telemetry.RecordToolError(ctx, nil, serverConfig.Name, inferServerTransportType(serverConfig), req.Params.Name)
+		}
+		return result, err
 	}
 }

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -12,14 +12,20 @@ import (
 )
 
 func guardedOAuthHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
+	var client *http.Client
 	if proxyDialer := desktop.DockerDesktopProxySocketDialer(ctx); proxyDialer != nil {
-		return remoteurl.NewTrustedProxyHTTPClient(timeout, proxyDialer)
+		client = remoteurl.NewTrustedProxyHTTPClient(timeout, proxyDialer)
+	} else {
+		client = remoteurl.NewDirectHTTPClient(timeout)
 	}
 
-	return &http.Client{
-		Timeout:   timeout,
-		Transport: remoteurl.GuardDirectTransport(),
+	// OAuth token and revocation requests carry credentials in headers or the
+	// request body. Never forward them to a redirect target, even when that
+	// target would otherwise pass the outbound URL safety checks.
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
+	return client
 }
 
 func validateOutboundDCRClientEndpoints(ctx context.Context, client dcr.Client) error {

--- a/pkg/oauth/endpoint_validation.go
+++ b/pkg/oauth/endpoint_validation.go
@@ -11,7 +11,10 @@ import (
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
-func guardedOAuthHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
+// NewCredentialHTTPClient returns an outbound OAuth client for requests that
+// carry credentials in headers or the request body. It preserves the standard
+// direct or Docker Desktop proxy transport guards, but never follows redirects.
+func NewCredentialHTTPClient(ctx context.Context, timeout time.Duration) *http.Client {
 	var client *http.Client
 	if proxyDialer := desktop.DockerDesktopProxySocketDialer(ctx); proxyDialer != nil {
 		client = remoteurl.NewTrustedProxyHTTPClient(timeout, proxyDialer)

--- a/pkg/oauth/endpoint_validation_test.go
+++ b/pkg/oauth/endpoint_validation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/mcp-gateway/pkg/remoteurl"
 )
 
-func TestGuardedOAuthHTTPClientDoesNotForwardCredentialsAcrossRedirects(t *testing.T) {
+func TestCredentialHTTPClientDoesNotForwardCredentialsAcrossRedirects(t *testing.T) {
 	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
 
 	redirectTargetCalled := false
@@ -32,7 +32,7 @@ func TestGuardedOAuthHTTPClientDoesNotForwardCredentialsAcrossRedirects(t *testi
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Basic client-secret")
 
-	resp, err := guardedOAuthHTTPClient(ctx, 0).Do(req)
+	resp, err := NewCredentialHTTPClient(ctx, 0).Do(req)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = resp.Body.Close() })
 

--- a/pkg/oauth/endpoint_validation_test.go
+++ b/pkg/oauth/endpoint_validation_test.go
@@ -1,0 +1,41 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/remoteurl"
+)
+
+func TestGuardedOAuthHTTPClientDoesNotForwardCredentialsAcrossRedirects(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	redirectTargetCalled := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		redirectTargetCalled = true
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	tokenEndpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", redirectTarget.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(tokenEndpoint.Close)
+
+	ctx := desktop.WithNoDockerDesktop(t.Context())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint.URL, http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Basic client-secret")
+
+	resp, err := guardedOAuthHTTPClient(ctx, 0).Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	assert.False(t, redirectTargetCalled, "OAuth credentials must not be forwarded to a redirect target")
+}

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -159,7 +159,7 @@ func (m *Manager) ExchangeCode(ctx context.Context, code string, state string) e
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(ctx, 0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, NewCredentialHTTPClient(ctx, 0))
 
 	token, err := config.Exchange(proxyCtx, code, opts...)
 	if err != nil {

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -289,7 +289,7 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(ctx, 0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, NewCredentialHTTPClient(ctx, 0))
 
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()
 	if err != nil {
@@ -335,7 +335,7 @@ func (p *Provider) refreshTokenCE(ctx context.Context) error {
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, guardedOAuthHTTPClient(ctx, 0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, NewCredentialHTTPClient(ctx, 0))
 
 	// TokenSource automatically refreshes using refresh_token
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()

--- a/pkg/oauth/revoke.go
+++ b/pkg/oauth/revoke.go
@@ -55,7 +55,7 @@ func RevokeTokenAtProvider(ctx context.Context, client dcr.Client, token *oauth2
 		return fmt.Errorf("OAuth token for %s contains no access or refresh token", client.ServerName)
 	}
 
-	httpClient := guardedOAuthHTTPClient(ctx, 30*time.Second)
+	httpClient := NewCredentialHTTPClient(ctx, 30*time.Second)
 
 	for _, item := range requests {
 		form := url.Values{

--- a/pkg/oauth/revoke.go
+++ b/pkg/oauth/revoke.go
@@ -56,9 +56,6 @@ func RevokeTokenAtProvider(ctx context.Context, client dcr.Client, token *oauth2
 	}
 
 	httpClient := guardedOAuthHTTPClient(ctx, 30*time.Second)
-	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
 
 	for _, item := range requests {
 		form := url.Values{

--- a/pkg/oauth/token_store.go
+++ b/pkg/oauth/token_store.go
@@ -113,7 +113,7 @@ func (t *TokenStore) Retrieve(dcrClient dcr.Client) (*oauth2.Token, error) {
 	encoded, err := getTokenCredential(t.credentialHelper, dcrClient, true)
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
-			return nil, fmt.Errorf("token not found for %s", dcrClient.ServerName)
+			return nil, fmt.Errorf("token not found for %s: %w", dcrClient.ServerName, err)
 		}
 		return nil, fmt.Errorf("retrieving token for %s: %w", dcrClient.ServerName, err)
 	}
@@ -131,6 +131,12 @@ func (t *TokenStore) Retrieve(dcrClient dcr.Client) (*oauth2.Token, error) {
 	}
 
 	return &token, nil
+}
+
+// IsTokenNotFound reports whether an OAuth token operation failed because the
+// local credential is already absent.
+func IsTokenNotFound(err error) bool {
+	return credentials.IsErrCredentialsNotFound(err)
 }
 
 // Delete removes an OAuth token from the credential helper

--- a/pkg/oauth/token_store_test.go
+++ b/pkg/oauth/token_store_test.go
@@ -61,6 +61,7 @@ func TestTokenStoreDoesNotReadAmbiguousLegacyKey(t *testing.T) {
 	_, err = store.Retrieve(attacker)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token not found")
+	assert.True(t, IsTokenNotFound(err))
 }
 
 func TestTokenStoreMigratesUnambiguousLegacyKey(t *testing.T) {

--- a/pkg/oauthdiscovery/discovery.go
+++ b/pkg/oauthdiscovery/discovery.go
@@ -73,6 +73,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 
 	var resourceMetadata *oauthhelpers.ProtectedResourceMetadata
 	authServerURL := defaultAuthServerURL
+	resourceMetadataClient := sameOriginHTTPClient(client, serverURL)
 
 	resourceMetadataURL := ""
 	if challenges != nil {
@@ -80,15 +81,32 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	}
 
 	if resourceMetadataURL != "" {
-		resourceMetadata, err = fetchOAuthProtectedResourceMetadata(ctx, client, resourceMetadataURL)
-		if err == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
+		if err := validateSameOrigin(serverURL, resourceMetadataURL); err != nil {
+			return nil, fmt.Errorf("invalid protected resource metadata URL: %w", err)
+		}
+		resourceMetadata, err = fetchOAuthProtectedResourceMetadata(ctx, resourceMetadataClient, resourceMetadataURL)
+		if err != nil {
+			return nil, fmt.Errorf("fetching protected resource metadata from %s: %w", resourceMetadataURL, err)
+		}
+		if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
+			return nil, err
+		}
+		if resourceMetadata.AuthorizationServer != "" {
 			authServerURL = resourceMetadata.AuthorizationServer
 		}
 	} else {
-		wellKnownURL := fmt.Sprintf("%s/.well-known/oauth-protected-resource", defaultAuthServerURL)
-		resourceMetadata, err = fetchOAuthProtectedResourceMetadata(ctx, client, wellKnownURL)
-		if err == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
-			authServerURL = resourceMetadata.AuthorizationServer
+		wellKnownURL, buildErr := buildRFC9728WellKnownURL(ctx, serverURL)
+		if buildErr != nil {
+			return nil, fmt.Errorf("building protected resource metadata URL: %w", buildErr)
+		}
+		resourceMetadata, err = fetchOAuthProtectedResourceMetadata(ctx, resourceMetadataClient, wellKnownURL)
+		if err == nil && resourceMetadata != nil {
+			if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
+				return nil, err
+			}
+			if resourceMetadata.AuthorizationServer != "" {
+				authServerURL = resourceMetadata.AuthorizationServer
+			}
 		}
 	}
 
@@ -101,8 +119,8 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		Discovery: oauthhelpers.Discovery{
 			RequiresOAuth: true,
 
-			ResourceURL:         defaultAuthServerURL,
-			ResourceServer:      defaultAuthServerURL,
+			ResourceURL:         serverURL,
+			ResourceServer:      serverURL,
 			AuthorizationServer: authServerURL,
 
 			Issuer:                            authServerMetadata.Issuer,
@@ -350,6 +368,87 @@ func validateAuthorizationServerIssuer(expected, actual string) error {
 		return fmt.Errorf("authorization server metadata issuer %q does not match requested issuer %q", actual, expected)
 	}
 	return nil
+}
+
+func validateProtectedResource(expected, actual string) error {
+	if actual != expected {
+		return fmt.Errorf("protected resource metadata resource %q does not match requested resource %q", actual, expected)
+	}
+	return nil
+}
+
+func validateSameOrigin(serverURL, metadataURL string) error {
+	server, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+	metadata, err := url.Parse(metadataURL)
+	if err != nil {
+		return fmt.Errorf("invalid metadata URL: %w", err)
+	}
+	if server.Scheme == "" || server.Hostname() == "" || server.User != nil {
+		return fmt.Errorf("server URL must be an absolute URL without user information")
+	}
+	if metadata.Scheme == "" || metadata.Hostname() == "" || metadata.User != nil {
+		return fmt.Errorf("metadata URL must be an absolute URL without user information")
+	}
+
+	serverPort := server.Port()
+	if serverPort == "" {
+		serverPort = defaultPort(server.Scheme)
+	}
+	metadataPort := metadata.Port()
+	if metadataPort == "" {
+		metadataPort = defaultPort(metadata.Scheme)
+	}
+	if !strings.EqualFold(server.Scheme, metadata.Scheme) ||
+		!strings.EqualFold(server.Hostname(), metadata.Hostname()) ||
+		serverPort != metadataPort {
+		return fmt.Errorf("metadata URL %q must use the same origin as MCP server %q", metadataURL, serverURL)
+	}
+	return nil
+}
+
+func sameOriginHTTPClient(client *http.Client, originURL string) *http.Client {
+	cloned := *client
+	cloned.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		return validateSameOrigin(originURL, req.URL.String())
+	}
+	return &cloned
+}
+
+func defaultPort(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+func buildRFC9728WellKnownURL(ctx context.Context, resourceURL string) (string, error) {
+	parsed, err := url.Parse(resourceURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid resource URL: %w", err)
+	}
+	if err := remoteurl.Validate(ctx, resourceURL); err != nil {
+		return "", err
+	}
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("resource URL must not contain fragment")
+	}
+
+	resourcePath := parsed.EscapedPath()
+	if resourcePath == "/" {
+		resourcePath = ""
+	}
+	metadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource%s", parsed.Scheme, strings.ToLower(parsed.Host), resourcePath)
+	if parsed.RawQuery != "" {
+		metadataURL += "?" + parsed.RawQuery
+	}
+	return metadataURL, nil
 }
 
 func buildRFC8414WellKnownURL(ctx context.Context, issuerURL string) (string, error) {

--- a/pkg/oauthdiscovery/discovery_test.go
+++ b/pkg/oauthdiscovery/discovery_test.go
@@ -1,6 +1,9 @@
 package oauthdiscovery
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,4 +50,104 @@ func TestValidateAuthorizationServerIssuer(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not match requested issuer")
 	}
+}
+
+func TestBuildRFC9728WellKnownURLPreservesResourcePathAndQuery(t *testing.T) {
+	metadataURL, err := buildRFC9728WellKnownURL(
+		t.Context(),
+		"https://8.8.8.8/tenant/mcp?region=west",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://8.8.8.8/.well-known/oauth-protected-resource/tenant/mcp?region=west", metadataURL)
+}
+
+func TestValidateSameOrigin(t *testing.T) {
+	require.NoError(t, validateSameOrigin(
+		"https://mcp.example.com/mcp",
+		"https://mcp.example.com:443/.well-known/oauth-protected-resource/mcp",
+	))
+
+	for _, metadataURL := range []string{
+		"https://metadata.mcp.example.com/.well-known/oauth-protected-resource",
+		"http://mcp.example.com/.well-known/oauth-protected-resource",
+		"https://mcp.example.com:8443/.well-known/oauth-protected-resource",
+	} {
+		err := validateSameOrigin("https://mcp.example.com/mcp", metadataURL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "same origin")
+	}
+}
+
+func TestDiscoverRejectsCrossOriginResourceMetadataURL(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	metadataRequested := false
+	metadataServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		metadataRequested = true
+	}))
+	t.Cleanup(metadataServer.Close)
+
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s/metadata"`, metadataServer.URL))
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(mcpServer.Close)
+
+	_, err := DiscoverOAuthRequirements(t.Context(), mcpServer.URL+"/mcp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same origin")
+	assert.False(t, metadataRequested)
+}
+
+func TestDiscoverRejectsCrossOriginResourceMetadataRedirect(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	redirectTargetCalled := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetCalled = true
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	var mcpServer *httptest.Server
+	mcpServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mcp":
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s/metadata"`, mcpServer.URL))
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/metadata":
+			http.Redirect(w, r, redirectTarget.URL+"/metadata", http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(mcpServer.Close)
+
+	_, err := DiscoverOAuthRequirements(t.Context(), mcpServer.URL+"/mcp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same origin")
+	assert.False(t, redirectTargetCalled)
+}
+
+func TestDiscoverRejectsMetadataForDifferentResource(t *testing.T) {
+	t.Setenv(remoteurl.AllowInsecureRemoteURLEnv, "1")
+
+	var mcpServer *httptest.Server
+	mcpServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mcp":
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, mcpServer.URL))
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/.well-known/oauth-protected-resource/mcp":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"resource":%q,"authorization_servers":[%q]}`, mcpServer.URL+"/other", mcpServer.URL)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(mcpServer.Close)
+
+	_, err := DiscoverOAuthRequirements(t.Context(), mcpServer.URL+"/mcp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match requested resource")
 }

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/README.md
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/README.md
@@ -11,3 +11,16 @@ This library provides the core OAuth/DCR functions for MCP Gateway:
 - **OAuth Discovery**: Discover OAuth requirements from MCP servers (RFC 9728 + 8414)
 - **Dynamic Client Registration**: Register OAuth clients automatically (RFC 7591)
 - **WWW-Authenticate Parsing**: Parse OAuth challenge headers
+
+## Configuring redirect URI validation
+
+By default DCR only accepts redirect URI hosts for localhost, `mcp.docker.com`, and `mcp-stage.docker.com`.
+Use `PerformDCRWithConfig` to provide a custom allowlist:
+
+```go
+allowedHosts := append(oauth.DefaultAllowedRedirectURIHosts(), "oauth.example.com")
+creds, err := oauth.PerformDCRWithConfig(ctx, discovery, "my-server", oauth.DCRConfig{
+    RedirectURI:             "https://oauth.example.com/callback",
+    AllowedRedirectURIHosts: allowedHosts,
+})
+```

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/README.md
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/README.md
@@ -12,6 +12,17 @@ This library provides the core OAuth/DCR functions for MCP Gateway:
 - **Dynamic Client Registration**: Register OAuth clients automatically (RFC 7591)
 - **WWW-Authenticate Parsing**: Parse OAuth challenge headers
 
+## Local development
+
+OAuth discovery allows only public HTTPS authorization servers by default. It
+rejects localhost, private, link-local, and reserved destinations before
+dialing, including redirect targets.
+
+For local development with an HTTP or private-network OAuth provider, set
+`DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1`. This disables the authorization
+server network guard and HTTPS requirement, so it must not be enabled with
+untrusted MCP servers.
+
 ## Configuring redirect URI validation
 
 By default DCR only accepts redirect URI hosts for localhost, `mcp.docker.com`, and `mcp-stage.docker.com`.

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/dcr.go
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/dcr.go
@@ -8,13 +8,37 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const DefaultRedirectURI = "https://mcp.docker.com/oauth/callback"
 
-// isValidRedirectURI validates that the redirect URI is allowed for this library
-// Only localhost and mcp.docker.com are permitted for security
-func isValidRedirectURI(redirectURI string) error {
+var defaultAllowedRedirectURIHosts = []string{
+	"localhost",
+	"127.0.0.1",
+	"::1",
+	"mcp.docker.com",
+	"mcp-stage.docker.com",
+}
+
+// DCRConfig configures Dynamic Client Registration behavior.
+type DCRConfig struct {
+	// RedirectURI is the OAuth callback URI to register. If empty, DefaultRedirectURI is used.
+	RedirectURI string
+
+	// AllowedRedirectURIHosts is the allowlist of hosts accepted for RedirectURI validation.
+	// Hosts should not include a port. If nil, DefaultAllowedRedirectURIHosts is used.
+	// Use DefaultAllowedRedirectURIHosts() and append to it to keep the built-in hosts.
+	AllowedRedirectURIHosts []string
+}
+
+// DefaultAllowedRedirectURIHosts returns a copy of the built-in redirect URI host allowlist.
+func DefaultAllowedRedirectURIHosts() []string {
+	return append([]string(nil), defaultAllowedRedirectURIHosts...)
+}
+
+// isValidRedirectURI validates that the redirect URI host is allowed.
+func isValidRedirectURI(redirectURI string, allowedHosts []string) error {
 	if redirectURI == "" {
 		return nil // Empty is OK (will use default)
 	}
@@ -26,18 +50,57 @@ func isValidRedirectURI(redirectURI string) error {
 
 	// Extract hostname (handles ports automatically)
 	hostname := parsed.Hostname()
-
-	// Allow localhost variations
-	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" {
-		return nil
+	if hostname == "" {
+		return fmt.Errorf("invalid redirect URI %q: missing host", redirectURI)
 	}
 
-	// Allow mcp.docker.com (production)
-	if hostname == "mcp.docker.com" {
-		return nil
+	if allowedHosts == nil {
+		allowedHosts = defaultAllowedRedirectURIHosts
 	}
 
-	return fmt.Errorf("redirect URI host %q not allowed - must be localhost or mcp.docker.com", hostname)
+	for _, allowedHost := range allowedHosts {
+		allowedHost = normalizeAllowedRedirectURIHost(allowedHost)
+		if allowedHost == "" {
+			continue
+		}
+		if strings.EqualFold(hostname, allowedHost) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("redirect URI host %q not allowed - allowed hosts: %s", hostname, formatAllowedRedirectURIHosts(allowedHosts))
+}
+
+func normalizeAllowedRedirectURIHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+
+	// Be forgiving if callers pass a full redirect URI instead of just a host.
+	if parsed, err := url.Parse(host); err == nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
+	}
+
+	return host
+}
+
+func formatAllowedRedirectURIHosts(hosts []string) string {
+	if len(hosts) == 0 {
+		return "(none)"
+	}
+
+	formatted := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		if normalized := normalizeAllowedRedirectURIHost(host); normalized != "" {
+			formatted = append(formatted, normalized)
+		}
+	}
+	if len(formatted) == 0 {
+		return "(none)"
+	}
+
+	return strings.Join(formatted, ", ")
 }
 
 // PerformDCR performs Dynamic Client Registration with the authorization server
@@ -50,18 +113,24 @@ func isValidRedirectURI(redirectURI string) error {
 //
 // redirectURI: The OAuth callback URI to register. If empty, uses DefaultRedirectURI.
 func PerformDCR(ctx context.Context, discovery *Discovery, serverName string, redirectURI string) (*ClientCredentials, error) {
+	return PerformDCRWithConfig(ctx, discovery, serverName, DCRConfig{RedirectURI: redirectURI})
+}
+
+// PerformDCRWithConfig performs Dynamic Client Registration with configurable DCR behavior.
+func PerformDCRWithConfig(ctx context.Context, discovery *Discovery, serverName string, config DCRConfig) (*ClientCredentials, error) {
 	if discovery.RegistrationEndpoint == "" {
 		return nil, fmt.Errorf("no registration endpoint found for %s", serverName)
 	}
 
-	// Validate redirect URI for security (only localhost or mcp.docker.com allowed)
-	if err := isValidRedirectURI(redirectURI); err != nil {
-		return nil, fmt.Errorf("invalid redirect URI: %w", err)
-	}
-
-	// Use provided redirectURI, fallback to default if empty
+	// Use provided redirectURI, fallback to default if empty.
+	redirectURI := config.RedirectURI
 	if redirectURI == "" {
 		redirectURI = DefaultRedirectURI
+	}
+
+	// Validate redirect URI for security.
+	if err := isValidRedirectURI(redirectURI, config.AllowedRedirectURIHosts); err != nil {
+		return nil, fmt.Errorf("invalid redirect URI: %w", err)
 	}
 
 	// Build DCR request for PUBLIC client

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/discovery.go
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/discovery.go
@@ -109,7 +109,9 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	authServerURL := defaultAuthServerURL
 	resourceMetadataClient := sameOriginHTTPClient(client, serverURL)
 
-	// STEP 4: Try to get resource metadata (OPTIONAL - don't fail if missing)
+	// STEP 4: Resolve protected resource metadata. Discovery may continue when
+	// the fallback well-known endpoint is absent, but explicitly advertised
+	// resource_metadata is authoritative and must be fetched successfully.
 	// RFC 9728 Section 5.1: resource_metadata parameter in WWW-Authenticate
 	resourceMetadataURL := ""
 	if challenges != nil {
@@ -129,12 +131,10 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
 			return nil, err
 		}
-		if resourceMetadataError == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
+		if resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
 			// Use authorization server from resource metadata if available
 			authServerURL = resourceMetadata.AuthorizationServer
 			logger.Infof("resource metadata retrieved, auth server: %s", authServerURL)
-		} else if resourceMetadataError != nil {
-			logger.Warnf("failed to fetch resource metadata: %v", resourceMetadataError)
 		}
 	} else {
 		// No resource_metadata in WWW-Authenticate - try well-known endpoint
@@ -158,7 +158,11 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	// STEP 5: Fetch Authorization Server Metadata (REQUIRED)
 	// MCP Spec Section 3.1: "Authorization servers MUST provide OAuth 2.0 Authorization Server Metadata (RFC8414)"
 	logger.Infof("fetching authorization server metadata from: %s", authServerURL)
-	authServerMetadata, err := fetchAuthorizationServerMetadata(ctx, client, authServerURL)
+	authServerClient, err := authorizationServerHTTPClientFunc(client)
+	if err != nil {
+		return nil, fmt.Errorf("securing authorization server metadata client: %w", err)
+	}
+	authServerMetadata, err := fetchAuthorizationServerMetadata(ctx, authServerClient, authServerURL)
 	if err != nil {
 		logger.Warnf("failed to fetch authorization server metadata: %v", err)
 		return nil, fmt.Errorf("fetching authorization server metadata from %s: %w", authServerURL, err)
@@ -276,8 +280,10 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		return "", fmt.Errorf("invalid issuer URL: %w", err)
 	}
 
-	// RFC 8414 Section 2: issuer must use https scheme
-	if parsed.Scheme != "https" {
+	// RFC 8414 Section 2 requires HTTPS. Local development can explicitly
+	// opt into insecure remote URLs to exercise HTTP-only OAuth providers.
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" && (scheme != "http" || !allowInsecureRemoteURLs()) {
 		return "", fmt.Errorf("issuer URL must use https scheme")
 	}
 
@@ -301,8 +307,8 @@ func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
 		path = ""
 	}
 
-	return fmt.Sprintf("https://%s/.well-known/oauth-authorization-server%s",
-		host, path), nil
+	return fmt.Sprintf("%s://%s/.well-known/oauth-authorization-server%s",
+		scheme, host, path), nil
 }
 
 // fetchAuthorizationServerMetadata fetches metadata from /.well-known/oauth-authorization-server

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/discovery.go
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/discovery.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+// httpClientFunc allows tests to inject a custom HTTP client (e.g., for TLS test servers)
+var httpClientFunc = func() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
 // DiscoverOAuthRequirements probes an MCP server to discover OAuth requirements
 //
 // MCP AUTHORIZATION SPEC COMPLIANCE:
@@ -36,10 +41,8 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 
 	logger.Infof("starting OAuth discovery for server: %s", serverURL)
 
-	// Create HTTP client with reasonable timeout
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	// Create HTTP client (can be overridden in tests for TLS support)
+	client := httpClientFunc()
 
 	// Parse server URL to extract base domain for defaults
 	parsedURL, err := url.Parse(serverURL)
@@ -265,19 +268,55 @@ func fetchOAuthProtectedResourceMetadata(ctx context.Context, client *http.Clien
 	return &metadata, nil
 }
 
+// buildRFC8414WellKnownURL constructs the well-known URL per RFC 8414 Section 3.1
+// Inserts /.well-known/oauth-authorization-server between host and path.
+func buildRFC8414WellKnownURL(issuerURL string) (string, error) {
+	parsed, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid issuer URL: %w", err)
+	}
+
+	// RFC 8414 Section 2: issuer must use https scheme
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("issuer URL must use https scheme")
+	}
+
+	// RFC 8414 Section 2: issuer must not have query
+	if parsed.RawQuery != "" {
+		return "", fmt.Errorf("issuer URL must not contain query parameters")
+	}
+
+	// RFC 8414 Section 2: issuer must not have fragment
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("issuer URL must not contain fragment")
+	}
+
+	// RFC 3986 Section 3.2.2: host is case-insensitive, canonicalize to lowercase
+	host := strings.ToLower(parsed.Host)
+
+	// RFC 8414 Section 3.1: Insert .well-known between host and path
+	// Path may be empty, "/" or "/some/path"
+	path := parsed.Path
+	if path == "/" {
+		path = ""
+	}
+
+	return fmt.Sprintf("https://%s/.well-known/oauth-authorization-server%s",
+		host, path), nil
+}
+
 // fetchAuthorizationServerMetadata fetches metadata from /.well-known/oauth-authorization-server
 //
 // RFC 8414 COMPLIANCE:
 // - Implements RFC 8414 Section 3 "Authorization Server Metadata"
+// - Implements RFC 8414 Section 3.1 for well-known URL construction with path support
 // - Validates required fields: issuer, authorization_endpoint, token_endpoint
 // - Validates issuer URL matches authorization server URL (RFC 8414 Section 3.2)
 func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerURL string) (*AuthorizationServerMetadata, error) {
-	// RFC 8414 Section 3: Construct well-known URL
-	var metadataURL string
-	if strings.HasSuffix(authServerURL, "/") {
-		metadataURL = authServerURL + ".well-known/oauth-authorization-server"
-	} else {
-		metadataURL = authServerURL + "/.well-known/oauth-authorization-server"
+	// RFC 8414 Section 3.1: Construct well-known URL (handles issuer paths correctly)
+	metadataURL, err := buildRFC8414WellKnownURL(authServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("building well-known URL: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
@@ -389,6 +428,9 @@ func defaultPort(scheme string) string {
 	}
 }
 
+// buildRFC9728WellKnownURL constructs the protected-resource metadata URL by
+// inserting the well-known suffix before the resource path while preserving
+// its query, as required by RFC 9728 Section 3.1.
 func buildRFC9728WellKnownURL(resourceURL string) (string, error) {
 	parsed, err := url.Parse(resourceURL)
 	if err != nil {

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/discovery.go
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/discovery.go
@@ -104,6 +104,7 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	var resourceMetadata *ProtectedResourceMetadata
 	var resourceMetadataError error
 	authServerURL := defaultAuthServerURL
+	resourceMetadataClient := sameOriginHTTPClient(client, serverURL)
 
 	// STEP 4: Try to get resource metadata (OPTIONAL - don't fail if missing)
 	// RFC 9728 Section 5.1: resource_metadata parameter in WWW-Authenticate
@@ -115,7 +116,16 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 	if resourceMetadataURL != "" {
 		// Resource metadata URL found - try to fetch it
 		logger.Infof("fetching protected resource metadata from: %s", resourceMetadataURL)
-		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, client, resourceMetadataURL)
+		if err := validateSameOrigin(serverURL, resourceMetadataURL); err != nil {
+			return nil, fmt.Errorf("invalid protected resource metadata URL: %w", err)
+		}
+		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, resourceMetadataClient, resourceMetadataURL)
+		if resourceMetadataError != nil {
+			return nil, fmt.Errorf("fetching protected resource metadata from %s: %w", resourceMetadataURL, resourceMetadataError)
+		}
+		if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
+			return nil, err
+		}
 		if resourceMetadataError == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
 			// Use authorization server from resource metadata if available
 			authServerURL = resourceMetadata.AuthorizationServer
@@ -125,9 +135,17 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		}
 	} else {
 		// No resource_metadata in WWW-Authenticate - try well-known endpoint
-		wellKnownURL := fmt.Sprintf("%s/.well-known/oauth-protected-resource", defaultAuthServerURL)
+		wellKnownURL, err := buildRFC9728WellKnownURL(serverURL)
+		if err != nil {
+			return nil, fmt.Errorf("building protected resource metadata URL: %w", err)
+		}
 		logger.Infof("fallback: trying well-known resource metadata endpoint: %s", wellKnownURL)
-		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, client, wellKnownURL)
+		resourceMetadata, resourceMetadataError = fetchOAuthProtectedResourceMetadata(ctx, resourceMetadataClient, wellKnownURL)
+		if resourceMetadataError == nil && resourceMetadata != nil {
+			if err := validateProtectedResource(serverURL, resourceMetadata.Resource); err != nil {
+				return nil, err
+			}
+		}
 		if resourceMetadataError == nil && resourceMetadata != nil && resourceMetadata.AuthorizationServer != "" {
 			authServerURL = resourceMetadata.AuthorizationServer
 			logger.Infof("resource metadata from well-known endpoint, auth server: %s", authServerURL)
@@ -150,8 +168,8 @@ func DiscoverOAuthRequirements(ctx context.Context, serverURL string) (*Discover
 		RequiresOAuth: true,
 
 		// Use resource metadata if available, otherwise use defaults
-		ResourceURL:         defaultAuthServerURL,
-		ResourceServer:      defaultAuthServerURL,
+		ResourceURL:         serverURL,
+		ResourceServer:      serverURL,
 		AuthorizationServer: authServerURL,
 
 		// From Authorization Server Metadata (RFC 8414) - always available
@@ -294,6 +312,9 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 	if metadata.Issuer == "" {
 		return nil, fmt.Errorf("issuer field missing in authorization server metadata")
 	}
+	if metadata.Issuer != authServerURL {
+		return nil, fmt.Errorf("authorization server metadata issuer %q does not match requested issuer %q", metadata.Issuer, authServerURL)
+	}
 	if metadata.AuthorizationEndpoint == "" {
 		return nil, fmt.Errorf("authorization_endpoint field missing in authorization server metadata")
 	}
@@ -302,13 +323,91 @@ func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, 
 	}
 
 	// RFC 8414 Section 3.2: Validate issuer URL is valid
-	// Note: We trust the issuer field in the metadata as authoritative
-	// Cross-domain OAuth setups (like Stripe) are valid where resource server
-	// and authorization server are on different domains
 	_, err = url.Parse(metadata.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("invalid issuer URL: %w", err)
 	}
 
 	return &metadata, nil
+}
+
+func validateProtectedResource(expected, actual string) error {
+	if actual != expected {
+		return fmt.Errorf("protected resource metadata resource %q does not match requested resource %q", actual, expected)
+	}
+	return nil
+}
+
+func validateSameOrigin(serverURL, metadataURL string) error {
+	server, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+	metadata, err := url.Parse(metadataURL)
+	if err != nil {
+		return fmt.Errorf("invalid metadata URL: %w", err)
+	}
+	if server.Scheme == "" || server.Hostname() == "" || server.User != nil {
+		return fmt.Errorf("server URL must be an absolute URL without user information")
+	}
+	if metadata.Scheme == "" || metadata.Hostname() == "" || metadata.User != nil {
+		return fmt.Errorf("metadata URL must be an absolute URL without user information")
+	}
+
+	serverPort := server.Port()
+	if serverPort == "" {
+		serverPort = defaultPort(server.Scheme)
+	}
+	metadataPort := metadata.Port()
+	if metadataPort == "" {
+		metadataPort = defaultPort(metadata.Scheme)
+	}
+	if !strings.EqualFold(server.Scheme, metadata.Scheme) ||
+		!strings.EqualFold(server.Hostname(), metadata.Hostname()) ||
+		serverPort != metadataPort {
+		return fmt.Errorf("metadata URL %q must use the same origin as MCP server %q", metadataURL, serverURL)
+	}
+	return nil
+}
+
+func sameOriginHTTPClient(client *http.Client, originURL string) *http.Client {
+	cloned := *client
+	cloned.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		return validateSameOrigin(originURL, req.URL.String())
+	}
+	return &cloned
+}
+
+func defaultPort(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+func buildRFC9728WellKnownURL(resourceURL string) (string, error) {
+	parsed, err := url.Parse(resourceURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid resource URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Hostname() == "" || parsed.User != nil {
+		return "", fmt.Errorf("resource URL must be an absolute URL without user information")
+	}
+	if parsed.Fragment != "" {
+		return "", fmt.Errorf("resource URL must not contain fragment")
+	}
+
+	resourcePath := parsed.EscapedPath()
+	if resourcePath == "/" {
+		resourcePath = ""
+	}
+	metadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource%s", parsed.Scheme, strings.ToLower(parsed.Host), resourcePath)
+	if parsed.RawQuery != "" {
+		metadataURL += "?" + parsed.RawQuery
+	}
+	return metadataURL, nil
 }

--- a/vendor/github.com/docker/mcp-gateway-oauth-helpers/ssrf.go
+++ b/vendor/github.com/docker/mcp-gateway-oauth-helpers/ssrf.go
@@ -1,0 +1,227 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const allowInsecureRemoteURLEnv = "DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS"
+
+type ipResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+var authorizationServerHTTPClientFunc = newAuthorizationServerHTTPClient
+
+// newAuthorizationServerHTTPClient limits attacker-influenced authorization
+// server metadata requests to public HTTPS destinations. It resolves and pins
+// the address at dial time so DNS rebinding cannot redirect the connection to
+// a private service. The guarded transport is also used for every redirect.
+func newAuthorizationServerHTTPClient(client *http.Client) (*http.Client, error) {
+	return newAuthorizationServerHTTPClientWithResolver(client, net.DefaultResolver)
+}
+
+func newAuthorizationServerHTTPClientWithResolver(client *http.Client, resolver ipResolver) (*http.Client, error) {
+	if client == nil {
+		return nil, fmt.Errorf("HTTP client is nil")
+	}
+	if allowInsecureRemoteURLs() {
+		insecureClient := *client
+		return &insecureClient, nil
+	}
+	if resolver == nil {
+		return nil, fmt.Errorf("IP resolver is nil")
+	}
+
+	base := client.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	transport, ok := base.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("HTTP transport %T cannot be guarded at dial time", base)
+	}
+
+	guardedTransport := transport.Clone()
+	if guardedTransport.DialTLS != nil || //nolint:staticcheck // A legacy TLS dialer would bypass the guarded DialContext.
+		guardedTransport.DialTLSContext != nil {
+		return nil, fmt.Errorf("HTTP transport with a custom TLS dialer cannot be guarded at dial time")
+	}
+	// A generic proxy cannot guarantee that the validated address is the one
+	// ultimately dialed. Authorization-server discovery therefore uses a direct
+	// connection whose resolved public address is pinned below.
+	guardedTransport.Proxy = nil
+
+	originalDialContext := guardedTransport.DialContext
+	if originalDialContext == nil {
+		originalDialContext = (&net.Dialer{}).DialContext
+	}
+	guardedTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("invalid authorization server dial address %q: %w", address, err)
+		}
+		return dialPublicAddress(ctx, resolver, originalDialContext, network, host, port)
+	}
+
+	guardedClient := *client
+	guardedClient.Transport = &publicOnlyRoundTripper{base: guardedTransport}
+	return &guardedClient, nil
+}
+
+type publicOnlyRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (t *publicOnlyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := validatePublicHTTPSURL(req.URL); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req)
+}
+
+func validatePublicHTTPSURL(target *url.URL) error {
+	if target == nil || target.Scheme == "" || target.Host == "" {
+		return fmt.Errorf("authorization server URL must be absolute")
+	}
+	if !strings.EqualFold(target.Scheme, "https") {
+		return fmt.Errorf("authorization server URL must use https")
+	}
+	if target.User != nil {
+		return fmt.Errorf("authorization server URL must not include userinfo")
+	}
+
+	host := normalizeHostname(target.Hostname())
+	if host == "" || strings.ContainsAny(host, "\x00%") {
+		return fmt.Errorf("authorization server URL host is malformed")
+	}
+	if isBlockedHostname(host) {
+		return fmt.Errorf("authorization server URL host %q is not allowed", host)
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validatePublicAddr(ip); err != nil {
+			return fmt.Errorf("authorization server URL host %q is not allowed: %w", host, err)
+		}
+	}
+	return nil
+}
+
+func dialPublicAddress(
+	ctx context.Context,
+	resolver ipResolver,
+	dial func(context.Context, string, string) (net.Conn, error),
+	network, host, port string,
+) (net.Conn, error) {
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if err := validatePublicAddr(ip); err != nil {
+			return nil, err
+		}
+		return dial(ctx, network, net.JoinHostPort(ip.String(), port))
+	}
+
+	ips, err := resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return nil, fmt.Errorf("resolving authorization server host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("authorization server host %q did not resolve to any IP addresses", host)
+	}
+	for _, ip := range ips {
+		if err := validatePublicAddr(ip); err != nil {
+			return nil, fmt.Errorf("authorization server host %q resolved to disallowed address %s: %w", host, ip, err)
+		}
+	}
+
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dial(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func normalizeHostname(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}
+
+func isBlockedHostname(host string) bool {
+	host = normalizeHostname(host)
+	switch host {
+	case "localhost", "metadata", "metadata.google.internal", "metadata.azure.internal":
+		return true
+	}
+	for _, suffix := range []string{
+		".localhost",
+		".local",
+		".localdomain",
+		".internal",
+		".cluster.local",
+		".svc",
+	} {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func allowInsecureRemoteURLs() bool {
+	value := os.Getenv(allowInsecureRemoteURLEnv)
+	return value == "1" || strings.EqualFold(value, "true")
+}
+
+var blockedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("255.255.255.255/32"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+	netip.MustParsePrefix("2001:db8::/32"),
+}
+
+func validatePublicAddr(ip netip.Addr) error {
+	if !ip.IsValid() {
+		return fmt.Errorf("invalid IP address")
+	}
+	if ip.Zone() != "" {
+		return fmt.Errorf("scoped IPv6 addresses are not allowed")
+	}
+
+	ip = ip.Unmap()
+	for _, prefix := range blockedPrefixes {
+		if prefix.Contains(ip) {
+			return fmt.Errorf("address is in blocked range %s", prefix)
+		}
+	}
+	if !ip.IsGlobalUnicast() || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("address is not public")
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/mcp-gateway-oauth-helpers v0.0.6
+# github.com/docker/mcp-gateway-oauth-helpers v0.0.7
 ## explicit; go 1.23.0
 github.com/docker/mcp-gateway-oauth-helpers
 # github.com/docker/secrets-engine/client v0.0.30

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/mcp-gateway-oauth-helpers v0.0.3
+# github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab
 ## explicit; go 1.23.0
 github.com/docker/mcp-gateway-oauth-helpers
 # github.com/docker/secrets-engine/client v0.0.30

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0
+# github.com/docker/mcp-gateway-oauth-helpers v0.0.6
 ## explicit; go 1.23.0
 github.com/docker/mcp-gateway-oauth-helpers
 # github.com/docker/secrets-engine/client v0.0.30

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5
+# github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813163100-967ee4ea52d0
 ## explicit; go 1.23.0
 github.com/docker/mcp-gateway-oauth-helpers
 # github.com/docker/secrets-engine/client v0.0.30

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162556-16fe74113cab
+# github.com/docker/mcp-gateway-oauth-helpers v0.0.6-0.20260813162743-fe5cca4afba5
 ## explicit; go 1.23.0
 github.com/docker/mcp-gateway-oauth-helpers
 # github.com/docker/secrets-engine/client v0.0.30


### PR DESCRIPTION
## Context

This is a follow-up to #546. It closes the security, authorization, and observability gaps found during the post-merge security review: credential-bearing OAuth requests could still follow redirects; protected-resource discovery was not fully bound to the MCP resource; `ActionInvoke` enforcement was duplicated across dispatch paths; CE revocation could not remove stale DCR state after its local token disappeared; Windows browser launch crossed a `cmd.exe` shell boundary with an untrusted OAuth URL; case-insensitive tool allowlisting could enable a case-variant tool the operator did not select; code mode rebuilt an unfiltered backend tool surface outside the gateway's registration boundary; globally registered code-mode tools captured the creator's session identity; and self-hosted dynamic management treated a noop policy as authorization to activate catalog-only servers.

## What changed

### Refuse redirects for credential-bearing OAuth requests

- Build the guarded OAuth client through the standard direct or Docker Desktop proxy constructors.
- Export and reuse one credential-bearing OAuth client across CE and community authorization-code exchange, CE and community refresh, and provider revocation.
- Refuse every redirect in that shared client so authorization codes, PKCE verifiers, refresh tokens, and credential headers are never replayed to a redirect target.
- Keep redirect responses visible to the OAuth caller so the operation fails instead of silently following them.

### Open OAuth authorization URLs without a shell

- Validate authorization URLs before launching a platform browser handler: require an absolute public HTTPS URL by default and reject userinfo or unsafe hosts.
- Replace Windows `cmd /c start` with `rundll32.exe url.dll,FileProtocolHandler`, passing the complete authorization URL as one process argument.
- Preserve the explicit local-development opt-in for HTTP/private authorization URLs through `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1`.

### Bind OAuth discovery to the requested MCP resource

- Require a `resource_metadata` URL from `WWW-Authenticate` to have the same scheme, host, and effective port as the MCP server.
- Reapply that same-origin requirement to every metadata redirect hop.
- Require protected-resource metadata's `resource` value to exactly match the full MCP server URL being probed, including path and query.
- Construct the fallback protected-resource well-known URL using RFC 9728's path-aware form.
- Consume `mcp-gateway-oauth-helpers v0.0.7` and regenerate the vendored module from that release.
- Apply the same resource, origin, redirect, and issuer checks to the vendored helper implementation.
- Guard helper authorization-server metadata fetches at dial time: require public HTTPS destinations, reject private and reserved DNS results, pin validated IPs, and enforce the guard across redirects.
- Continue requiring exact RFC 8414 issuer equality. A trailing-slash difference is intentionally a mismatch.

### Enforce exact-case tool allowlisting

- Match bare, server-scoped, and image-scoped tool selectors using the exact case advertised by the MCP server, consistent with MCP tool dispatch.
- Keep global, server, and image wildcards exact (`*`, `server:*`, and `image:*`).
- Reject case-folded collisions between registered tool names, reserved gateway tools, and existing tool registrations before they can create ambiguous operator intent.
- Warn on the same case-folded collisions while assembling catalog tools so configuration problems are visible before invocation.
- Keep collision detection scoped to tools: prompts and resources remain independent MCP capability namespaces, and resource URIs retain their original case.

### Keep code mode inside the filtered, session-scoped registration boundary

- Stop re-listing backend tools and creating separate direct-session handlers when a code-mode tool is created or executed.
- Build each selected server's JavaScript functions from `g.toolRegistrations`, which contains the exact-case allowlisted and `ActionLoad`-filtered tool definitions.
- Reuse each registered handler so code mode inherits the same `ActionInvoke` middleware, telemetry, original backend tool-name mapping, and prefixed gateway tool name as direct dispatch and `mcp-exec`.
- Remove the creator session and request metadata from the globally registered code-mode adapter.
- Propagate `Session`, `Extra`, and request `Meta` dynamically from every outer code-mode invocation to its nested registered-handler calls, so the backend connection, roots/state, policy identity, and audit attribution always belong to the current caller.
- Validate requested servers against the exact enabled-server list rather than the full catalog, preventing profile catalog entries and case variants from being selected before activation.
- Snapshot registrations under the capability lock and sort them by exact tool name for deterministic generated documentation and function installation.

### Require authoritative policy for catalog-only management

- Treat the configured registry/server list as the operator-enabled management boundary.
- Let `mcp-add`, `mcp-config-set`, and profile activation skip new authorization only for servers already inside the operator-enabled set.
- Require a real policy provider and an allowed `ActionLoad` decision before an individual tool or profile can activate or configure a catalog-only server.
- Build profile activation decisions from the profile's server metadata before merging it into the gateway, preserving complete policy inputs without weakening the active-set boundary.
- Treat a nil policy client and the self-hosted `policy.NoopClient` as absence of authorization, rather than an allow decision.
- Reuse the shared load-policy gate so authoritative allow/deny/error decisions retain the existing audit event and fail-closed behavior.
- Return an error before validation, image pulls, capability reloads, or configuration mutation when profile access is not authorized.

### Centralize `ActionInvoke` enforcement

- Add one fail-closed `ActionInvoke` middleware and attach it when backend tool handlers are registered.
- Route direct MCP calls, POCI tools, `mcp-exec`, and code mode through the same wrapped handlers.
- Preserve each path's existing client-facing error shape while producing one policy decision and one audit event per attempted invocation.
- Keep both POCI and MCP-server telemetry outside the policy middleware so denials and evaluator failures record the normal tool-call counter, end-to-end duration, error counter, and error span.
- Remove the duplicate MCP-server instrumentation from the backend handler, ensuring allowed calls and policy short-circuits each produce exactly one telemetry envelope.

### Make missing-token CE revocation idempotent

- Preserve the credential-helper not-found sentinel through `TokenStore.Retrieve`.
- Treat only that sentinel as an already-completed local token deletion and continue removing the DCR client.
- Continue failing closed for provider, transport, malformed-token, and other credential-helper failures.

## Compatibility notes

- Protected-resource and issuer comparisons use exact string equality. Providers whose metadata changes only by a trailing slash will be rejected and must publish the exact identifier used for discovery.
- Explicit `resource_metadata` failures are no longer ignored. A server advertising invalid, cross-origin, unreachable, or mismatched metadata fails discovery before browser authorization or code exchange.
- Helper authorization-server metadata discovery permits only public HTTPS destinations by default. Local, private-network, or HTTP OAuth requires the explicit development opt-in `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1`; this disables the network guard and must not be used with untrusted MCP servers.
- `--open-browser` applies the same URL policy before starting the platform handler. Without the development opt-in, relative, non-HTTP(S), HTTP, userinfo-bearing, localhost, private, and reserved authorization URLs are rejected.
- Tool allowlists are now case-sensitive. Existing selectors whose capitalization differs from the advertised MCP tool name must be corrected; wildcards retain their existing behavior.
- Code mode now exposes only tools registered for an enabled server. Disabled, `ActionLoad`-denied, catalog-only, and case-mismatched tools no longer appear as JavaScript functions; prefixed tools must be called by their registered gateway name.
- Globally registered code-mode tools now use the invoking client's session and request identity on every call; they no longer retain the session that created the generated tool.
- In self-hosted/no-governance mode, dynamic tools and profile activation cannot add or configure a catalog-only server. Pre-enable the server in the registry, use a fixed `--servers` set, or configure an enforcing governance policy that allows its `ActionLoad` request.
- CE revoke remains strict for real provider and storage failures; only an already-absent local token permits DCR cleanup to continue.

## Automated validation

- `make format`
- `go test ./pkg/oauth ./pkg/oauthdiscovery ./cmd/docker-mcp/oauth ./pkg/gateway`
- `go test -race -count=1 ./pkg/gateway -run 'TestCodeModeUsesRegisteredServerTools|TestCodeModeRejectsServersOutsideEnabledSet|TestCheckServerManagementAccess|TestNoopPolicyCannotMutateCatalogOnlyServer|TestActivateProfileCannotActivateCatalogOnlyServerWithoutEnforcingPolicy|TestMCPServerPolicyFailuresRecordCompleteTelemetry'`
- `go vet ./pkg/codemode ./pkg/gateway`
- `go test github.com/docker/mcp-gateway-oauth-helpers`
- `make test`
- `make lint`

## Manual testing

Use a test MCP/OAuth provider and a credential-capture HTTP server. Point a catalog entry at the test MCP server, then run the branch build through the normal CE/community test setup.

1. **Token endpoint redirect does not leak credentials**
   - Configure token endpoint A to return `307 Temporary Redirect` with `Location` set to capture endpoint B on another host or port.
   - Complete authorization through the point where the gateway exchanges the authorization code, once in CE mode and once through the Desktop community-server path.
   - Repeat with both `307 Temporary Redirect` and `308 Permanent Redirect`; confirm each exchange fails on the redirect response.
   - Confirm endpoint B received no request, `Authorization` header, client ID, client secret, authorization code, PKCE verifier, or refresh token.

2. **Sibling-origin `resource_metadata` is rejected before fetch**
   - Have the MCP endpoint return `401` with `WWW-Authenticate: Bearer resource_metadata="https://metadata.example.test/.well-known/oauth-protected-resource"` while the probed server is `https://mcp.example.test/mcp`.
   - Run OAuth discovery.
   - Confirm discovery reports a same-origin validation error and the metadata host receives no request.

3. **Cross-origin metadata redirects are rejected**
   - Advertise a same-origin metadata URL from the MCP endpoint.
   - Make that URL return a redirect to a second host or port.
   - Run OAuth discovery and confirm it fails at the redirect.
   - Confirm the redirect target receives no request.

4. **Protected-resource identity is exact**
   - Probe `https://mcp.example.test/mcp` and return same-origin protected-resource metadata with `"resource": "https://mcp.example.test/other"`.
   - Confirm discovery fails before DCR, browser authorization, or token exchange.
   - Change `resource` to exactly `https://mcp.example.test/mcp`; confirm discovery continues.
   - Repeat with only a trailing slash or query difference and confirm it is rejected.

5. **Authorization-server issuer is exact in both implementations**
   - Request metadata for issuer `https://auth.example.test` while returning `"issuer": "https://auth.example.test/"`, then repeat with an unrelated issuer.
   - Confirm both cases fail before the authorization URL is used.
   - Return the exact requested issuer and confirm discovery succeeds.
   - Exercise both the gateway discovery package and the vendored helper call path.

6. **Every tool dispatch path uses the shared policy gate**
   - Configure the policy evaluator to deny one `(server, tool, invoke)` tuple and enable backend invocation logging.
   - Attempt that tool directly, through a POCI registration, through `mcp-exec`, and through code mode.
   - Confirm all four attempts are denied and the backend/container is never invoked.
   - Confirm each attempt creates exactly one policy evaluation and one audit event.
   - For both POCI and MCP-server attempts, confirm the tool call counter, duration histogram, error counter, and error span are each recorded exactly once even though the backend handler does not run.
   - Repeat with an evaluator error and confirm all paths fail closed with the same telemetry envelope and exactly one audit event.

7. **CE revoke cleans stale DCR state when the token is already absent**
   - Authorize a CE OAuth server so both its token credential and DCR client exist.
   - Delete only the token entry (`https://oauth-token.mcp/v2/...`) from the configured credential helper, leaving the DCR entry intact.
   - Run `docker mcp oauth revoke <server>`.
   - Confirm the command reports that the token is already absent, exits successfully, and removes the DCR client.
   - As a negative control, reauthorize, make the provider revocation endpoint return HTTP 500, and run revoke again. Confirm the command exits non-zero and preserves the local token and DCR client for retry.

8. **Local OAuth requires explicit opt-in**
   - Configure a localhost MCP server that discovers an HTTP localhost OAuth issuer.
   - Unset `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS` and run OAuth discovery. Confirm it fails before dialing authorization-server metadata.
   - Set `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1` and repeat. Confirm discovery reaches the local provider and the OAuth flow can proceed.
   - Unset the environment variable after testing.

9. **Windows browser launch treats the authorization URL as data**
   - On Windows, configure an authorization endpoint whose query includes `x=1&calc.exe&y=` and run OAuth authorization with `--open-browser`.
   - Confirm the default browser receives the complete URL and no `calc.exe` process or other extra command is launched.
   - Repeat with a relative URL, `file:` URL, and plain HTTP public URL while `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS` is unset. Confirm each is rejected before a browser handler starts.
   - As a local-development control, set `DOCKER_MCP_ALLOW_INSECURE_REMOTE_URLS=1` and confirm an HTTP localhost authorization URL can still be opened.

10. **Tool allowlists honor exact MCP tool names**
   - Configure a test server to advertise two distinct tools, `ReadFile` and `readfile`.
   - Allow only `ReadFile` with a bare selector. Confirm `ReadFile` is exposed and callable while `readfile` is hidden and cannot be dispatched through the gateway.
   - Repeat with an exact server-scoped selector and an exact image-scoped selector; confirm a case-only mismatch does not enable either tool.
   - Confirm exact `*`, `server:*`, and `image:*` wildcards still expose the intended tools.
   - Attempt to register a tool whose name differs only by case from a reserved gateway tool or an existing registered tool. Confirm registration is rejected and catalog assembly reports a collision warning.
   - As namespace controls, expose a tool and prompt with the same name and confirm both remain usable through their separate MCP methods; expose two resource URIs differing only by path case and confirm they remain distinct.

11. **Code mode cannot restore filtered tools or catalog-only servers**
   - Configure an enabled test server to advertise `ReadFile`, `readfile`, and `AdminDelete`. Allowlist only `ReadFile` and configure the policy evaluator to deny `AdminDelete` at `ActionLoad`.
   - Create a code-mode tool for that server. Confirm its generated JavaScript documentation contains only `ReadFile` and does not contain `readfile` or `AdminDelete`.
   - Execute a script that calls `ReadFile` and confirm the already-registered handler runs with normal telemetry and exactly one `ActionInvoke` evaluation.
   - Attempt scripts that call `readfile` and `AdminDelete`. Confirm both functions are undefined and neither reaches the backend or produces an invocation-policy audit event.
   - In profile mode, leave a second server in the catalog but do not activate it. Attempt to create code mode for that catalog-only name and for a case variant of the enabled server name; confirm both requests fail as not enabled before any backend client is acquired.
   - Activate the second server and repeat with its exact name. Confirm code mode then exposes only that server's registered, filtered tool set.

12. **Generated code-mode tools preserve each invoking session's identity**
   - Open MCP session A and create a code-mode tool for an enabled backend server; keep the generated tool registered.
   - Invoke that generated tool from session A and record the backend client/session, roots or session-scoped state, request metadata, and audit identity.
   - Open session B and invoke the same globally registered generated tool, both directly and through `mcp-exec` if that path is exposed by the client.
   - Confirm both session-B calls use B's backend connection, roots/state, request metadata, policy identity, and audit attribution; none of A's identity or state is visible.
   - Invoke the tool from A again and confirm it still uses A, demonstrating that identity is derived per invocation rather than captured when the tool was created.

13. **Noop policy cannot activate or configure catalog-only servers**
   - In a self-hosted/no-governance gateway, put server A in the registry and leave server B only in the catalog.
   - Run `mcp-add` for B and `mcp-config-set` for B. Confirm both return an MCP error, B is not appended to the enabled-server list, no B configuration is written, and no reload occurs.
   - Create a profile containing B and activate it with the nil/noop policy client. Confirm activation fails before image pulls or capability reloads and leaves B absent from the enabled-server list and configuration.
   - Run the same management operation for already-enabled A and confirm it retains the supported self-hosted behavior.
   - Configure an enforcing policy provider, allow B's `ActionLoad` request, and repeat both individual and profile activation. Confirm each succeeds and emits the existing policy audit event using B's complete server metadata.
   - Change the policy to deny B (and separately make evaluation fail), then repeat. Confirm each attempt fails closed and leaves the enabled-server list and configuration unchanged.
