### PR TITLE
fix: load pulled catalogs for --servers

### DIFF
--- a/pkg/gateway/configuration.go
+++ b/pkg/gateway/configuration.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/config"
+	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/docker"
 	"github.com/docker/mcp-gateway/pkg/log"
 	"github.com/docker/mcp-gateway/pkg/oci"
@@ -312,7 +313,8 @@ type FileBasedConfiguration struct {
 	Watch              bool
 	McpOAuthDcrEnabled bool
 
-	docker docker.Client
+	docker     docker.Client
+	catalogDAO db.DAO // optional; tests inject a temp DB. production opens the default catalog DB.
 }
 
 func (c *FileBasedConfiguration) Read(ctx context.Context) (Configuration, chan Configuration, func() error, error) {
@@ -460,6 +462,14 @@ func (c *FileBasedConfiguration) readOnce(ctx context.Context) (Configuration, e
 	}
 
 	servers := mcpCatalog.Servers
+
+	// Servers from `docker mcp catalog pull` / `catalog create` live in the
+	// DB-backed store. `--servers` still goes through this file-based path,
+	// so without this merge a pulled catalog is invisible and the gateway
+	// starts zero backend tools.
+	if err := c.mergePulledCatalogServers(ctx, servers, serverCatalogs, serverSourceTypeOverrides); err != nil {
+		return Configuration{}, err
+	}
 
 	// Read servers from OCI references if any are provided
 	ociServers, ociCatalogRefs, err := c.readServersFromOci(ctx)
@@ -619,6 +629,67 @@ func (c *FileBasedConfiguration) readCatalog(ctx context.Context) (catalog.Catal
 	}
 
 	return catalog.Catalog{Servers: mergedServers}, serverCatalogs, nil
+}
+
+func (c *FileBasedConfiguration) pulledCatalogDAO() (db.DAO, func(), error) {
+	if c.catalogDAO != nil {
+		return c.catalogDAO, func() {}, nil
+	}
+	dao, err := db.New()
+	if err != nil {
+		return nil, nil, err
+	}
+	return dao, func() { _ = dao.Close() }, nil
+}
+
+func (c *FileBasedConfiguration) mergePulledCatalogServers(
+	ctx context.Context,
+	servers map[string]catalog.Server,
+	serverCatalogs map[string]string,
+	serverSourceTypeOverrides map[string]string,
+) error {
+	dao, closer, err := c.pulledCatalogDAO()
+	if err != nil {
+		if c.catalogDAO != nil {
+			return fmt.Errorf("opening pulled catalogs: %w", err)
+		}
+		log.Log("  - Skipping pulled catalogs:", err)
+		return nil
+	}
+	defer closer()
+
+	catalogs, err := dao.ListCatalogs(ctx)
+	if err != nil {
+		if c.catalogDAO != nil {
+			return fmt.Errorf("listing pulled catalogs: %w", err)
+		}
+		log.Log("  - Skipping pulled catalogs:", err)
+		return nil
+	}
+
+	added := 0
+	for _, cat := range catalogs {
+		for _, server := range cat.Servers {
+			if server.Snapshot == nil {
+				continue
+			}
+			name := server.Snapshot.Server.Name
+			if name == "" {
+				continue
+			}
+			if _, exists := servers[name]; exists {
+				continue
+			}
+			servers[name] = server.Snapshot.Server
+			serverCatalogs[name] = cat.Ref
+			serverSourceTypeOverrides[name] = "registry"
+			added++
+		}
+	}
+	if added > 0 {
+		log.Log(fmt.Sprintf("  - Added %d server(s) from pulled catalogs", added))
+	}
+	return nil
 }
 
 func (c *FileBasedConfiguration) readRegistry(ctx context.Context) (config.Registry, error) {

--- a/pkg/gateway/configuration_test.go
+++ b/pkg/gateway/configuration_test.go
@@ -2,14 +2,119 @@ package gateway
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/db"
 	"github.com/docker/mcp-gateway/pkg/docker"
 )
+
+func setupGatewayTestDB(t *testing.T) db.DAO {
+	t.Helper()
+	dao, err := db.New(db.WithDatabaseFile(filepath.Join(t.TempDir(), "test.db")))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dao.Close())
+	})
+	return dao
+}
+
+func seedPulledCatalog(t *testing.T, dao db.DAO, ref, name, image string) {
+	t.Helper()
+	err := dao.UpsertCatalog(t.Context(), db.Catalog{
+		Ref:    ref,
+		Digest: "d-" + name,
+		Title:  "pulled",
+		Servers: []db.CatalogServer{{
+			ServerType: "image",
+			Image:      image,
+			Snapshot: &db.ServerSnapshot{
+				Server: catalog.Server{
+					Name:  name,
+					Type:  "server",
+					Image: image,
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+}
+
+func TestReadOnceUsesPulledCatalogsForServers(t *testing.T) {
+	dao := setupGatewayTestDB(t)
+	seedPulledCatalog(t, dao, "docker.io/test/pulled:latest", "fetch", "mcp/fetch:pulled")
+	seedPulledCatalog(t, dao, "docker.io/test/other:latest", "unused", "mcp/unused:latest")
+
+	cfg := &FileBasedConfiguration{
+		ServerNames: []string{"fetch"},
+		catalogDAO:  dao,
+	}
+	got, err := cfg.readOnce(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"fetch"}, got.ServerNames())
+	server, _, found := got.Find("fetch")
+	require.True(t, found)
+	require.NotNil(t, server)
+	assert.Equal(t, "mcp/fetch:pulled", server.Spec.Image)
+	_, _, unusedFound := got.Find("unused")
+	assert.True(t, unusedFound, "pulled catalogs should be available for lookup")
+}
+
+func TestReadOnceFileCatalogWinsOverPulledCatalog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	catalogsDir := filepath.Join(home, ".docker", "mcp", "catalogs")
+	require.NoError(t, os.MkdirAll(catalogsDir, 0o755))
+	err := os.WriteFile(filepath.Join(catalogsDir, "local.yaml"), []byte(`registry:
+  fetch:
+    type: server
+    image: mcp/fetch:file
+`), 0o644)
+	require.NoError(t, err)
+
+	dao := setupGatewayTestDB(t)
+	seedPulledCatalog(t, dao, "docker.io/test/pulled:latest", "fetch", "mcp/fetch:pulled")
+
+	cfg := &FileBasedConfiguration{
+		CatalogPath: []string{"local.yaml"},
+		ServerNames: []string{"fetch"},
+		catalogDAO:  dao,
+	}
+	got, err := cfg.readOnce(t.Context())
+	require.NoError(t, err)
+
+	server, _, found := got.Find("fetch")
+	require.True(t, found)
+	require.NotNil(t, server)
+	assert.Equal(t, "mcp/fetch:file", server.Spec.Image)
+}
+
+func TestMergePulledCatalogServersSkipsEmptySnapshots(t *testing.T) {
+	dao := setupGatewayTestDB(t)
+	err := dao.UpsertCatalog(t.Context(), db.Catalog{
+		Ref:    "docker.io/test/empty:latest",
+		Digest: "empty",
+		Title:  "empty",
+		Servers: []db.CatalogServer{{
+			ServerType: "image",
+			Image:      "mcp/orphan:latest",
+		}},
+	})
+	require.NoError(t, err)
+
+	servers := map[string]catalog.Server{}
+	catalogs := map[string]string{}
+	overrides := map[string]string{}
+	cfg := &FileBasedConfiguration{catalogDAO: dao}
+	require.NoError(t, cfg.mergePulledCatalogServers(t.Context(), servers, catalogs, overrides))
+	assert.Empty(t, servers)
+}
 
 func TestReadServersFromOci(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fix `docker mcp gateway run --servers <names>` so server names from DB-backed catalogs created by `catalog pull` or `catalog create` are available to the gateway configuration.

## Changes

- Merge server definitions loaded from the catalog database into the file-based gateway configuration.
- Preserve file and OCI catalog entries when the same server name is present.
- Ignore empty pulled-catalog snapshots.
- Add regression coverage for pulled catalogs, precedence, and empty snapshots.

This restores static server selection for users who use the current catalog commands and avoids silently starting with zero tools.

## Verification

```
go test -mod=vendor ./pkg/gateway -short -count=1
```

The package test suite passes with the repository's declared Go 1.25.12 toolchain.
