### PR TITLE
fix(gateway): honor --secrets file for dynamically added remote servers

### DIFF
--- a/pkg/gateway/configuration.go
+++ b/pkg/gateway/configuration.go
@@ -55,6 +55,18 @@ func (c *Configuration) AddSecrets(secrets map[string]string) {
 	}
 }
 
+// mergeResolvedSecrets merges secret references (se:// URIs) into the
+// configuration without overwriting a concrete value already present
+// (e.g. one provided via --secrets).
+func (c *Configuration) mergeResolvedSecrets(secrets map[string]string) {
+	for name, uri := range secrets {
+		if v, ok := c.secrets[name]; ok && v != "" && !strings.HasPrefix(v, "se://") {
+			continue
+		}
+		c.AddSecrets(map[string]string{name: uri})
+	}
+}
+
 func (c *Configuration) DockerImages() []string {
 	uniqueDockerImages := map[string]bool{}
 

--- a/pkg/gateway/configuration_secrets_test.go
+++ b/pkg/gateway/configuration_secrets_test.go
@@ -1,0 +1,61 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeResolvedSecrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]string
+		incoming map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "does not downgrade a concrete value to an se:// reference",
+			existing: map[string]string{"TOKEN": "real-token"},
+			incoming: map[string]string{"TOKEN": "se://TOKEN"},
+			expected: map[string]string{"TOKEN": "real-token"},
+		},
+		{
+			name:     "adds a reference when no value exists yet",
+			existing: map[string]string{},
+			incoming: map[string]string{"TOKEN": "se://TOKEN"},
+			expected: map[string]string{"TOKEN": "se://TOKEN"},
+		},
+		{
+			name:     "refreshes an existing se:// reference",
+			existing: map[string]string{"TOKEN": "se://old"},
+			incoming: map[string]string{"TOKEN": "se://new"},
+			expected: map[string]string{"TOKEN": "se://new"},
+		},
+		{
+			name:     "overwrites an empty value",
+			existing: map[string]string{"TOKEN": ""},
+			incoming: map[string]string{"TOKEN": "se://TOKEN"},
+			expected: map[string]string{"TOKEN": "se://TOKEN"},
+		},
+		{
+			name:     "keeps concrete value but adds unrelated reference",
+			existing: map[string]string{"TOKEN": "real-token"},
+			incoming: map[string]string{"TOKEN": "se://TOKEN", "OTHER": "se://OTHER"},
+			expected: map[string]string{"TOKEN": "real-token", "OTHER": "se://OTHER"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Configuration{secrets: tt.existing}
+			c.mergeResolvedSecrets(tt.incoming)
+			assert.Equal(t, tt.expected, c.secrets)
+		})
+	}
+}
+
+func TestMergeResolvedSecretsInitializesNilMap(t *testing.T) {
+	c := &Configuration{}
+	c.mergeResolvedSecrets(map[string]string{"TOKEN": "se://TOKEN"})
+	assert.Equal(t, map[string]string{"TOKEN": "se://TOKEN"}, c.secrets)
+}

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -107,11 +107,16 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 			}}
 			availableSecrets = BuildSecretsURIs(ctx, configs)
 
-			// Check which secrets are missing
+			// Available if the engine has it or a concrete value was already
+			// provided (e.g. via --secrets).
 			for _, secret := range serverConfig.Spec.Secrets {
-				if _, exists := availableSecrets[secret.Name]; !exists {
-					missingSecrets = append(missingSecrets, secret.Name)
+				if _, exists := availableSecrets[secret.Name]; exists {
+					continue
 				}
+				if v, ok := g.configuration.secrets[secret.Name]; ok && v != "" && !strings.HasPrefix(v, "se://") {
+					continue
+				}
+				missingSecrets = append(missingSecrets, secret.Name)
 			}
 		}
 
@@ -217,7 +222,7 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 		// This is needed because g.configuration.secrets is built at startup and doesn't
 		// include secrets for dynamically added servers.
 		if len(availableSecrets) > 0 {
-			g.configuration.AddSecrets(availableSecrets)
+			g.configuration.mergeResolvedSecrets(availableSecrets)
 		}
 
 		// Pull the Docker image before trying to use the server


### PR DESCRIPTION
**What I did**

Fixed `mcp-add` (dynamic-tools) not honoring the `--secrets` .env file for remote servers. When the secrets engine is unreachable (e.g. outside Docker Desktop / in Kubernetes), `BuildSecretsURIs` emits an `se://` reference for every declared secret and `AddSecrets` overwrote the concrete value loaded at startup from `--secrets`. `remote.go` then skips `se://` values and falls back to the engine, so remote header auth resolved to an empty token and the server failed to initialize with `Unauthorized`.

- Added `Configuration.mergeResolvedSecrets`, which merges engine references
  without overwriting a concrete value already present.
- Used it from `mcp-add`, and treat a startup-provided concrete secret as
  satisfied in the missing-secrets check.
- Startup-enabled servers already resolve file secrets via `Find()`; this makes
  dynamically added remote servers behave the same.

Backwards compatible: Docker Desktop users' secrets are `se://` references (or absent), so the guard is a no-op for them. Added unit tests for `mergeResolvedSecrets`; `make format`, lint, and `make test` pass.

**Related issue**

fixes #554