### PR TITLE
Docs: optional TOA verify for MCP lifecycle / promote

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Developers face criticial barriers when integrating Model Context Protocol (MCP)
 - 📋 **Server Catalog**: Manage and configure multiple MCP catalogs.
 - 🔍 **Dynamic Discovery**: Automatic tool, prompt, and resource discovery from running servers.
 - 📊 **Monitoring**: Built-in logging and call tracing capabilities.
+- 🧾 **Optional TOA gate**: Offline delivery-evidence verify before enable/promote ([docs](docs/toa-optional-lifecycle-gate.md)). Distinct from image signatures and audit interceptors.
 
 ## Installation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,6 +79,15 @@ Third-party images outside Docker MCP's signing namespace are not verified with
 Docker MCP signatures. Their trust comes from the user's catalog, profile, or
 operator configuration choice.
 
+### Optional delivery evidence (TOA)
+
+Image signature verification proves who published a container image. Optional
+offline [Tool Outcome Attestation](https://github.com/Carmel-Labs-Inc/toa)
+(`toa/0.1`) prove graded tool delivery from a probe before enable/promote. TOA is
+not a substitute for signatures, and it is not the same as gateway audit
+attestation interceptors. See [Optional TOA lifecycle gate](toa-optional-lifecycle-gate.md).
+
+
 ### Container execution
 
 MCP server containers do not receive the user's host environment by default. The

--- a/docs/toa-optional-lifecycle-gate.md
+++ b/docs/toa-optional-lifecycle-gate.md
@@ -40,7 +40,7 @@ recent TOA attestation and verify it offline with `--require-emitter` and option
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/docs/toa-optional-lifecycle-gate.md
+++ b/docs/toa-optional-lifecycle-gate.md
@@ -29,7 +29,7 @@ from TOA:
 
 Optional, off by default. Before enabling a server in a profile, pushing a
 catalog/profile to an OCI registry, or promoting a Compose stack, require a
-recent TOA attestation and verify it offline with a pinned emitter public key.
+recent TOA attestation and verify it offline with `--require-emitter` and optional `--max-age`.
 
 - Any party can emit if they sign the schema.
 - AgentStatus is one optional emitter.
@@ -40,8 +40,8 @@ recent TOA attestation and verify it offline with a pinned emitter public key.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Copy-paste workflow: [`examples/toa-after-lifecycle.yml`](../examples/toa-after-lifecycle.yml).

--- a/docs/toa-optional-lifecycle-gate.md
+++ b/docs/toa-optional-lifecycle-gate.md
@@ -1,0 +1,56 @@
+# Optional TOA verify for MCP lifecycle / promote
+
+Docker MCP Gateway manages MCP server lifecycle in containers, authenticates
+clients, verifies Docker MCP image signatures for `mcp/` images, and can attach
+interceptors to tool calls. Those controls answer isolation, auth, supply-chain
+signatures, and optional request audit.
+
+They do not answer whether a tool recently delivered a real result under an
+outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is an Apache-2.0 signed
+JSON evidence format for MCP tool delivery (reach, invoke, functional, shape,
+and related layers). It is not a wire protocol. It is not meant to run on every
+live `tools/call`.
+
+## Not the same as gateway audit attestation
+
+This repository also discusses **audit attestation** for tamper-evident tool-call
+records (see open design work around interceptors). That is a different artifact
+from TOA:
+
+| Concern | Docker MCP image signatures / audit attestation | TOA |
+|---|---|---|
+| What is signed | Image / call record integrity | Graded delivery evidence from a probe |
+| When | Pull/run or per-call intercept | CI / promote / enable gate |
+| Hot path | Gateway runtime | Offline `toa-verify` only |
+
+## Suggested fit
+
+Optional, off by default. Before enabling a server in a profile, pushing a
+catalog/profile to an OCI registry, or promoting a Compose stack, require a
+recent TOA attestation and verify it offline with a pinned emitter public key.
+
+- Any party can emit if they sign the schema.
+- AgentStatus is one optional emitter.
+- No AgentStatus account is required to verify.
+
+```yaml
+      # After gateway health / compose smoke checks.
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Copy-paste workflow: [`examples/toa-after-lifecycle.yml`](../examples/toa-after-lifecycle.yml).
+Compose health example: [`examples/health`](../examples/health).
+
+## Out of scope
+
+- Replacing image signature verification, OAuth, or interceptors
+- Signing every production `tools/call`
+- Changing gateway runtime code
+
+See also: [security model](security.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,3 +12,5 @@
 + `interceptors` - Configure interceptors on Tool Calls.
 + `health` - Health checks with Compose.
 + `compose-static` - Run the MCP Gateway, with Compose, in `static` mode. (Experimental)
++ `toa-after-lifecycle.yml` - Optional offline TOA verify after health / enable (not per-call).
+

--- a/examples/toa-after-lifecycle.yml
+++ b/examples/toa-after-lifecycle.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-lifecycle.yml
+++ b/examples/toa-after-lifecycle.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-lifecycle.yml
+++ b/examples/toa-after-lifecycle.yml
@@ -1,0 +1,25 @@
+# Example only. Copy into your org workflow as needed.
+# After Docker MCP Gateway health / profile enable, optionally verify TOA.
+name: MCP gateway lifecycle and optional TOA
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "examples/**"
+      - "toa.json"
+
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Your docker mcp gateway run / compose health checks go here.
+      # See examples/health for Compose healthcheck patterns.
+
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before enabling or promoting an MCP server / profile / catalog via Docker MCP Gateway.

- `docs/toa-optional-lifecycle-gate.md` (explicitly distinguishes TOA from image signatures and from gateway audit attestation interceptors)
- Pointer in `docs/security.md`
- `examples/toa-after-lifecycle.yml` + examples README entry
- Root README Features pointer

Does not change gateway runtime. TOA (`toa/0.1`) is adjacent delivery evidence, not a wire protocol and not per-call signing. No AgentStatus account is required to verify.

## Test plan

- [ ] Docs clearly separate TOA from image signature verify and audit attestation work
- [ ] Example YAML is optional / gated on `toa.json`
- [ ] Copy does not claim TOA replaces `/health`, OAuth, or interceptors


Made with [Cursor](https://cursor.com)