### PR TITLE
fix: reject malformed downstream capabilities

### DIFF
--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -165,6 +165,10 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 					prefix := g.getToolNamePrefix(serverConfig)
 
 					for _, tool := range tools.Tools {
+						if tool == nil {
+							log.Logf("  > Ignoring invalid nil tool from %s", serverConfig.Name)
+							continue
+						}
 						if !isToolEnabled(g.configuration, serverConfig.Name, serverConfig.Spec.Image, tool.Name, g.ToolNames) {
 							continue
 						}
@@ -194,6 +198,10 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 					telemetry.RecordPromptList(ctx, serverConfig.Name, len(prompts.Prompts))
 
 					for _, prompt := range prompts.Prompts {
+						if prompt == nil {
+							log.Logf("  > Ignoring invalid nil prompt from %s", serverConfig.Name)
+							continue
+						}
 						capabilities.Prompts = append(capabilities.Prompts, PromptRegistration{
 							ServerName: serverConfig.Name,
 							Prompt:     prompt,
@@ -208,6 +216,10 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 					telemetry.RecordResourceList(ctx, serverConfig.Name, len(resources.Resources))
 
 					for _, resource := range resources.Resources {
+						if resource == nil {
+							log.Logf("  > Ignoring invalid nil resource from %s", serverConfig.Name)
+							continue
+						}
 						capabilities.Resources = append(capabilities.Resources, ResourceRegistration{
 							ServerName: serverConfig.Name,
 							Resource:   resource,
@@ -222,6 +234,10 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 					telemetry.RecordResourceTemplateList(ctx, serverConfig.Name, len(resourceTemplates.ResourceTemplates))
 
 					for _, resourceTemplate := range resourceTemplates.ResourceTemplates {
+						if resourceTemplate == nil {
+							log.Logf("  > Ignoring invalid nil resource template from %s", serverConfig.Name)
+							continue
+						}
 						capabilities.ResourceTemplates = append(capabilities.ResourceTemplates, ResourceTemplateRegistration{
 							ServerName:       serverConfig.Name,
 							ResourceTemplate: *resourceTemplate,

--- a/pkg/gateway/capability_validation.go
+++ b/pkg/gateway/capability_validation.go
@@ -1,0 +1,102 @@
+package gateway
+
+import (
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/mcp-gateway/pkg/log"
+)
+
+// filterInvalidCapabilities rejects downstream capabilities that the MCP SDK
+// would panic while registering. Downstream servers are not trusted to return
+// setter-safe metadata, so validate against an isolated server before touching
+// the gateway's live server or capability indexes.
+func filterInvalidCapabilities(caps *Capabilities) *Capabilities {
+	if caps == nil {
+		return &Capabilities{}
+	}
+
+	validator := mcp.NewServer(
+		&mcp.Implementation{Name: "mcp-gateway-capability-validator", Version: "0"},
+		&mcp.ServerOptions{Capabilities: &mcp.ServerCapabilities{
+			Prompts:   &mcp.PromptCapabilities{},
+			Resources: &mcp.ResourceCapabilities{},
+			Tools:     &mcp.ToolCapabilities{},
+		}},
+	)
+	filtered := &Capabilities{
+		Tools:             make([]ToolRegistration, 0, len(caps.Tools)),
+		Prompts:           make([]PromptRegistration, 0, len(caps.Prompts)),
+		Resources:         make([]ResourceRegistration, 0, len(caps.Resources)),
+		ResourceTemplates: make([]ResourceTemplateRegistration, 0, len(caps.ResourceTemplates)),
+	}
+
+	for _, registration := range caps.Tools {
+		name := "<nil>"
+		if registration.Tool != nil {
+			name = registration.Tool.Name
+		}
+		if err := catchCapabilitySetterPanic(func() {
+			validator.AddTool(registration.Tool, registration.Handler)
+		}); err != nil {
+			logInvalidCapability("tool", name, registration.ServerName, err)
+			continue
+		}
+		filtered.Tools = append(filtered.Tools, registration)
+	}
+
+	for _, registration := range caps.Prompts {
+		name := "<nil>"
+		if registration.Prompt != nil {
+			name = registration.Prompt.Name
+		}
+		if err := catchCapabilitySetterPanic(func() {
+			validator.AddPrompt(registration.Prompt, registration.Handler)
+		}); err != nil {
+			logInvalidCapability("prompt", name, registration.ServerName, err)
+			continue
+		}
+		filtered.Prompts = append(filtered.Prompts, registration)
+	}
+
+	for _, registration := range caps.Resources {
+		uri := "<nil>"
+		if registration.Resource != nil {
+			uri = registration.Resource.URI
+		}
+		if err := catchCapabilitySetterPanic(func() {
+			validator.AddResource(registration.Resource, registration.Handler)
+		}); err != nil {
+			logInvalidCapability("resource", uri, registration.ServerName, err)
+			continue
+		}
+		filtered.Resources = append(filtered.Resources, registration)
+	}
+
+	for _, registration := range caps.ResourceTemplates {
+		if err := catchCapabilitySetterPanic(func() {
+			validator.AddResourceTemplate(&registration.ResourceTemplate, registration.Handler)
+		}); err != nil {
+			logInvalidCapability("resource template", registration.ResourceTemplate.URITemplate, registration.ServerName, err)
+			continue
+		}
+		filtered.ResourceTemplates = append(filtered.ResourceTemplates, registration)
+	}
+
+	return filtered
+}
+
+func catchCapabilitySetterPanic(setter func()) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("MCP SDK setter rejected capability: %v", recovered)
+		}
+	}()
+	setter()
+	return nil
+}
+
+func logInvalidCapability(kind, identifier, serverName string, err error) {
+	log.Logf("  > Ignoring invalid %s %q from %s: %v", kind, identifier, serverName, err)
+}

--- a/pkg/gateway/capability_validation_test.go
+++ b/pkg/gateway/capability_validation_test.go
@@ -1,0 +1,58 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterInvalidCapabilitiesRejectsSetterPanics(t *testing.T) {
+	caps := &Capabilities{
+		Tools: []ToolRegistration{
+			{ServerName: "server", Tool: &mcp.Tool{Name: "valid-tool", InputSchema: map[string]any{"type": "object"}}},
+			{ServerName: "server", Tool: &mcp.Tool{Name: "missing-schema"}},
+			{ServerName: "server", Tool: nil},
+		},
+		Prompts: []PromptRegistration{
+			{ServerName: "server", Prompt: &mcp.Prompt{Name: "valid-prompt"}},
+			{ServerName: "server", Prompt: nil},
+		},
+		Resources: []ResourceRegistration{
+			{ServerName: "server", Resource: &mcp.Resource{Name: "valid-resource", URI: "file:///valid"}},
+			{ServerName: "server", Resource: &mcp.Resource{Name: "invalid-resource", URI: "%"}},
+			{ServerName: "server", Resource: nil},
+		},
+		ResourceTemplates: []ResourceTemplateRegistration{
+			{ServerName: "server", ResourceTemplate: mcp.ResourceTemplate{Name: "valid-template", URITemplate: "file:///{path}"}},
+			{ServerName: "server", ResourceTemplate: mcp.ResourceTemplate{Name: "invalid-template", URITemplate: "%"}},
+		},
+	}
+
+	var filtered *Capabilities
+	assert.NotPanics(t, func() {
+		filtered = filterInvalidCapabilities(caps)
+	})
+
+	if assert.Len(t, filtered.Tools, 1) {
+		assert.Equal(t, "valid-tool", filtered.Tools[0].Tool.Name)
+	}
+	if assert.Len(t, filtered.Prompts, 1) {
+		assert.Equal(t, "valid-prompt", filtered.Prompts[0].Prompt.Name)
+	}
+	if assert.Len(t, filtered.Resources, 1) {
+		assert.Equal(t, "file:///valid", filtered.Resources[0].Resource.URI)
+	}
+	if assert.Len(t, filtered.ResourceTemplates, 1) {
+		assert.Equal(t, "file:///{path}", filtered.ResourceTemplates[0].ResourceTemplate.URITemplate)
+	}
+}
+
+func TestFilterInvalidCapabilitiesHandlesNil(t *testing.T) {
+	filtered := filterInvalidCapabilities(nil)
+
+	assert.Empty(t, filtered.Tools)
+	assert.Empty(t, filtered.Prompts)
+	assert.Empty(t, filtered.Resources)
+	assert.Empty(t, filtered.ResourceTemplates)
+}

--- a/pkg/gateway/reload.go
+++ b/pkg/gateway/reload.go
@@ -33,6 +33,7 @@ func (g *Gateway) reloadConfiguration(ctx context.Context, configuration Configu
 	if err != nil {
 		return fmt.Errorf("listing resources: %w", err)
 	}
+	capabilities = filterInvalidCapabilities(capabilities)
 	log.Log(">", len(capabilities.Tools), "tools listed in", time.Since(startList))
 
 	capabilities = g.filterToolCapabilitiesByPolicy(ctx, configuration, capabilities, "tool")
@@ -398,6 +399,7 @@ func (g *Gateway) reloadServerCapabilities(ctx context.Context, serverName strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to list capabilities for %s: %w", serverName, err)
 	}
+	newServerCaps = filterInvalidCapabilities(newServerCaps)
 
 	// Lock for reading/writing capability tracking
 	g.capabilitiesMu.Lock()


### PR DESCRIPTION
**What I did**

- Validate downstream tools, prompts, resources, and resource templates against an isolated MCP SDK server before registering them on the live gateway.
- Recover SDK setter panics, log and omit only the malformed capability, and keep valid capabilities from the same server available.
- Apply validation during initial configuration loading and runtime capability reloads.
- Ignore `null` entries returned by downstream list methods before dereferencing them.
- Add regression coverage for a bare `%` resource URI, malformed templates and tool schemas, and nil capability entries.

**Related issue**

[RT-258](https://docker.atlassian.net/browse/RT-258)

**Testing**

- `make test`
- `make lint`

[RT-258]: https://docker.atlassian.net/browse/RT-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ