### PR TITLE
fix(secret): overwrite existing default secrets

### DIFF
--- a/cmd/docker-mcp/secret-management/secret/credstore.go
+++ b/cmd/docker-mcp/secret-management/secret/credstore.go
@@ -74,14 +74,19 @@ func List(ctx context.Context) ([]client.ID, error) {
 	return secrets, nil
 }
 
+func defaultSecretSetCommand(ctx context.Context, key client.ID, value string) *exec.Cmd {
+	c := cmd(ctx, "set", key.String(), "--force")
+	c.Stdin = strings.NewReader(value)
+	return c
+}
+
 // setDefaultSecret stores a secret in the default realm (docker/mcp/**).
 func setDefaultSecret(ctx context.Context, id client.ID, value string) error {
 	key, err := GetDefaultSecretKey(id)
 	if err != nil {
 		return err
 	}
-	c := cmd(ctx, "set", key.String())
-	c.Stdin = strings.NewReader(value)
+	c := defaultSecretSetCommand(ctx, key, value)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("could not store secret: %s\n%s", bytes.TrimSpace(out), err)

--- a/cmd/docker-mcp/secret-management/secret/secret_test.go
+++ b/cmd/docker-mcp/secret-management/secret/secret_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"io"
 	"testing"
 
 	seclient "github.com/docker/secrets-engine/client"
@@ -30,4 +31,27 @@ func TestIsDirectValueProvider(t *testing.T) {
 	assert.True(t, isDirectValueProvider(""))
 	assert.True(t, isDirectValueProvider(Credstore))
 	assert.False(t, isDirectValueProvider("oauth/github"))
+}
+
+func TestDefaultSecretSetCommand(t *testing.T) {
+	key, err := GetDefaultSecretKey(seclient.MustParseID("mykey"))
+	require.NoError(t, err)
+
+	const secretValue = "super-secret-value-123"
+	c := defaultSecretSetCommand(t.Context(), key, secretValue)
+	require.NotNil(t, c)
+
+	// Verify command and arguments contain --force overwrite flag
+	assert.Equal(t, []string{"docker", "pass", "set", "docker/mcp/mykey", "--force"}, c.Args)
+
+	// Verify secret is NOT leaked into command arguments
+	for _, arg := range c.Args {
+		assert.NotContains(t, arg, secretValue)
+	}
+
+	// Verify secret value is properly delivered via stdin
+	require.NotNil(t, c.Stdin)
+	stdinBytes, err := io.ReadAll(c.Stdin)
+	require.NoError(t, err)
+	assert.Equal(t, secretValue, string(stdinBytes))
 }


### PR DESCRIPTION
## What I changed

- make \docker mcp secret set\ use the secrets-engine overwrite path so existing default secrets can be updated
- add regression coverage proving the default secret production path requests overwrite semantics
- preserve stdin secret delivery and ensure the secret is not leaked in argv

## Why

Updating an existing default MCP secret can fail with duplicate-item behavior (for example macOS Keychain \-25299\) because the previous implementation did not request overwrite semantics.

## Related issue

Fixes #551