### PR TITLE
Fix community OAuth token refresh

### DIFF
--- a/cmd/docker-mcp/secret-management/secret/secretsengine.go
+++ b/cmd/docker-mcp/secret-management/secret/secretsengine.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/docker/secrets-engine/client"
 	"github.com/docker/secrets-engine/client/realms"
@@ -38,6 +39,33 @@ func GetSecrets(ctx context.Context) ([]client.Envelope, error) {
 // GetSecret retrieves a single secret by its full ID (e.g., "docker/mcp/oauth/github").
 // Returns ErrSecretNotFound if the secret does not exist.
 func GetSecret(ctx context.Context, id client.ID) (*client.Envelope, error) {
+	envelopes, err := getSecretsByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &envelopes[0], nil
+}
+
+// GetSecretFromProvider retrieves a secret by ID from one specific Secrets
+// Engine provider when multiple providers resolve the same realm.
+func GetSecretFromProvider(ctx context.Context, id client.ID, provider string) (*client.Envelope, error) {
+	envelopes, err := getSecretsByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return secretFromProvider(envelopes, id, provider)
+}
+
+func secretFromProvider(envelopes []client.Envelope, id client.ID, provider string) (*client.Envelope, error) {
+	for i := range envelopes {
+		if envelopes[i].Provider == provider {
+			return &envelopes[i], nil
+		}
+	}
+	return nil, fmt.Errorf("%w: provider %q for %s", ErrSecretNotFound, provider, id.String())
+}
+
+func getSecretsByID(ctx context.Context, id client.ID) ([]client.Envelope, error) {
 	pattern, err := client.ParsePattern(id.String())
 	if err != nil {
 		return nil, err
@@ -58,5 +86,5 @@ func GetSecret(ctx context.Context, id client.ID) (*client.Envelope, error) {
 	if len(envelopes) == 0 {
 		return nil, ErrSecretNotFound
 	}
-	return &envelopes[0], nil
+	return envelopes, nil
 }

--- a/cmd/docker-mcp/secret-management/secret/secretsengine_test.go
+++ b/cmd/docker-mcp/secret-management/secret/secretsengine_test.go
@@ -1,0 +1,33 @@
+package secret
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/secrets-engine/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretFromProvider(t *testing.T) {
+	id, err := client.ParseID("docker/mcp/oauth-dcr/law-mcp")
+	require.NoError(t, err)
+	envelopes := []client.Envelope{
+		{ID: id, Provider: "docker-desktop-mcp-dcr", Value: []byte("desktop")},
+		{ID: id, Provider: "docker-pass", Value: []byte("community")},
+	}
+
+	selected, err := secretFromProvider(envelopes, id, "docker-pass")
+	require.NoError(t, err)
+	assert.Equal(t, "docker-pass", selected.Provider)
+	assert.Equal(t, []byte("community"), selected.Value)
+}
+
+func TestSecretFromProviderMissing(t *testing.T) {
+	id, err := client.ParseID("docker/mcp/oauth-dcr/law-mcp")
+	require.NoError(t, err)
+
+	_, err = secretFromProvider(nil, id, "docker-pass")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSecretNotFound))
+}

--- a/pkg/oauth/dockerpass.go
+++ b/pkg/oauth/dockerpass.go
@@ -16,10 +16,16 @@ import (
 	"github.com/docker/mcp-gateway/pkg/oauth/dcr"
 )
 
+var getDockerPassDCRSecret = func(ctx context.Context, id seclient.ID) (*seclient.Envelope, error) {
+	return secret.GetSecretFromProvider(ctx, id, "docker-pass")
+}
+
 // Docker pass stores tokens and DCR clients in the OS Keychain at well-known
 // key paths. Writes use the `docker pass set` CLI command (via the secret
 // package). Reads go through the Secrets Engine API, which aggregates all
-// providers including the docker-pass plugin.
+// providers including the docker-pass plugin. DCR reads select that provider
+// explicitly because a stale Desktop OAuth provider entry can otherwise shadow
+// the community-server DCR client.
 //
 // Plugin resolution: both the docker-pass plugin (pattern `**`) and the
 // docker-desktop-mcp-oauth plugin (pattern `docker/mcp/oauth/**`) match the
@@ -242,10 +248,7 @@ func GetDCRClientFromDockerPass(ctx context.Context, serverName string) (dcr.Cli
 	if err != nil {
 		return dcr.Client{}, err
 	}
-	env, err := secret.GetSecret(ctx, dcrID)
-	if errors.Is(err, secret.ErrSecretNotFound) {
-		return dcr.Client{}, fmt.Errorf("DCR client not found for %s: %w", serverName, secret.ErrSecretNotFound)
-	}
+	env, err := getDockerPassDCRSecret(ctx, dcrID)
 	if err != nil {
 		return dcr.Client{}, fmt.Errorf("failed to query Secrets Engine for DCR client %s: %w", serverName, err)
 	}

--- a/pkg/oauth/dockerpass_test.go
+++ b/pkg/oauth/dockerpass_test.go
@@ -1,11 +1,13 @@
 package oauth
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"testing"
 	"time"
 
+	seclient "github.com/docker/secrets-engine/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -44,9 +46,7 @@ func TestEncodeDecodeToken(t *testing.T) {
 		"expiry mismatch: want %v, got %v", original.Expiry, restored.Expiry)
 }
 
-// TestEncodeDecodeDCRClient verifies the round-trip encoding of dcr.Client
-// used by SaveDCRClientToDockerPass and GetDCRClientFromDockerPass.
-func TestEncodeDecodeDCRClient(t *testing.T) {
+func TestGetDCRClientFromDockerPass(t *testing.T) {
 	original := dcr.Client{
 		ServerName:            "notion-remote",
 		ProviderName:          "notion-remote",
@@ -64,12 +64,15 @@ func TestEncodeDecodeDCRClient(t *testing.T) {
 	require.NoError(t, err)
 	encoded := base64.StdEncoding.EncodeToString(jsonData)
 
-	// Decode (same logic as GetDCRClientFromDockerPass)
-	decoded, err := base64.StdEncoding.DecodeString(encoded)
-	require.NoError(t, err)
+	oldGetDockerPassDCRSecret := getDockerPassDCRSecret
+	t.Cleanup(func() { getDockerPassDCRSecret = oldGetDockerPassDCRSecret })
+	getDockerPassDCRSecret = func(_ context.Context, id seclient.ID) (*seclient.Envelope, error) {
+		assert.Equal(t, "docker/mcp/oauth-dcr/notion-remote", id.String())
+		return &seclient.Envelope{Provider: "docker-pass", Value: []byte(encoded)}, nil
+	}
 
-	var restored dcr.Client
-	require.NoError(t, json.Unmarshal(decoded, &restored))
+	restored, err := GetDCRClientFromDockerPass(t.Context(), "notion-remote")
+	require.NoError(t, err)
 
 	assert.Equal(t, original.ServerName, restored.ServerName)
 	assert.Equal(t, original.ProviderName, restored.ProviderName)

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -1,8 +1,12 @@
 package oauth
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -61,6 +65,52 @@ func (p *DCRProvider) ResourceURL() string {
 // The challenge is automatically computed by oauth2 library when using S256ChallengeOption
 func (p *DCRProvider) GeneratePKCE() string {
 	return oauth2.GenerateVerifier()
+}
+
+// refreshResourceRoundTripper adds RFC 8707's resource parameter to refresh
+// token grants. x/oauth2 supports additional parameters during the initial
+// code exchange, but not when its TokenSource performs a refresh.
+type refreshResourceRoundTripper struct {
+	base     http.RoundTripper
+	resource string
+}
+
+func (t *refreshResourceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body == nil || t.resource == "" || req.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+		return t.base.RoundTrip(req)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	values, err := url.ParseQuery(string(body))
+	if err != nil || values.Get("grant_type") != "refresh_token" {
+		return t.base.RoundTrip(req)
+	}
+
+	values.Set("resource", t.resource)
+	encoded := values.Encode()
+	cloned := req.Clone(req.Context())
+	cloned.Body = io.NopCloser(bytes.NewBufferString(encoded))
+	cloned.ContentLength = int64(len(encoded))
+	cloned.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBufferString(encoded)), nil
+	}
+	return t.base.RoundTrip(cloned)
+}
+
+func newRefreshHTTPClient(ctx context.Context, resource string) *http.Client {
+	client := NewCredentialHTTPClient(ctx, 0)
+	base := client.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	client.Transport = &refreshResourceRoundTripper{base: base, resource: resource}
+	return client
 }
 
 // Provider manages OAuth token lifecycle for a single MCP server.
@@ -289,7 +339,7 @@ func (p *Provider) refreshTokenCommunity(ctx context.Context) error {
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, NewCredentialHTTPClient(ctx, 0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, newRefreshHTTPClient(ctx, provider.ResourceURL()))
 
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()
 	if err != nil {
@@ -335,7 +385,7 @@ func (p *Provider) refreshTokenCE(ctx context.Context) error {
 	// Inject proxy transport so the token endpoint is reachable through
 	// Docker Desktop's HTTP proxy when applicable, while blocking unsafe
 	// derived OAuth endpoints.
-	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, NewCredentialHTTPClient(ctx, 0))
+	proxyCtx := context.WithValue(ctx, oauth2.HTTPClient, newRefreshHTTPClient(ctx, provider.ResourceURL()))
 
 	// TokenSource automatically refreshes using refresh_token
 	refreshedToken, err := config.TokenSource(proxyCtx, token).Token()

--- a/pkg/oauth/provider_test.go
+++ b/pkg/oauth/provider_test.go
@@ -1,0 +1,97 @@
+package oauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRefreshResourceRoundTripperAddsResourceToRefreshGrant(t *testing.T) {
+	const resource = "https://mcp.example.com/api"
+
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		values, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		require.Equal(t, "refresh_token", values.Get("grant_type"))
+		require.Equal(t, "refresh-token", values.Get("refresh_token"))
+		require.Equal(t, resource, values.Get("resource"))
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"new-access-token","token_type":"Bearer","expires_in":3600}`)),
+		}, nil
+	})
+	client := &http.Client{Transport: &refreshResourceRoundTripper{base: base, resource: resource}}
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, client)
+	config := &oauth2.Config{
+		ClientID: "client-id",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: "https://auth.example.com/token",
+		},
+	}
+	expired := &oauth2.Token{
+		AccessToken:  "old-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(-time.Minute),
+	}
+
+	refreshed, err := config.TokenSource(ctx, expired).Token()
+	require.NoError(t, err)
+	require.Equal(t, "new-access-token", refreshed.AccessToken)
+}
+
+func TestRefreshResourceRoundTripperLeavesOtherRequestsUnchanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		resource string
+	}{
+		{
+			name: "empty resource",
+			body: "grant_type=refresh_token&refresh_token=refresh-token",
+		},
+		{
+			name:     "non-refresh grant",
+			body:     "code=authorization-code&grant_type=authorization_code",
+			resource: "https://mcp.example.com/api",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.Equal(t, test.body, string(body))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("{}")),
+				}, nil
+			})
+			transport := &refreshResourceRoundTripper{base: base, resource: test.resource}
+			req, err := http.NewRequest(http.MethodPost, "https://auth.example.com/token", strings.NewReader(test.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			_, err = transport.RoundTrip(req)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
**What I did**

- Select the `docker-pass` Secrets Engine envelope explicitly when loading a community server's DCR client. This prevents a stale `docker-desktop-mcp-dcr` envelope for the same key from being decoded as the Docker Pass value.
- Add the registered resource URL to OAuth refresh-token grants. The MCP Authorization specification requires `resource` in token requests, but `golang.org/x/oauth2.TokenSource` does not provide a refresh-grant option for it.
- Add focused tests for provider selection, missing-provider errors, resource injection, field preservation, and pass-through behavior.

Before this change, community refresh could fail while decoding the wrong DCR envelope:

```
failed to decode DCR client: illegal base64 data at input byte 0
```

If the correct envelope was selected, refresh could still produce a token rejected by an MCP resource server because the refresh grant omitted `resource`.

The refresh transport retains the gateway's existing endpoint validation, proxy behavior, and redirect policy. It only rewrites form-encoded refresh-token grants and leaves empty-resource and non-refresh requests unchanged.

References:

- [MCP Authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
- [RFC 8707, Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html)

Validation:

- `go test -mod=vendor ./cmd/docker-mcp/secret-management/secret ./pkg/oauth -count=1`
- `go test -race -mod=vendor ./cmd/docker-mcp/secret-management/secret ./pkg/oauth -count=1`
- `go vet -mod=vendor ./cmd/docker-mcp/secret-management/secret ./pkg/oauth`
- Live community-mode test: forced an existing MCP token to expire, refreshed it through the patched path, launched the patched gateway, listed the permitted tools, and successfully invoked a read-only tool with the refreshed token.

`go test -mod=vendor ./... -short -count=1` also reaches and passes the affected packages. It has two unrelated failures in `pkg/gateway/TestValidateDockerVolumeBinds`; both reproduce on the unmodified base commit `9254e88`.

**Related issue**

None found.
