### PR TITLE
feat: cross-stack conformance vectors for audit attestation (#557)

### DIFF
--- a/fixtures/cross-stack/mcp-audit-gateway-v0.6/SOURCE.md
+++ b/fixtures/cross-stack/mcp-audit-gateway-v0.6/SOURCE.md
@@ -1,0 +1,56 @@
+# Source Provenance
+
+These vectors are extracted from the mcp-audit-gateway project's conformance
+test suite. They exercise the tuple-array canonicalization format and
+hash-chained checkpoint mechanism used for tamper-evident audit records.
+
+## Upstream
+
+- Repository: https://github.com/elang2/mcp-audit-gateway
+- Tag: v0.6.0
+- Commit: 5564da9
+- Tag SHA: 69afbaba40f2da3b0d97420f04067eac897959b6
+
+## File Hashes (SHA-256)
+
+```
+34f8261aacb666c4bff9e48a2fe7cbda6647a3fb295d371a1a7e8bd5e3826a32  canonicalization.json
+1eadd73cef1910c91e911eb57a496bc8e4c373c9c33820233c8b654714877d70  checkpoint.json
+```
+
+## What These Vectors Test
+
+**canonicalization.json** covers the tuple-array canonical form used for
+signing audit records. It includes field ordering, null handling, conditional
+fields (decisionContextDigest, parties, extensionsDigest), the injective
+type-tagged canonicalizeValue() algorithm (M/L tags, safe-integer constraint,
+UTF-16 key sorting), and negative cases (floats throw, lone surrogates throw).
+
+**checkpoint.json** covers the checkpoint and chain-integrity mechanism.
+It includes basic checkpoint canonicalization, chain continuity across log
+rotation boundaries, truncation detection via externalized checkpoints,
+sequence regression detection, chain_break records, and verification modes
+(strict vs relative/suffix).
+
+## Relevance to mcp-gateway
+
+These vectors validate behavior needed by an audit attestation interceptor
+(issue #557). The interceptor produces hash-chained records; consumers need
+to verify chain integrity, detect truncation, and confirm checkpoints without
+implementing the canonicalization from scratch. These vectors let any
+implementation verify compatibility with the upstream format.
+
+## Cross-SDK Context
+
+The v0.6.0 release also includes cross-SDK differential testing that found
+26 serialization divergences across all 10 official MCP SDKs. The
+canonicalization format used here (tuple-array with type tags) was designed
+specifically to be immune to these divergences: it uses safe integers only
+(no float formatting variance), explicit field ordering (no key-sort
+disagreements), and surrogate rejection (no encoding ambiguity).
+
+See: https://github.com/elang2/mcp-audit-gateway/blob/v0.6.0/test/vectors/SDK-AUDIT.md
+
+## License
+
+Apache-2.0 (same as upstream repository)

--- a/fixtures/cross-stack/mcp-audit-gateway-v0.6/canonicalization.json
+++ b/fixtures/cross-stack/mcp-audit-gateway-v0.6/canonicalization.json
@@ -1,0 +1,764 @@
+{
+  "format_version": "1.1.0",
+  "implementation": "mcp-audit-gateway",
+  "canonical_form": "tuple-array",
+  "description": "Conformance vectors for mcp-audit-gateway's tuple-array canonicalization and SHA-256 hash chain.",
+  "encoding": "utf-8",
+  "hash_algorithm": "sha256",
+  "hash_output": "hex-lowercase",
+  "null_rule": "Fields listed in field_order that are absent or undefined in the source record MUST be serialized as JSON null in the tuple-array canonical form.",
+  "signing_exclusions": [
+    "attestation"
+  ],
+  "signing_note": "The attestation field is excluded from the canonical form used for signing. It cannot be included because the signature IS the attestation value (including it would be circular). The canonical form contains exactly the 11 fields listed in field_order.",
+  "chain_hash_note": "The chain hash (record_hash) uses JSON.stringify(fullRecord) which INCLUDES the attestation field. This binds the signature into the chain sequence, preventing attestation stripping without breaking the chain. The chain hash depends on JavaScript insertion order; verifiers must serialize keys in the order specified by chain.chain_key_order.",
+  "field_order": [
+    "id",
+    "timestamp",
+    "method",
+    "toolName",
+    "namespace",
+    "upstream",
+    "principal",
+    "durationMs",
+    "success",
+    "errorCode",
+    "previousHash"
+  ],
+  "conditional_fields": {
+    "decisionContextDigest": "Included at position 10 (before previousHash) when present and non-null.",
+    "parties": "Included after previousHash (or after decisionContextDigest if present) when present and non-null. The value is a JSON array of party objects serialized inline."
+  },
+  "canonicalization": [
+    {
+      "name": "genesis_all_fields",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440001",
+        "timestamp": "2026-08-21T12:00:00.000Z",
+        "method": "tools/call",
+        "toolName": "weather_lookup",
+        "namespace": "external-apis",
+        "upstream": "weather-server",
+        "principal": "user:alice@example.com",
+        "durationMs": 142,
+        "success": true,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440001\"],[\"timestamp\",\"2026-08-21T12:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"weather_lookup\"],[\"namespace\",\"external-apis\"],[\"upstream\",\"weather-server\"],[\"principal\",\"user:alice@example.com\"],[\"durationMs\",142],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "4e9c29d6e22fc2ef1f931994997b01f48f054c1294a7c287bfeece79417e5d43"
+    },
+    {
+      "name": "genesis_null_optionals",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440002",
+        "timestamp": "2026-08-21T12:00:01.000Z",
+        "method": "tools/list",
+        "durationMs": 3,
+        "success": true,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440002\"],[\"timestamp\",\"2026-08-21T12:00:01.000Z\"],[\"method\",\"tools/list\"],[\"toolName\",null],[\"namespace\",null],[\"upstream\",null],[\"principal\",null],[\"durationMs\",3],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "e6d9cb79804d69a479c59e2c4e162e90a505ee3cc311d68f6225332764b417c0"
+    },
+    {
+      "name": "error_with_code",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440003",
+        "timestamp": "2026-08-21T12:00:02.500Z",
+        "method": "tools/call",
+        "toolName": "database_query",
+        "namespace": "internal",
+        "upstream": "db-server",
+        "principal": "service:backend-agent",
+        "durationMs": 5021,
+        "success": false,
+        "errorCode": -32603,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440003\"],[\"timestamp\",\"2026-08-21T12:00:02.500Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"database_query\"],[\"namespace\",\"internal\"],[\"upstream\",\"db-server\"],[\"principal\",\"service:backend-agent\"],[\"durationMs\",5021],[\"success\",false],[\"errorCode\",-32603],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "01f4d49a71137289af02111ca6a6b2d7568a7ab4d28aefcfaa17a679bcda90b6"
+    },
+    {
+      "name": "zero_duration",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440004",
+        "timestamp": "2026-08-21T12:00:03.000Z",
+        "method": "tools/call",
+        "toolName": "cache_get",
+        "namespace": "infra",
+        "upstream": "cache-server",
+        "durationMs": 0,
+        "success": true,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440004\"],[\"timestamp\",\"2026-08-21T12:00:03.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"cache_get\"],[\"namespace\",\"infra\"],[\"upstream\",\"cache-server\"],[\"principal\",null],[\"durationMs\",0],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "e67ed42f822a66e7851de0044e7a02b9e66a525419c78166966fa88cca5c325e"
+    },
+    {
+      "name": "invalid_params_error",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440005",
+        "timestamp": "2026-08-21T12:00:04.000Z",
+        "method": "tools/call",
+        "toolName": "send_email",
+        "namespace": "comms",
+        "upstream": "email-server",
+        "principal": "user:bob@example.com",
+        "durationMs": 12,
+        "success": false,
+        "errorCode": -32602,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440005\"],[\"timestamp\",\"2026-08-21T12:00:04.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"send_email\"],[\"namespace\",\"comms\"],[\"upstream\",\"email-server\"],[\"principal\",\"user:bob@example.com\"],[\"durationMs\",12],[\"success\",false],[\"errorCode\",-32602],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "a67508503e33af3fcf179c34f3ff4e6a0c066870e481fb999f9d03e128f3af3b"
+    },
+    {
+      "name": "unicode_in_fields",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440006",
+        "timestamp": "2026-08-21T12:00:05.000Z",
+        "method": "tools/call",
+        "toolName": "天気検索",
+        "namespace": "external-apis",
+        "upstream": "weather-server-⚡",
+        "principal": "user:tanaka.太郎@example.jp",
+        "durationMs": 88,
+        "success": true,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440006\"],[\"timestamp\",\"2026-08-21T12:00:05.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"天気検索\"],[\"namespace\",\"external-apis\"],[\"upstream\",\"weather-server-⚡\"],[\"principal\",\"user:tanaka.太郎@example.jp\"],[\"durationMs\",88],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "715926536f94e0a05f59613c9b41a7be103df413202fb9bcdefee2a402697a4e"
+    },
+    {
+      "name": "max_safe_integer_duration",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440007",
+        "timestamp": "2026-08-21T12:00:06.000Z",
+        "method": "tools/call",
+        "toolName": "long_running_task",
+        "namespace": "compute",
+        "upstream": "batch-server",
+        "principal": "service:scheduler",
+        "durationMs": 9007199254740991,
+        "success": true,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440007\"],[\"timestamp\",\"2026-08-21T12:00:06.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"long_running_task\"],[\"namespace\",\"compute\"],[\"upstream\",\"batch-server\"],[\"principal\",\"service:scheduler\"],[\"durationMs\",9007199254740991],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "75c90c99a36a895d1ba5acdb05167443e0fd1a1b3bf2a305d4cefdcac024511a"
+    },
+    {
+      "name": "empty_string_tool_name",
+      "record": {
+        "id": "550e8400-e29b-41d4-a716-446655440008",
+        "timestamp": "2026-08-21T12:00:07.000Z",
+        "method": "tools/call",
+        "toolName": "",
+        "namespace": "",
+        "upstream": "legacy-server",
+        "principal": "user:admin",
+        "durationMs": 1,
+        "success": true,
+        "previousHash": "genesis"
+      },
+      "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440008\"],[\"timestamp\",\"2026-08-21T12:00:07.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"\"],[\"namespace\",\"\"],[\"upstream\",\"legacy-server\"],[\"principal\",\"user:admin\"],[\"durationMs\",1],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "2343460398a9d803ccedd27d8cc1d9693897e58e0c4d8985e2e88ba60170835c"
+    }
+  ],
+  "chain": {
+    "description": "Three linked records demonstrating hash chain verification. The chain hash covers the FULL record including the attestation field. This means the attestation (signature) is bound into the chain sequence.",
+    "chain_algorithm": "sha256(JSON.stringify(fullRecord))",
+    "chain_key_order": [
+      "id",
+      "timestamp",
+      "method",
+      "toolName",
+      "namespace",
+      "upstream",
+      "principal",
+      "durationMs",
+      "success",
+      "previousHash",
+      "attestation"
+    ],
+    "chain_key_order_note": "The chain hash uses JSON.stringify which preserves JavaScript insertion order. Verifiers in languages without ordered maps MUST serialize keys in this exact order to reproduce chain hashes. The canonical form (tuple-array) does NOT have this limitation.",
+    "genesis_seed": "genesis",
+    "records": [
+      {
+        "record": {
+          "id": "660e8400-e29b-41d4-a716-446655440001",
+          "timestamp": "2026-08-21T13:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "search",
+          "namespace": "research",
+          "upstream": "search-server",
+          "principal": "user:carol@example.com",
+          "durationMs": 230,
+          "success": true,
+          "previousHash": "genesis",
+          "attestation": "abc123deadbeef"
+        },
+        "full_record_json": "{\"id\":\"660e8400-e29b-41d4-a716-446655440001\",\"timestamp\":\"2026-08-21T13:00:00.000Z\",\"method\":\"tools/call\",\"toolName\":\"search\",\"namespace\":\"research\",\"upstream\":\"search-server\",\"principal\":\"user:carol@example.com\",\"durationMs\":230,\"success\":true,\"previousHash\":\"genesis\",\"attestation\":\"abc123deadbeef\"}",
+        "record_hash": "bcb759bae3e453c133cae1dd026b477522bc493084be15a84686d7b819eb2b99",
+        "canonical": "[[\"id\",\"660e8400-e29b-41d4-a716-446655440001\"],[\"timestamp\",\"2026-08-21T13:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"search\"],[\"namespace\",\"research\"],[\"upstream\",\"search-server\"],[\"principal\",\"user:carol@example.com\"],[\"durationMs\",230],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+        "sha256_canonical": "2779a8c2eee23f409039929b49b7dd6df30e95ba9a3d83e6443d16c13ba5306a"
+      },
+      {
+        "record": {
+          "id": "660e8400-e29b-41d4-a716-446655440002",
+          "timestamp": "2026-08-21T13:00:01.500Z",
+          "method": "tools/call",
+          "toolName": "summarize",
+          "namespace": "research",
+          "upstream": "llm-server",
+          "principal": "user:carol@example.com",
+          "durationMs": 1840,
+          "success": true,
+          "previousHash": "bcb759bae3e453c133cae1dd026b477522bc493084be15a84686d7b819eb2b99",
+          "attestation": "def456cafebabe"
+        },
+        "full_record_json": "{\"id\":\"660e8400-e29b-41d4-a716-446655440002\",\"timestamp\":\"2026-08-21T13:00:01.500Z\",\"method\":\"tools/call\",\"toolName\":\"summarize\",\"namespace\":\"research\",\"upstream\":\"llm-server\",\"principal\":\"user:carol@example.com\",\"durationMs\":1840,\"success\":true,\"previousHash\":\"bcb759bae3e453c133cae1dd026b477522bc493084be15a84686d7b819eb2b99\",\"attestation\":\"def456cafebabe\"}",
+        "record_hash": "8890ec9936274006781013783a3e4b319ae4e912bb14a597800efc9347a29abe",
+        "canonical": "[[\"id\",\"660e8400-e29b-41d4-a716-446655440002\"],[\"timestamp\",\"2026-08-21T13:00:01.500Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"summarize\"],[\"namespace\",\"research\"],[\"upstream\",\"llm-server\"],[\"principal\",\"user:carol@example.com\"],[\"durationMs\",1840],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"bcb759bae3e453c133cae1dd026b477522bc493084be15a84686d7b819eb2b99\"]]",
+        "sha256_canonical": "89bf2344f791f6f20bbb74fc8dfffeca1c1a3877cf60fa225c5d7292e8189bb9",
+        "previous_record_hash": "bcb759bae3e453c133cae1dd026b477522bc493084be15a84686d7b819eb2b99"
+      },
+      {
+        "record": {
+          "id": "660e8400-e29b-41d4-a716-446655440003",
+          "timestamp": "2026-08-21T13:00:05.000Z",
+          "method": "tools/call",
+          "toolName": "store_result",
+          "namespace": "research",
+          "upstream": "storage-server",
+          "principal": "user:carol@example.com",
+          "durationMs": 45,
+          "success": true,
+          "previousHash": "8890ec9936274006781013783a3e4b319ae4e912bb14a597800efc9347a29abe",
+          "attestation": "789abcfeedface"
+        },
+        "full_record_json": "{\"id\":\"660e8400-e29b-41d4-a716-446655440003\",\"timestamp\":\"2026-08-21T13:00:05.000Z\",\"method\":\"tools/call\",\"toolName\":\"store_result\",\"namespace\":\"research\",\"upstream\":\"storage-server\",\"principal\":\"user:carol@example.com\",\"durationMs\":45,\"success\":true,\"previousHash\":\"8890ec9936274006781013783a3e4b319ae4e912bb14a597800efc9347a29abe\",\"attestation\":\"789abcfeedface\"}",
+        "record_hash": "287b9307278203eab4429fea6636492044f428b96ade97910aa7ad86303ffc16",
+        "canonical": "[[\"id\",\"660e8400-e29b-41d4-a716-446655440003\"],[\"timestamp\",\"2026-08-21T13:00:05.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"store_result\"],[\"namespace\",\"research\"],[\"upstream\",\"storage-server\"],[\"principal\",\"user:carol@example.com\"],[\"durationMs\",45],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"8890ec9936274006781013783a3e4b319ae4e912bb14a597800efc9347a29abe\"]]",
+        "sha256_canonical": "d049da892b814c95c3e5c31e4756c5db26023a85e6f41e2c38984146b3fb2597",
+        "previous_record_hash": "8890ec9936274006781013783a3e4b319ae4e912bb14a597800efc9347a29abe"
+      }
+    ]
+  },
+  "dual_hash_demo": {
+    "description": "Two records with identical auditable fields but different attestation values. They produce the SAME canonical hash (attestation is excluded from signing) but DIFFERENT chain hashes (attestation is included in chain). This demonstrates the dual-hash design.",
+    "record_a": {
+      "record": {
+        "id": "770e8400-e29b-41d4-a716-446655440001",
+        "timestamp": "2026-08-21T14:00:00.000Z",
+        "method": "tools/call",
+        "toolName": "verify_identity",
+        "namespace": "auth",
+        "upstream": "identity-server",
+        "principal": "user:dave@example.com",
+        "durationMs": 55,
+        "success": true,
+        "previousHash": "genesis",
+        "attestation": "sig_aaa111"
+      },
+      "canonical": "[[\"id\",\"770e8400-e29b-41d4-a716-446655440001\"],[\"timestamp\",\"2026-08-21T14:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"verify_identity\"],[\"namespace\",\"auth\"],[\"upstream\",\"identity-server\"],[\"principal\",\"user:dave@example.com\"],[\"durationMs\",55],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "0443b29e0a27962c296cd4e854f954491213515426eb0d25adc773c463e02e00",
+      "full_record_json": "{\"id\":\"770e8400-e29b-41d4-a716-446655440001\",\"timestamp\":\"2026-08-21T14:00:00.000Z\",\"method\":\"tools/call\",\"toolName\":\"verify_identity\",\"namespace\":\"auth\",\"upstream\":\"identity-server\",\"principal\":\"user:dave@example.com\",\"durationMs\":55,\"success\":true,\"previousHash\":\"genesis\",\"attestation\":\"sig_aaa111\"}",
+      "record_hash": "16943a93113fe9895979585a6a972a12eca7d94a67370a8abd8eefa52deafdac"
+    },
+    "record_b": {
+      "record": {
+        "id": "770e8400-e29b-41d4-a716-446655440001",
+        "timestamp": "2026-08-21T14:00:00.000Z",
+        "method": "tools/call",
+        "toolName": "verify_identity",
+        "namespace": "auth",
+        "upstream": "identity-server",
+        "principal": "user:dave@example.com",
+        "durationMs": 55,
+        "success": true,
+        "previousHash": "genesis",
+        "attestation": "sig_bbb222"
+      },
+      "canonical": "[[\"id\",\"770e8400-e29b-41d4-a716-446655440001\"],[\"timestamp\",\"2026-08-21T14:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"verify_identity\"],[\"namespace\",\"auth\"],[\"upstream\",\"identity-server\"],[\"principal\",\"user:dave@example.com\"],[\"durationMs\",55],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+      "sha256_canonical": "0443b29e0a27962c296cd4e854f954491213515426eb0d25adc773c463e02e00",
+      "full_record_json": "{\"id\":\"770e8400-e29b-41d4-a716-446655440001\",\"timestamp\":\"2026-08-21T14:00:00.000Z\",\"method\":\"tools/call\",\"toolName\":\"verify_identity\",\"namespace\":\"auth\",\"upstream\":\"identity-server\",\"principal\":\"user:dave@example.com\",\"durationMs\":55,\"success\":true,\"previousHash\":\"genesis\",\"attestation\":\"sig_bbb222\"}",
+      "record_hash": "770efbb50562d529f271f94b26f373749ddfda9936f4305a5ec2c4a256bf24b7"
+    },
+    "assertions": {
+      "canonical_hashes_match": true,
+      "chain_hashes_differ": true
+    }
+  },
+  "party_attribution": {
+    "description": "Vectors demonstrating multi-party attribution in the canonical form. The parties field is an array of {party, role, scope} objects that declares which entity asserted which fields. It appears at the end of the tuple-array (after previousHash, or after decisionContextDigest if present). Records without parties omit the field entirely from the canonical form. Includes edge cases: empty array vs null, scope ordering significance, and chain continuity with parties.",
+    "vectors": [
+      {
+        "name": "parties_gateway_only",
+        "description": "Single-party record: gateway witnesses all 11 base fields.",
+        "record": {
+          "id": "880e8400-e29b-41d4-a716-446655440001",
+          "timestamp": "2026-08-22T10:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "read_file",
+          "namespace": "filesystem",
+          "upstream": "fs-server",
+          "principal": "user:eve@example.com",
+          "durationMs": 34,
+          "success": true,
+          "previousHash": "genesis",
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": [
+                "id",
+                "timestamp",
+                "method",
+                "toolName",
+                "namespace",
+                "upstream",
+                "principal",
+                "durationMs",
+                "success",
+                "errorCode",
+                "previousHash"
+              ]
+            }
+          ]
+        },
+        "canonical": "[[\"id\",\"880e8400-e29b-41d4-a716-446655440001\"],[\"timestamp\",\"2026-08-22T10:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"read_file\"],[\"namespace\",\"filesystem\"],[\"upstream\",\"fs-server\"],[\"principal\",\"user:eve@example.com\"],[\"durationMs\",34],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]}]]]",
+        "sha256_canonical": "57cecd4f1d3f7f3f745a1e8cf1188f9a2d019cfe992edfebb506c4f3cd000231"
+      },
+      {
+        "name": "parties_dual_attribution",
+        "description": "Dual-party record: gateway witnesses base fields, policy-engine asserts decisionContextDigest. Demonstrates the 11:1 field split.",
+        "record": {
+          "id": "880e8400-e29b-41d4-a716-446655440002",
+          "timestamp": "2026-08-22T10:00:01.000Z",
+          "method": "tools/call",
+          "toolName": "execute_query",
+          "namespace": "database",
+          "upstream": "db-server",
+          "principal": "service:data-agent",
+          "durationMs": 412,
+          "success": true,
+          "decisionContextDigest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "previousHash": "genesis",
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": [
+                "id",
+                "timestamp",
+                "method",
+                "toolName",
+                "namespace",
+                "upstream",
+                "principal",
+                "durationMs",
+                "success",
+                "errorCode",
+                "previousHash"
+              ]
+            },
+            {
+              "party": "policy-engine",
+              "role": "asserter",
+              "scope": [
+                "decisionContextDigest"
+              ]
+            }
+          ]
+        },
+        "canonical": "[[\"id\",\"880e8400-e29b-41d4-a716-446655440002\"],[\"timestamp\",\"2026-08-22T10:00:01.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"execute_query\"],[\"namespace\",\"database\"],[\"upstream\",\"db-server\"],[\"principal\",\"service:data-agent\"],[\"durationMs\",412],[\"success\",true],[\"errorCode\",null],[\"decisionContextDigest\",\"sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\"],[\"previousHash\",\"genesis\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]},{\"party\":\"policy-engine\",\"role\":\"asserter\",\"scope\":[\"decisionContextDigest\"]}]]]",
+        "sha256_canonical": "bd81a3ab5c5e0b8bc910348ddbd77d274a2f3664260c96023df0a6e4ac2bc741"
+      },
+      {
+        "name": "no_parties_backward_compat",
+        "description": "Record without parties field — canonical form identical to pre-parties vectors. Proves backward compatibility.",
+        "record": {
+          "id": "880e8400-e29b-41d4-a716-446655440003",
+          "timestamp": "2026-08-22T10:00:02.000Z",
+          "method": "tools/list",
+          "durationMs": 2,
+          "success": true,
+          "previousHash": "genesis"
+        },
+        "canonical": "[[\"id\",\"880e8400-e29b-41d4-a716-446655440003\"],[\"timestamp\",\"2026-08-22T10:00:02.000Z\"],[\"method\",\"tools/list\"],[\"toolName\",null],[\"namespace\",null],[\"upstream\",null],[\"principal\",null],[\"durationMs\",2],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+        "sha256_canonical": "e6468120453a560a5d55c6b37fdc0df35213f9ffa3f93042d1583341ab530621"
+      },
+      {
+        "name": "parties_empty_array",
+        "description": "An empty parties array ([]) is NOT null and MUST be included in the canonical form. Distinguishes \"no attribution declared\" (null/absent = excluded) from \"parties explicitly empty\" ([] = included).",
+        "record": {
+          "id": "rec_empty_parties_001",
+          "timestamp": "2026-08-22T10:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "validate",
+          "inputHash": "sha256:abc123",
+          "outputHash": "sha256:def456",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "namespace": "test",
+          "upstream": null,
+          "principal": "user:tester",
+          "parties": []
+        },
+        "canonical": "[[\"id\",\"rec_empty_parties_001\"],[\"timestamp\",\"2026-08-22T10:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"validate\"],[\"namespace\",\"test\"],[\"upstream\",null],[\"principal\",\"user:tester\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"sha256:0000000000000000000000000000000000000000000000000000000000000000\"],[\"parties\",[]]]",
+        "sha256_canonical": "14b5da4505f02cd8414f24556e19b787fa7d9fc0fb033778f9ed512f9a265a16"
+      },
+      {
+        "name": "scope_order_original",
+        "description": "Scope array order is significant. [\"toolName\", \"id\", \"timestamp\"] produces a DIFFERENT hash than alphabetically sorted. Implementations MUST NOT sort scope arrays.",
+        "record": {
+          "id": "rec_scope_order_001",
+          "timestamp": "2026-08-22T11:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "execute",
+          "inputHash": "sha256:aaa111",
+          "outputHash": "sha256:bbb222",
+          "durationMs": 100,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "namespace": "ordering-test",
+          "upstream": null,
+          "principal": "user:verifier",
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": [
+                "toolName",
+                "id",
+                "timestamp"
+              ]
+            }
+          ]
+        },
+        "canonical": "[[\"id\",\"rec_scope_order_001\"],[\"timestamp\",\"2026-08-22T11:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"execute\"],[\"namespace\",\"ordering-test\"],[\"upstream\",null],[\"principal\",\"user:verifier\"],[\"durationMs\",100],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"sha256:1111111111111111111111111111111111111111111111111111111111111111\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"toolName\",\"id\",\"timestamp\"]}]]]",
+        "sha256_canonical": "ae6803d101ac18ec66d883c15ca20b3ace811fc1f1d77938b653ff7e5066b3e0"
+      },
+      {
+        "name": "scope_order_sorted",
+        "description": "Same record as scope_order_original but with scope alphabetically sorted. Hash MUST differ, proving scope order is normative.",
+        "record": {
+          "id": "rec_scope_order_001",
+          "timestamp": "2026-08-22T11:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "execute",
+          "inputHash": "sha256:aaa111",
+          "outputHash": "sha256:bbb222",
+          "durationMs": 100,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "namespace": "ordering-test",
+          "upstream": null,
+          "principal": "user:verifier",
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": [
+                "id",
+                "timestamp",
+                "toolName"
+              ]
+            }
+          ]
+        },
+        "canonical": "[[\"id\",\"rec_scope_order_001\"],[\"timestamp\",\"2026-08-22T11:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"execute\"],[\"namespace\",\"ordering-test\"],[\"upstream\",null],[\"principal\",\"user:verifier\"],[\"durationMs\",100],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"sha256:1111111111111111111111111111111111111111111111111111111111111111\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"toolName\"]}]]]",
+        "sha256_canonical": "ab3287cabbfc2970ae5c1111a8fb32c9ab5b8d0382488a693229a68527ff8289"
+      }
+    ],
+    "chain_with_parties": {
+      "description": "Two-record chain where both records carry party attribution. Proves parties are included in record_hash used for chain linkage.",
+      "genesis_seed": "sha256:chain_parties_genesis_0000000000000000000000000000000000000000",
+      "records": [
+        {
+          "record": {
+            "id": "rec_chain_pa_001",
+            "timestamp": "2026-08-22T12:00:00.000Z",
+            "method": "tools/call",
+            "toolName": "fetch_data",
+            "inputHash": "sha256:input_fetch",
+            "outputHash": "sha256:output_fetch",
+            "durationMs": 230,
+            "success": true,
+            "errorCode": null,
+            "previousHash": "sha256:chain_parties_genesis_0000000000000000000000000000000000000000",
+            "namespace": "chain-party-test",
+            "upstream": "https://api.example.com",
+            "principal": "user:chain-tester",
+            "decisionContextDigest": "sha256:policy_eval_001",
+            "parties": [
+              {
+                "party": "gateway",
+                "role": "witness",
+                "scope": [
+                  "id",
+                  "timestamp",
+                  "method",
+                  "toolName",
+                  "namespace",
+                  "upstream",
+                  "principal",
+                  "durationMs",
+                  "success",
+                  "errorCode",
+                  "previousHash"
+                ]
+              },
+              {
+                "party": "policy-engine",
+                "role": "asserter",
+                "scope": [
+                  "decisionContextDigest"
+                ]
+              }
+            ]
+          },
+          "canonical": "[[\"id\",\"rec_chain_pa_001\"],[\"timestamp\",\"2026-08-22T12:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"fetch_data\"],[\"namespace\",\"chain-party-test\"],[\"upstream\",\"https://api.example.com\"],[\"principal\",\"user:chain-tester\"],[\"durationMs\",230],[\"success\",true],[\"errorCode\",null],[\"decisionContextDigest\",\"sha256:policy_eval_001\"],[\"previousHash\",\"sha256:chain_parties_genesis_0000000000000000000000000000000000000000\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]},{\"party\":\"policy-engine\",\"role\":\"asserter\",\"scope\":[\"decisionContextDigest\"]}]]]",
+          "sha256_canonical": "5ff1b9a27985dbd920a44a81661e134a8f1b6968c0f30ac4fb027c5cb62fc10e",
+          "full_record_json": "{\"id\":\"rec_chain_pa_001\",\"timestamp\":\"2026-08-22T12:00:00.000Z\",\"method\":\"tools/call\",\"toolName\":\"fetch_data\",\"inputHash\":\"sha256:input_fetch\",\"outputHash\":\"sha256:output_fetch\",\"durationMs\":230,\"success\":true,\"errorCode\":null,\"previousHash\":\"sha256:chain_parties_genesis_0000000000000000000000000000000000000000\",\"namespace\":\"chain-party-test\",\"upstream\":\"https://api.example.com\",\"principal\":\"user:chain-tester\",\"decisionContextDigest\":\"sha256:policy_eval_001\",\"parties\":[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]},{\"party\":\"policy-engine\",\"role\":\"asserter\",\"scope\":[\"decisionContextDigest\"]}]}",
+          "record_hash": "f154e23342cd33318799c1edc23507437d17a04451aad1a89f733afd3b74c195"
+        },
+        {
+          "record": {
+            "id": "rec_chain_pa_002",
+            "timestamp": "2026-08-22T12:00:01.500Z",
+            "method": "tools/call",
+            "toolName": "transform_data",
+            "inputHash": "sha256:input_transform",
+            "outputHash": "sha256:output_transform",
+            "durationMs": 85,
+            "success": true,
+            "errorCode": null,
+            "previousHash": "f154e23342cd33318799c1edc23507437d17a04451aad1a89f733afd3b74c195",
+            "namespace": "chain-party-test",
+            "upstream": null,
+            "principal": "user:chain-tester",
+            "decisionContextDigest": "sha256:policy_eval_002",
+            "parties": [
+              {
+                "party": "gateway",
+                "role": "witness",
+                "scope": [
+                  "id",
+                  "timestamp",
+                  "method",
+                  "toolName",
+                  "namespace",
+                  "upstream",
+                  "principal",
+                  "durationMs",
+                  "success",
+                  "errorCode",
+                  "previousHash"
+                ]
+              },
+              {
+                "party": "policy-engine",
+                "role": "asserter",
+                "scope": [
+                  "decisionContextDigest"
+                ]
+              }
+            ]
+          },
+          "canonical": "[[\"id\",\"rec_chain_pa_002\"],[\"timestamp\",\"2026-08-22T12:00:01.500Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"transform_data\"],[\"namespace\",\"chain-party-test\"],[\"upstream\",null],[\"principal\",\"user:chain-tester\"],[\"durationMs\",85],[\"success\",true],[\"errorCode\",null],[\"decisionContextDigest\",\"sha256:policy_eval_002\"],[\"previousHash\",\"f154e23342cd33318799c1edc23507437d17a04451aad1a89f733afd3b74c195\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]},{\"party\":\"policy-engine\",\"role\":\"asserter\",\"scope\":[\"decisionContextDigest\"]}]]]",
+          "sha256_canonical": "7583bd43ae7ca4eefb9bf143af5c3d77a79fde96bb0d98d1fdb68c94d6246c7b",
+          "full_record_json": "{\"id\":\"rec_chain_pa_002\",\"timestamp\":\"2026-08-22T12:00:01.500Z\",\"method\":\"tools/call\",\"toolName\":\"transform_data\",\"inputHash\":\"sha256:input_transform\",\"outputHash\":\"sha256:output_transform\",\"durationMs\":85,\"success\":true,\"errorCode\":null,\"previousHash\":\"f154e23342cd33318799c1edc23507437d17a04451aad1a89f733afd3b74c195\",\"namespace\":\"chain-party-test\",\"upstream\":null,\"principal\":\"user:chain-tester\",\"decisionContextDigest\":\"sha256:policy_eval_002\",\"parties\":[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]},{\"party\":\"policy-engine\",\"role\":\"asserter\",\"scope\":[\"decisionContextDigest\"]}]}",
+          "record_hash": "592254c9851b3a7fad4c17bef66f73d8b4bc58ea58d041c08e0ceff27f9d98c8",
+          "previous_record_hash": "f154e23342cd33318799c1edc23507437d17a04451aad1a89f733afd3b74c195"
+        }
+      ]
+    }
+  },
+  "ai_invocation_signing": {
+    "description": "aiInvocation is signature-covered: inserted after extensionsDigest, before parties, as its canonicalizeValue (M/L-tagged) form. Keys sort by UTF-16 code units.",
+    "vectors": [
+      {
+        "name": "ai_invocation_full",
+        "record": {
+          "id": "aivec-0001",
+          "timestamp": "2026-08-23T00:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "github/create_pr",
+          "namespace": "github",
+          "upstream": "gh",
+          "principal": "user-1",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "aiInvocation": {
+            "turnId": "t1",
+            "invocationReason": "user asked",
+            "model": "claude-4"
+          }
+        },
+        "canonical": "[[\"id\",\"aivec-0001\"],[\"timestamp\",\"2026-08-23T00:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"github/create_pr\"],[\"namespace\",\"github\"],[\"upstream\",\"gh\"],[\"principal\",\"user-1\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"aiInvocation\",[\"M\",[[\"invocationReason\",\"user asked\"],[\"model\",\"claude-4\"],[\"turnId\",\"t1\"]]]]]",
+        "sha256_canonical": "fddd4a4043f5403a731c116051fb182018176618edb17d3e5d020083e8ff33cf"
+      },
+      {
+        "name": "ai_invocation_partial_turnid_only",
+        "record": {
+          "id": "aivec-0001",
+          "timestamp": "2026-08-23T00:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "github/create_pr",
+          "namespace": "github",
+          "upstream": "gh",
+          "principal": "user-1",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "aiInvocation": {
+            "turnId": "t1"
+          }
+        },
+        "canonical": "[[\"id\",\"aivec-0001\"],[\"timestamp\",\"2026-08-23T00:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"github/create_pr\"],[\"namespace\",\"github\"],[\"upstream\",\"gh\"],[\"principal\",\"user-1\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"aiInvocation\",[\"M\",[[\"turnId\",\"t1\"]]]]]",
+        "sha256_canonical": "7e8627013a6a2430b0fb308fa493e3f6a7b552385734621bb1b8cb4587d4d1f3"
+      },
+      {
+        "name": "ai_invocation_with_all_optionals",
+        "record": {
+          "id": "aivec-0001",
+          "timestamp": "2026-08-23T00:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "github/create_pr",
+          "namespace": "github",
+          "upstream": "gh",
+          "principal": "user-1",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "decisionContextDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "extensionsDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "aiInvocation": {
+            "turnId": "t1",
+            "model": "claude-4"
+          },
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": [
+                "id",
+                "timestamp",
+                "method",
+                "toolName",
+                "namespace",
+                "upstream",
+                "principal",
+                "durationMs",
+                "success",
+                "errorCode",
+                "previousHash"
+              ]
+            },
+            {
+              "party": "client",
+              "role": "asserter",
+              "scope": [
+                "aiInvocation"
+              ]
+            }
+          ]
+        },
+        "canonical": "[[\"id\",\"aivec-0001\"],[\"timestamp\",\"2026-08-23T00:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"github/create_pr\"],[\"namespace\",\"github\"],[\"upstream\",\"gh\"],[\"principal\",\"user-1\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"decisionContextDigest\",\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"],[\"previousHash\",\"genesis\"],[\"extensionsDigest\",\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"],[\"aiInvocation\",[\"M\",[[\"model\",\"claude-4\"],[\"turnId\",\"t1\"]]]],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\",\"timestamp\",\"method\",\"toolName\",\"namespace\",\"upstream\",\"principal\",\"durationMs\",\"success\",\"errorCode\",\"previousHash\"]},{\"party\":\"client\",\"role\":\"asserter\",\"scope\":[\"aiInvocation\"]}]]]",
+        "sha256_canonical": "cc6cc5a9146f4c5cf5952e354288705cb67a642f5790fc2fec7acd6bb3c5e682"
+      }
+    ],
+    "mutation_negative": {
+      "description": "Mutating any aiInvocation field changes the signing digest; a signature over the original record must fail against the mutated record.",
+      "original": {
+        "name": "original",
+        "record": {
+          "id": "aivec-0001",
+          "timestamp": "2026-08-23T00:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "github/create_pr",
+          "namespace": "github",
+          "upstream": "gh",
+          "principal": "user-1",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "aiInvocation": {
+            "turnId": "t1",
+            "invocationReason": "user asked",
+            "model": "claude-4"
+          }
+        },
+        "canonical": "[[\"id\",\"aivec-0001\"],[\"timestamp\",\"2026-08-23T00:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"github/create_pr\"],[\"namespace\",\"github\"],[\"upstream\",\"gh\"],[\"principal\",\"user-1\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"aiInvocation\",[\"M\",[[\"invocationReason\",\"user asked\"],[\"model\",\"claude-4\"],[\"turnId\",\"t1\"]]]]]",
+        "sha256_canonical": "fddd4a4043f5403a731c116051fb182018176618edb17d3e5d020083e8ff33cf"
+      },
+      "mutated": {
+        "name": "mutated_turnId",
+        "record": {
+          "id": "aivec-0001",
+          "timestamp": "2026-08-23T00:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "github/create_pr",
+          "namespace": "github",
+          "upstream": "gh",
+          "principal": "user-1",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "aiInvocation": {
+            "turnId": "t2",
+            "invocationReason": "user asked",
+            "model": "claude-4"
+          }
+        },
+        "canonical": "[[\"id\",\"aivec-0001\"],[\"timestamp\",\"2026-08-23T00:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"github/create_pr\"],[\"namespace\",\"github\"],[\"upstream\",\"gh\"],[\"principal\",\"user-1\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"aiInvocation\",[\"M\",[[\"invocationReason\",\"user asked\"],[\"model\",\"claude-4\"],[\"turnId\",\"t2\"]]]]]",
+        "sha256_canonical": "960ffc250afd098da527c99dd932fd6d4cc3c1c51283c69861facda20db7f438"
+      },
+      "digests_differ": true
+    }
+  },
+  "extensions_digest_base": {
+    "description": "Base-suite exercise of extensionsDigest insertion order (between decisionContextDigest slot and parties).",
+    "vectors": [
+      {
+        "name": "extensions_digest_with_parties",
+        "record": {
+          "id": "aivec-0001",
+          "timestamp": "2026-08-23T00:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "github/create_pr",
+          "namespace": "github",
+          "upstream": "gh",
+          "principal": "user-1",
+          "durationMs": 42,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "extensionsDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": [
+                "id"
+              ]
+            }
+          ]
+        },
+        "canonical": "[[\"id\",\"aivec-0001\"],[\"timestamp\",\"2026-08-23T00:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"github/create_pr\"],[\"namespace\",\"github\"],[\"upstream\",\"gh\"],[\"principal\",\"user-1\"],[\"durationMs\",42],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"extensionsDigest\",\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"id\"]}]]]",
+        "sha256_canonical": "0fb68b55f31aabe40cea3ab15962aa4ea348c148b9c85ed6cad5a522e7ac1b34"
+      }
+    ]
+  }
+}

--- a/fixtures/cross-stack/mcp-audit-gateway-v0.6/checkpoint.json
+++ b/fixtures/cross-stack/mcp-audit-gateway-v0.6/checkpoint.json
@@ -1,0 +1,450 @@
+{
+  "format_version": "1.0.0",
+  "implementation": "mcp-audit-gateway",
+  "description": "Conformance vectors for checkpoint records. Checkpoints enable truncation detection by providing externally-anchorable chain state. The completeness guarantee requires the consumer to externalize at least one checkpoint somewhere the gateway cannot rewrite.",
+  "canonical_form": "tuple-array",
+  "checkpoint_field_order": [
+    "id",
+    "type",
+    "timestamp",
+    "sequence",
+    "recordCount",
+    "previousHash"
+  ],
+  "conditional_fields": {
+    "parties": "Appended at position 6 when present and non-null."
+  },
+  "design_notes": {
+    "self_sufficiency": "Checkpoints alone do NOT solve truncation. An attacker with log access can drop checkpoints along with the records they cover. The detection guarantee comes from the consumer externalizing the checkpoint (storing previousHash + sequence + recordCount) somewhere the adversary cannot rewrite.",
+    "detection_vs_attribution": "A missing checkpoint tells the consumer something was dropped, but cannot distinguish malicious truncation from legitimate gateway downtime or crash.",
+    "no_chainHead_field": "No separate chainHead field exists. The checkpoint's previousHash IS the chain head at checkpoint time. A separate field would be redundant and introduce ambiguity about whether it means head-before or head-after the checkpoint."
+  },
+  "checkpoint_canonicalization": [
+    {
+      "name": "checkpoint_basic",
+      "description": "Basic checkpoint record without parties. Canonical form includes the type field at position 1.",
+      "record": {
+        "id": "ckpt_990e8400-e29b-41d4-a716-446655440001",
+        "type": "checkpoint",
+        "timestamp": "2026-08-22T20:00:00.000Z",
+        "sequence": 1,
+        "recordCount": 5,
+        "previousHash": "4e9c29d6e22fc2ef1f931994997b01f48f054c1294a7c287bfeece79417e5d43"
+      },
+      "canonical": "[[\"id\",\"ckpt_990e8400-e29b-41d4-a716-446655440001\"],[\"type\",\"checkpoint\"],[\"timestamp\",\"2026-08-22T20:00:00.000Z\"],[\"sequence\",1],[\"recordCount\",5],[\"previousHash\",\"4e9c29d6e22fc2ef1f931994997b01f48f054c1294a7c287bfeece79417e5d43\"]]",
+      "sha256_canonical": "29fcb385d7306fe136b50eb46fd55731ff3c2aadbecb18554267890c3b625794"
+    },
+    {
+      "name": "checkpoint_with_parties",
+      "description": "Checkpoint with gateway witness party declaring which fields it attests to. Parties array appended at end of tuple-array.",
+      "record": {
+        "id": "ckpt_990e8400-e29b-41d4-a716-446655440002",
+        "type": "checkpoint",
+        "timestamp": "2026-08-22T20:01:00.000Z",
+        "sequence": 2,
+        "recordCount": 10,
+        "previousHash": "abc123def456789",
+        "parties": [
+          {
+            "party": "gateway",
+            "role": "witness",
+            "scope": ["sequence", "recordCount", "previousHash"]
+          }
+        ]
+      },
+      "canonical": "[[\"id\",\"ckpt_990e8400-e29b-41d4-a716-446655440002\"],[\"type\",\"checkpoint\"],[\"timestamp\",\"2026-08-22T20:01:00.000Z\"],[\"sequence\",2],[\"recordCount\",10],[\"previousHash\",\"abc123def456789\"],[\"parties\",[{\"party\":\"gateway\",\"role\":\"witness\",\"scope\":[\"sequence\",\"recordCount\",\"previousHash\"]}]]]",
+      "sha256_canonical": "0b23e3a13467b142f6baaa206450428c03c9757889753d91e496f02c4b1c9d0f"
+    }
+  ],
+  "checkpoint_chain": {
+    "description": "Three-record chain with a checkpoint in the middle. Proves checkpoints participate in hash chain identically to tool_call records. The checkpoint's previousHash equals the hash of the preceding tool_call record. The subsequent tool_call record's previousHash equals the hash of the checkpoint (including its attestation field).",
+    "records": [
+      {
+        "record": {
+          "id": "990e8400-e29b-41d4-a716-446655440010",
+          "timestamp": "2026-08-22T20:10:00.000Z",
+          "method": "tools/call",
+          "toolName": "read_file",
+          "namespace": "fs",
+          "upstream": "fs-server",
+          "principal": "user:bob@example.com",
+          "durationMs": 25,
+          "success": true,
+          "previousHash": "genesis",
+          "attestation": "sig_chain_rec1"
+        },
+        "record_hash": "336524ce7dd7e651e7ef8774be253808fe5e1f8d3e4f62889e9bcc18390c7e89"
+      },
+      {
+        "record": {
+          "id": "ckpt_990e8400-e29b-41d4-a716-446655440011",
+          "type": "checkpoint",
+          "timestamp": "2026-08-22T20:10:01.000Z",
+          "sequence": 1,
+          "recordCount": 1,
+          "previousHash": "336524ce7dd7e651e7ef8774be253808fe5e1f8d3e4f62889e9bcc18390c7e89",
+          "parties": [
+            {
+              "party": "gateway",
+              "role": "witness",
+              "scope": ["sequence", "recordCount", "previousHash"]
+            }
+          ],
+          "attestation": "sig_chain_ckpt"
+        },
+        "record_hash": "f92d28a4494bd9700aa5b903acf4a538fca66f1971d772c8cf996ea925d12ef0",
+        "previous_record_hash": "336524ce7dd7e651e7ef8774be253808fe5e1f8d3e4f62889e9bcc18390c7e89"
+      },
+      {
+        "record": {
+          "id": "990e8400-e29b-41d4-a716-446655440012",
+          "timestamp": "2026-08-22T20:10:02.000Z",
+          "method": "tools/call",
+          "toolName": "write_file",
+          "namespace": "fs",
+          "upstream": "fs-server",
+          "principal": "user:bob@example.com",
+          "durationMs": 42,
+          "success": true,
+          "previousHash": "f92d28a4494bd9700aa5b903acf4a538fca66f1971d772c8cf996ea925d12ef0",
+          "attestation": "sig_chain_rec2"
+        },
+        "record_hash": "48838c2d0c0f389c3c45bde0f5d8d4ee58d07ab8d9948889000e2295f0f2b118",
+        "previous_record_hash": "f92d28a4494bd9700aa5b903acf4a538fca66f1971d772c8cf996ea925d12ef0"
+      }
+    ]
+  },
+  "truncation_detection": {
+    "description": "Demonstrates completeness verification using externalized checkpoints. The consumer stores one checkpoint (previousHash + sequence + recordCount) in a location the gateway cannot reach. During verification, the consumer checks that the delivered chain contains that checkpoint or a descendant. If neither is found, records were dropped.",
+    "external_checkpoint": {
+      "previousHash": "336524ce7dd7e651e7ef8774be253808fe5e1f8d3e4f62889e9bcc18390c7e89",
+      "sequence": 1,
+      "recordCount": 1
+    },
+    "complete_chain_result": {
+      "truncated": false,
+      "reason": "checkpoint found in delivered chain"
+    },
+    "truncated_chain": {
+      "description": "If only rec1 is delivered (checkpoint and rec2 dropped from tail), the external checkpoint cannot be matched. The remaining prefix verifies its own integrity (signatures valid, chain hashes correct) but the consumer knows records are missing because no checkpoint matches or descends from the externalized one.",
+      "records_delivered": [
+        {
+          "id": "990e8400-e29b-41d4-a716-446655440010",
+          "timestamp": "2026-08-22T20:10:00.000Z",
+          "method": "tools/call",
+          "toolName": "read_file",
+          "namespace": "fs",
+          "upstream": "fs-server",
+          "principal": "user:bob@example.com",
+          "durationMs": 25,
+          "success": true,
+          "previousHash": "genesis",
+          "attestation": "sig_chain_rec1"
+        }
+      ],
+      "detection_result": "truncated",
+      "reason": "externalized checkpoint not found in chain and no descendant checkpoint exists",
+      "failureCode": "head_missing"
+    }
+  },
+  "canonicalize_value": {
+    "description": "canonicalizeValue() recursively converts values to an injective canonical form using type tags. Objects become [\"M\", [[k,v],...]] with sorted keys. Arrays become [\"L\", [...]]. Type tags ensure {a:1} and [[\"a\",1]] produce distinct digests (no type-confusion collisions). Numbers must be safe integers (Number.isSafeInteger); floats and unsafe integers throw. Strings, booleans, and null pass through as scalars. Keys with undefined values are dropped.",
+    "constraints": {
+      "numbers": "Safe integers only (-(2^53-1) to 2^53-1). Floats, Infinity, NaN, and integers outside safe range must be pre-encoded as strings by the caller.",
+      "objects": "Recursively converted to [\"M\", sorted-pairs] at all depths. Type tag \"M\" ensures injectivity.",
+      "arrays": "[\"L\", elements] — element order preserved; each element recursively canonicalized. Type tag \"L\" ensures injectivity.",
+      "null_undefined": "Both canonicalize to JSON null.",
+      "undefined_keys": "Object keys whose value is undefined are dropped (matches JSON.stringify behavior)."
+    },
+    "vectors": [
+      {
+        "name": "nested_same_content_different_order",
+        "description": "Same logical content with different key insertion order produces identical canonical form and digest.",
+        "input_a": { "z": 1, "a": { "y": 2, "b": 3 } },
+        "input_b": { "a": { "b": 3, "y": 2 }, "z": 1 },
+        "canonical_form": "[\"M\",[[\"a\",[\"M\",[[\"b\",3],[\"y\",2]]]],[\"z\",1]]]",
+        "digest": "780dbde7596450dde10d8362bc4590826315109f85a55a2349f13539f023a07c"
+      },
+      {
+        "name": "array_order_matters",
+        "description": "Array element order is preserved — [1,2,3] and [3,2,1] produce different digests.",
+        "input_a": { "items": [1, 2, 3] },
+        "input_b": { "items": [3, 2, 1] },
+        "canonical_a": "[\"M\",[[\"items\",[\"L\",[1,2,3]]]]]",
+        "digest_a": "84a9ff2d4ccb26df641e5c01e9894a6b301d939f7f093f3acb76565018e50c94",
+        "canonical_b": "[\"M\",[[\"items\",[\"L\",[3,2,1]]]]]",
+        "digest_b": "24ec68e95f9bb0b135d4a8dd89b5939ac05fd7d4d43b2a7c85d800151441f2e9"
+      },
+      {
+        "name": "unicode_keys_sorted",
+        "description": "Unicode keys sorted by JS default string comparison (UTF-16 code unit order).",
+        "input": { "ñ": 1, "a": 2, "z": 3, "à": 4 },
+        "canonical_form": "[\"M\",[[\"a\",2],[\"z\",3],[\"à\",4],[\"ñ\",1]]]",
+        "digest": "6f8e940801e3f524e3f0db529e705583a0ab57c5ad5966cb29d6808fd064bc49"
+      },
+      {
+        "name": "astral_plane_keys_utf16_order",
+        "description": "Keys containing astral-plane characters (above BMP) must sort by UTF-16 code-unit order, not code-point order. U+10000 (surrogate pair D800 DC00, first code unit 0xD800=55296) sorts BEFORE U+FF61 (code unit 0xFF61=65377). Python's default sorted() uses code-point order and gets this wrong — must sort by key.encode('utf-16-be').",
+        "input": { "｡": 1, "𐀀": 2 },
+        "canonical_form": "[\"M\",[[\"𐀀\",2],[\"｡\",1]]]",
+        "digest": "17e0391b630e2a8ba408b2d47f689fbb6c4fd4e63c606691d3eca219d1843495",
+        "note": "If your implementation sorts U+FF61 before U+10000, you are using code-point order (wrong). UTF-16 code-unit order puts U+10000 first because its first code unit (0xD800) is numerically less than 0xFF61."
+      },
+      {
+        "name": "lone_surrogate_throws",
+        "description": "Strings containing unpaired surrogates must throw. This eliminates cross-language divergence in JSON serialization of lone surrogates. Test this by constructing a string with charCodeAt(0)===0xD800 in JS or chr(0xD800) in Python — do NOT rely on JSON parsing behavior for lone surrogates.",
+        "construct": "String.fromCharCode(0xD800) in JS; chr(0xD800) in Python",
+        "expected_error": "unpaired surrogate"
+      },
+      {
+        "name": "float_throws",
+        "description": "Non-integer numbers must throw. Callers encode floats as strings.",
+        "input": 0.1,
+        "expected_error": "unsafe number"
+      }
+    ]
+  },
+  "extensions_digest": {
+    "description": "extensionsDigest binds an extension map into the signed canonical form via canonicalizeValue(). The digest is SHA-256 of the injective type-tagged canonicalization ([\"M\",...] for objects, [\"L\",...] for arrays). Numbers must be safe integers; floats must be pre-encoded as strings. When extensionsDigest is absent/undefined, it is omitted from the record canonical form entirely (backward compatible).",
+    "vectors": [
+      {
+        "name": "simple_integer_map",
+        "description": "Extension map with string and integer values (integers are safe).",
+        "extensions": { "model": "gpt-4", "max_tokens": 1024 },
+        "canonical_form": "[\"M\",[[\"max_tokens\",1024],[\"model\",\"gpt-4\"]]]",
+        "digest": "bae5f878e0a23ed1918f2cb454e70d1306a862aa9bdc96117bbdc7d5b25b0d02"
+      },
+      {
+        "name": "empty_extension_map",
+        "description": "An empty object still produces a digest ([\"M\",[]]). Absent extensions (undefined) should NOT call computeExtensionsDigest at all.",
+        "extensions": {},
+        "canonical_form": "[\"M\",[]]",
+        "digest": "f262a0065c4f9cd6c0d849d4b5b291f7243748ddca5525ce54c6390ee07f126f"
+      },
+      {
+        "name": "nested_recursive_sort",
+        "description": "Keys sorted at every depth. Nested object {version: 2} becomes [\"M\",[[\"version\",2]]].",
+        "extensions": { "z_trace_id": "abc123", "a_deployment": "prod", "metadata": { "version": 2 } },
+        "canonical_form": "[\"M\",[[\"a_deployment\",\"prod\"],[\"metadata\",[\"M\",[[\"version\",2]]]],[\"z_trace_id\",\"abc123\"]]]",
+        "digest": "34fa7aa32aeda878bd56d0283d028dcd5bea5be5630dd7b3d15acdddd033a555"
+      },
+      {
+        "name": "float_as_string",
+        "description": "Floats must be pre-encoded as strings by the caller. This is the correct way to include non-integer numbers.",
+        "extensions": { "model": "gpt-4", "temperature": "0.7" },
+        "canonical_form": "[\"M\",[[\"model\",\"gpt-4\"],[\"temperature\",\"0.7\"]]]",
+        "digest": "83565ba3212a9bd8ebd3926fc2a1e7eb4c410804a8dbf2a564a2468fcc44f37c"
+      }
+    ],
+    "record_canonicalization": {
+      "description": "extensionsDigest appears after previousHash (or after decisionContextDigest if present) in the AuditRecord canonical form. When absent, the field is simply not included (backward compatible with pre-v0.3.0 records).",
+      "with_extensions_digest": {
+        "record": {
+          "id": "550e8400-e29b-41d4-a716-446655440099",
+          "timestamp": "2026-08-22T21:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "query_db",
+          "namespace": "data",
+          "upstream": "data-server",
+          "principal": "user:alice@example.com",
+          "durationMs": 150,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis",
+          "extensionsDigest": "bae5f878e0a23ed1918f2cb454e70d1306a862aa9bdc96117bbdc7d5b25b0d02"
+        },
+        "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440099\"],[\"timestamp\",\"2026-08-22T21:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"query_db\"],[\"namespace\",\"data\"],[\"upstream\",\"data-server\"],[\"principal\",\"user:alice@example.com\"],[\"durationMs\",150],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"],[\"extensionsDigest\",\"bae5f878e0a23ed1918f2cb454e70d1306a862aa9bdc96117bbdc7d5b25b0d02\"]]",
+        "sha256_canonical": "f5aa5b0cfbfcfd141c3e70a5ad2b4bee51ec170bdc88391829d1c05230550967"
+      },
+      "without_extensions_digest": {
+        "description": "Same record without extensionsDigest. Canonical form is identical to pre-v0.3.0 format.",
+        "record": {
+          "id": "550e8400-e29b-41d4-a716-446655440099",
+          "timestamp": "2026-08-22T21:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "query_db",
+          "namespace": "data",
+          "upstream": "data-server",
+          "principal": "user:alice@example.com",
+          "durationMs": 150,
+          "success": true,
+          "errorCode": null,
+          "previousHash": "genesis"
+        },
+        "canonical": "[[\"id\",\"550e8400-e29b-41d4-a716-446655440099\"],[\"timestamp\",\"2026-08-22T21:00:00.000Z\"],[\"method\",\"tools/call\"],[\"toolName\",\"query_db\"],[\"namespace\",\"data\"],[\"upstream\",\"data-server\"],[\"principal\",\"user:alice@example.com\"],[\"durationMs\",150],[\"success\",true],[\"errorCode\",null],[\"previousHash\",\"genesis\"]]",
+        "sha256_canonical": "9b7aa85506cfe76fd53b11425c206b32a5d3d2c1423d7e00686a201798475e54"
+      }
+    }
+  },
+  "rotation_boundary": {
+    "description": "Chain continuity across log rotation. The chain-global sequence (lastHash, checkpointSequence, totalRecordCount) persists via .state.json sidecar file. A rotation does NOT reset previousHash to 'genesis'. The first record in the new file chains to the last hash of the previous file.",
+    "file_1_records": [
+      {
+        "record": {
+          "id": "660e8400-e29b-41d4-a716-446655440001",
+          "timestamp": "2026-08-22T22:00:00.000Z",
+          "method": "tools/call",
+          "toolName": "list_files",
+          "namespace": "fs",
+          "upstream": "fs-server",
+          "principal": "user:charlie@example.com",
+          "durationMs": 12,
+          "success": true,
+          "previousHash": "genesis",
+          "attestation": "sig_rotation_rec1"
+        },
+        "record_hash": "ebed26d3fd72ead1ee70a6dd676720fc0c987d76b4d0454ee769abfd8c1634e6"
+      },
+      {
+        "record": {
+          "id": "ckpt_660e8400-e29b-41d4-a716-446655440002",
+          "type": "checkpoint",
+          "timestamp": "2026-08-22T22:00:01.000Z",
+          "sequence": 5,
+          "recordCount": 1,
+          "previousHash": "ebed26d3fd72ead1ee70a6dd676720fc0c987d76b4d0454ee769abfd8c1634e6",
+          "parties": [{ "party": "gateway", "role": "witness", "scope": ["sequence", "recordCount", "previousHash"] }],
+          "attestation": "sig_rotation_ckpt"
+        },
+        "record_hash": "9876964114ee76158f4551f0802c80d9a8869ef79f851e7524602861f1af0cc4"
+      }
+    ],
+    "rotation_note": "Log rotation happens here. State persisted: {lastHash: '9876964114ee76158f4551f0802c80d9a8869ef79f851e7524602861f1af0cc4', checkpointSequence: 5, totalRecordCount: 1}",
+    "file_2_records": [
+      {
+        "record": {
+          "id": "660e8400-e29b-41d4-a716-446655440003",
+          "timestamp": "2026-08-22T22:01:00.000Z",
+          "method": "tools/call",
+          "toolName": "read_file",
+          "namespace": "fs",
+          "upstream": "fs-server",
+          "principal": "user:charlie@example.com",
+          "durationMs": 35,
+          "success": true,
+          "previousHash": "9876964114ee76158f4551f0802c80d9a8869ef79f851e7524602861f1af0cc4",
+          "attestation": "sig_rotation_rec2"
+        },
+        "record_hash": "defa22cefc1c4fd457aff29b0c282e13b0d9d1faaaebb40c581802b99ae9a151",
+        "previous_record_hash": "9876964114ee76158f4551f0802c80d9a8869ef79f851e7524602861f1af0cc4",
+        "note": "This record's previousHash matches the checkpoint from file 1, proving chain survived rotation"
+      }
+    ],
+    "verification": {
+      "chain_valid": true,
+      "reason": "rec2.previousHash matches hash(checkpoint) from previous file. Chain is continuous across rotation boundary."
+    }
+  },
+  "sequence_regression": {
+    "description": "Detects rotation laundering or replay attacks where checkpoint sequence numbers go backward. If checkpoint N has sequence <= checkpoint N-1's sequence, the chain is compromised. This catches an attacker who rotates the log, resets state, and replays old records to hide the gap.",
+    "failure_code": "sequence_regression",
+    "chain": [
+      {
+        "record": {
+          "id": "770e8400-e29b-41d4-a716-446655440000",
+          "timestamp": "2026-08-22T22:59:00.000Z",
+          "method": "tools/call",
+          "toolName": "exec",
+          "namespace": "shell",
+          "upstream": "shell-server",
+          "principal": "user:dave@example.com",
+          "durationMs": 100,
+          "success": true,
+          "previousHash": "genesis",
+          "attestation": "sig_seqreg_rec0"
+        }
+      },
+      {
+        "record": {
+          "id": "ckpt_770e8400-e29b-41d4-a716-446655440001",
+          "type": "checkpoint",
+          "timestamp": "2026-08-22T23:00:00.000Z",
+          "sequence": 3,
+          "recordCount": 15,
+          "previousHash": "aaa111",
+          "parties": [{ "party": "gateway", "role": "witness", "scope": ["sequence", "recordCount", "previousHash"] }],
+          "attestation": "sig_seqreg_ckpt1"
+        },
+        "note": "Valid checkpoint at sequence 3"
+      },
+      {
+        "record": {
+          "id": "ckpt_770e8400-e29b-41d4-a716-446655440002",
+          "type": "checkpoint",
+          "timestamp": "2026-08-22T23:01:00.000Z",
+          "sequence": 2,
+          "recordCount": 20,
+          "previousHash": "bbb222",
+          "parties": [{ "party": "gateway", "role": "witness", "scope": ["sequence", "recordCount", "previousHash"] }],
+          "attestation": "sig_seqreg_ckpt2"
+        },
+        "note": "INVALID: sequence 2 <= previous sequence 3 (regression)"
+      }
+    ],
+    "detection_result": {
+      "truncated": true,
+      "failureCode": "sequence_regression",
+      "reason": "checkpoint sequence regressed: 2 <= 3"
+    }
+  },
+  "chain_break": {
+    "description": "A chain_break record is emitted when the operator forces a new chain (e.g. after a corrupt state file). It carries recoverable state from the prior chain as evidence of the discontinuity. The chain_break record is a valid chain start — subsequent records chain from its hash. This converts 'gap in evidence' into 'signed evidence of a gap'.",
+    "canonical_field_order": ["id", "type", "timestamp", "reason", "priorHead", "priorSequence", "priorRecordCount"],
+    "records": [
+      {
+        "record": {
+          "id": "break_880e8400-e29b-41d4-a716-446655440001",
+          "type": "chain_break",
+          "timestamp": "2026-08-22T23:30:00.000Z",
+          "reason": "state_file_corrupt",
+          "priorHead": "deadbeef1234567890abcdef",
+          "priorSequence": 10,
+          "priorRecordCount": 500,
+          "attestation": "sig_chain_break_1"
+        },
+        "record_hash": "3339fda07ff6daa328aa601cd61012b88ceb00ec1617357368692790ab7f31b2"
+      },
+      {
+        "record": {
+          "id": "880e8400-e29b-41d4-a716-446655440002",
+          "timestamp": "2026-08-22T23:30:01.000Z",
+          "method": "tools/call",
+          "toolName": "exec",
+          "namespace": "shell",
+          "upstream": "shell-server",
+          "principal": "user:eve@example.com",
+          "durationMs": 50,
+          "success": true,
+          "previousHash": "3339fda07ff6daa328aa601cd61012b88ceb00ec1617357368692790ab7f31b2",
+          "attestation": "sig_after_break"
+        },
+        "record_hash": "43701b65dbd89b8e22c34c9e2c75784749c42700925b5d27703b5b98c0832c23",
+        "note": "First record after chain_break chains from the break record's hash, proving continuity from the signed gap marker"
+      }
+    ]
+  },
+  "verification_modes": {
+    "description": "verifyCompleteness supports two explicit modes. Strict: full chain required, absolute counts verified, adjacent-pair deltas checked. Relative (suffix): descendant match acceptable, deltas checked, absolute counts marked unverified. This prevents a verifier from silently claiming full verification on a suffix.",
+    "modes": {
+      "strict": "Full chain from genesis (or chain_break). Absolute recordCount checked against prefix. Adjacent checkpoint deltas validated. absoluteCountVerified=true on success.",
+      "relative": "Suffix delivery acceptable. Descendant checkpoint match accepted. Deltas between adjacent checkpoints in the suffix are validated. absoluteCountVerified=false (honest downgrade). Result explicitly states verificationMode='relative'."
+    },
+    "adjacent_delta_check": {
+      "description": "Between every pair of adjacent checkpoints, the number of non-checkpoint records must equal the recordCount delta. This catches interior splices that absolute-count-only verification misses.",
+      "example": {
+        "checkpoint_a": { "sequence": 1, "recordCount": 5 },
+        "checkpoint_b": { "sequence": 2, "recordCount": 10 },
+        "expected_delta": 5,
+        "note": "If only 3 non-checkpoint records exist between checkpoint_a and checkpoint_b, failureCode is count_mismatch with reason mentioning 'adjacent checkpoint delta mismatch'."
+      }
+    }
+  },
+  "failure_codes": {
+    "description": "verifyCompleteness returns distinct failure codes to aid consumer diagnostics and automated response. Each code indicates a different class of tampering or failure.",
+    "codes": {
+      "head_missing": "The externalized checkpoint was not found in the delivered chain and no descendant checkpoint exists. Indicates tail truncation: records after the last externalized checkpoint were dropped.",
+      "count_mismatch": "The checkpoint exists in the chain but the number of non-checkpoint records preceding it does not match its recordCount claim, OR the delta between adjacent checkpoints doesn't match. Indicates a splice attack: valid checkpoint presented with a fabricated prefix or interior.",
+      "sequence_regression": "Two checkpoints in the chain have non-monotonic sequence numbers. Indicates rotation laundering: the chain was reset and old records replayed to hide the gap."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Any implementation of the audit attestation interceptor ([#557](https://github.com/docker/mcp-gateway/issues/557)) needs to produce hash chains that verify against the existing format. These vectors mean you don't have to reverse-engineer the canonicalization from source.

Added under [`fixtures/cross-stack/mcp-audit-gateway-v0.6/`](https://github.com/elang2/mcp-gateway/tree/feat/audit-attestation-vectors/fixtures/cross-stack/mcp-audit-gateway-v0.6) from [mcp-audit-gateway v0.6.0](https://github.com/elang2/mcp-audit-gateway/releases/tag/v0.6.0).

The two files cover record canonicalization (tuple-array with explicit field ordering), checkpoint anchoring for external verification, and the rotation-boundary and chain_break edge cases. Value canonicalization wraps objects and arrays with type markers so structurally different inputs can't accidentally produce the same digest.

## Why this format

I ran differential tests across all 10 official MCP SDKs and found [26 wire-level serialization divergences](https://github.com/elang2/mcp-audit-gateway/blob/v0.6.0/test/vectors/SDK-AUDIT.md). Without a format that sidesteps these, a Go implementation sorts keys lexicographically while Swift sorts numerically. Same audit record, different chain hash. Silently broken at the first cross-SDK boundary.

The format only allows integers because six SDKs format the same float six different ways. That's the main reason I went tuple-array. Keys have an explicit field order instead of relying on sort (Go, Swift, and TS all disagree on how to sort). Lone surrogates get rejected at the boundary before they can cause encoding disagreements downstream.

The serialization divergences in the [SDK audit](https://github.com/elang2/mcp-audit-gateway/blob/v0.6.0/test/vectors/SDK-AUDIT.md) are the same class of issue surfaced in [#307](https://github.com/docker/mcp-gateway/issues/307) and [#358](https://github.com/docker/mcp-gateway/issues/358). This canonicalization format sidesteps them by design.

## Test plan

[`SOURCE.md`](https://github.com/elang2/mcp-gateway/blob/feat/audit-attestation-vectors/fixtures/cross-stack/mcp-audit-gateway-v0.6/SOURCE.md) has the upstream commit SHA and per-file SHA-256 hashes. Run `shasum -a 256 fixtures/cross-stack/mcp-audit-gateway-v0.6/*.json` to verify they match.

Each vector entry includes its own preimage and expected digest, so they're independently recomputable without running the full gateway.