### PR TITLE
fix: continue pulling after image inspect errors

### DIFF
--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -55,7 +55,7 @@ func (c *dockerClient) InspectImage(ctx context.Context, name string) (image.Ins
 func (c *dockerClient) pullImage(ctx context.Context, imageName string, registryAuthFn func() string) error {
 	inspect, err := c.apiClient().ImageInspect(ctx, imageName)
 	if err != nil && !cerrdefs.IsNotFound(err) {
-		return fmt.Errorf("inspecting docker image %s: %w", imageName, err)
+		fmt.Fprintf(os.Stderr, "  - warning: inspecting docker image %s: %v", imageName, err)
 	}
 
 	if len(inspect.RepoDigests) > 0 {

--- a/pkg/docker/images_test.go
+++ b/pkg/docker/images_test.go
@@ -1,0 +1,48 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullImageContinuesAfterInspectError(t *testing.T) {
+	apiClient := &imageAPIClient{inspectErr: errors.New("engine is starting")}
+	dockerClient := &dockerClient{
+		apiClient: func() client.APIClient {
+			return apiClient
+		},
+	}
+
+	err := dockerClient.pullImage(t.Context(), "docker.io/library/alpine:latest", func() string {
+		return ""
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, apiClient.pullCalls)
+}
+
+type imageAPIClient struct {
+	client.APIClient
+	inspectErr error
+	pullCalls  int
+}
+
+func (c *imageAPIClient) ImageInspect(
+	context.Context, string, ...client.ImageInspectOption,
+) (image.InspectResponse, error) {
+	return image.InspectResponse{}, c.inspectErr
+}
+
+func (c *imageAPIClient) ImagePull(
+	context.Context, string, image.PullOptions,
+) (io.ReadCloser, error) {
+	c.pullCalls++
+	return io.NopCloser(strings.NewReader("")), nil
+}


### PR DESCRIPTION
**What I did**

Changed `pullImage` so a non-not-found `ImageInspect` error emits a warning and continues into the existing best-effort `ImagePull` path instead of failing the shared image-pull group. This keeps unrelated image pulls alive during transient engine-startup races.

Added a regression test that injects an inspect failure and verifies that the pull still runs and the operation succeeds.

Validation:

- `go test ./pkg/docker -run TestPullImageContinuesAfterInspectError -count=1`
- `go test -race ./pkg/docker -count=1`
- `CGO_ENABLED=0 go test -short --count=1 ./...`
- `go vet ./...`
- `golangci-lint` v2.8.0 for Linux, macOS, and Windows ARM64: 0 issues

**Related issue**

Fixes #560