### PR TITLE
feat: support bounded per-server CPU and memory limits

### DIFF
--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -70,6 +70,9 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 		Short: "Run the gateway",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := options.ValidateResourceOverrides(); err != nil {
+				return err
+			}
 			if features.IsProfilesFeatureEnabled() {
 				if len(options.ServerNames) > 0 || enableAllServers ||
 					len(options.CatalogPath) > 0 || len(options.RegistryPath) > 0 || len(options.ConfigPath) > 0 || len(options.ToolsPath) > 0 ||
@@ -217,6 +220,8 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli, features featur
 	runCmd.Flags().BoolVar(&options.LongLived, "long-lived", options.LongLived, "Containers are long-lived and will not be removed until the gateway is stopped, useful for stateful servers")
 	runCmd.Flags().BoolVar(&options.DebugDNS, "debug-dns", options.DebugDNS, "Debug DNS resolution")
 	runCmd.Flags().BoolVar(&options.Watch, "watch", options.Watch, "Watch for changes and reconfigure the gateway")
+	runCmd.Flags().StringToStringVar(&options.ServerCPUs, "server-cpus", nil, "Override CPU limit for a server (name=cpus, repeatable; supports fractional CPUs)")
+	runCmd.Flags().StringToStringVar(&options.ServerMemory, "server-memory", nil, "Override memory limit for a server (name=memory, repeatable)")
 	runCmd.Flags().IntVar(&options.Cpus, "cpus", options.Cpus, "CPUs allocated to each MCP Server (default is 1)")
 	runCmd.Flags().StringVar(&options.Memory, "memory", options.Memory, "Memory allocated to each MCP Server (default is 2Gb)")
 	runCmd.Flags().BoolVar(&options.Static, "static", options.Static, "Enable static mode (aka pre-started servers)")

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -291,3 +291,28 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		assert.False(t, shouldExclude, "should include configured catalogs when single non-Docker catalog")
 	})
 }
+
+func TestGatewayResourceFlags(t *testing.T) {
+	cmd := gatewayCommand(nil, nil, features.AllDisabled())
+	run, _, err := cmd.Find([]string{"run"})
+	require.NoError(t, err)
+	require.NoError(t, run.ParseFlags([]string{"--server-cpus", "heavy=2.5", "--server-cpus", "light=0.25", "--server-memory", "heavy=4g,light=128m"}))
+	cpus, err := run.Flags().GetStringToString("server-cpus")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"heavy": "2.5", "light": "0.25"}, cpus)
+	memory, err := run.Flags().GetStringToString("server-memory")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"heavy": "4g", "light": "128m"}, memory)
+}
+
+func TestGatewayRejectsInvalidResourceFlagsBeforeIO(t *testing.T) {
+	for _, args := range [][]string{{"--server-cpus", "worker=0"}, {"--server-memory", "worker=bad"}, {"--server-cpus", "=1"}} {
+		t.Run(args[1], func(t *testing.T) {
+			cmd := gatewayCommand(nil, nil, features.AllDisabled())
+			run, _, err := cmd.Find([]string{"run"})
+			require.NoError(t, err)
+			require.NoError(t, run.ParseFlags(args))
+			require.ErrorContains(t, run.RunE(run, nil), args[0])
+		})
+	}
+}

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -250,6 +250,27 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: server-cpus
+      value_type: stringToString
+      default_value: '[]'
+      description: |
+        Override CPU limit for a server (name=cpus, repeatable; supports fractional CPUs)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: server-memory
+      value_type: stringToString
+      default_value: '[]'
+      description: Override memory limit for a server (name=memory, repeatable)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: servers
       value_type: stringSlice
       default_value: '[]'

--- a/docs/generator/reference/mcp_gateway_run.md
+++ b/docs/generator/reference/mcp_gateway_run.md
@@ -5,39 +5,41 @@ Run the gateway
 
 ### Options
 
-| Name                        | Type          | Default             | Description                                                                                                                                   |
-|:----------------------------|:--------------|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
-| `--additional-catalog`      | `stringSlice` |                     | Additional catalog paths must resolve under ~/.docker/mcp/catalogs/                                                                           |
-| `--additional-config`       | `stringSlice` |                     | Additional config paths to merge with the default config.yaml                                                                                 |
-| `--additional-registry`     | `stringSlice` |                     | Additional registry paths to merge with the default registry.yaml                                                                             |
-| `--additional-tools-config` | `stringSlice` |                     | Additional tools paths to merge with the default tools.yaml                                                                                   |
-| `--allow-unauthenticated`   | `bool`        |                     | Allow unauthenticated HTTP/SSE gateway requests                                                                                               |
-| `--block-network`           | `bool`        |                     | Block tools from accessing forbidden network resources                                                                                        |
-| `--block-secrets`           | `bool`        | `true`              | Block secrets from being/received sent to/from tools                                                                                          |
-| `--catalog`                 | `stringSlice` | `[docker-mcp.yaml]` | Catalog paths must resolve under ~/.docker/mcp/catalogs/                                                                                      |
-| `--config`                  | `stringSlice` | `[config.yaml]`     | Paths to the config files (absolute or relative to ~/.docker/mcp/)                                                                            |
-| `--cpus`                    | `int`         | `1`                 | CPUs allocated to each MCP Server (default is 1)                                                                                              |
-| `--debug-dns`               | `bool`        |                     | Debug DNS resolution                                                                                                                          |
-| `--dry-run`                 | `bool`        |                     | Start the gateway but do not listen for connections (useful for testing the configuration)                                                    |
-| `--enable-all-servers`      | `bool`        |                     | Enable all servers in the catalog (instead of using individual --servers options)                                                             |
-| `--host`                    | `string`      |                     | Host or IP address to bind TCP transports to                                                                                                  |
-| `--interceptor`             | `stringArray` |                     | List of interceptors to use (format: when:type:path, e.g. 'before:exec:/bin/path')                                                            |
-| `--log-calls`               | `bool`        | `true`              | Log calls to the tools                                                                                                                        |
-| `--long-lived`              | `bool`        |                     | Containers are long-lived and will not be removed until the gateway is stopped, useful for stateful servers                                   |
-| `--mcp-registry`            | `stringSlice` |                     | MCP registry URLs to fetch servers from (can be repeated)                                                                                     |
-| `--memory`                  | `string`      | `2Gb`               | Memory allocated to each MCP Server (default is 2Gb)                                                                                          |
-| `--oci-ref`                 | `stringArray` |                     | OCI image references to use                                                                                                                   |
-| `--port`                    | `int`         | `0`                 | TCP port to listen on (default is to listen on stdio)                                                                                         |
-| `--registry`                | `stringSlice` | `[registry.yaml]`   | Paths to the registry files (absolute or relative to ~/.docker/mcp/)                                                                          |
-| `--secrets`                 | `string`      | `docker-desktop`    | Colon separated paths to search for secrets. Can be `docker-desktop` or a path to a .env file (default to using Docker Desktop's secrets API) |
-| `--servers`                 | `stringSlice` |                     | Names of the servers to enable (if non empty, ignore --registry flag)                                                                         |
-| `--static`                  | `bool`        |                     | Enable static mode (aka pre-started servers)                                                                                                  |
-| `--tools`                   | `stringSlice` |                     | List of tools to enable                                                                                                                       |
-| `--tools-config`            | `stringSlice` | `[tools.yaml]`      | Paths to the tools files (absolute or relative to ~/.docker/mcp/)                                                                             |
-| `--transport`               | `string`      | `stdio`             | stdio, sse or streaming. Uses MCP_GATEWAY_AUTH_TOKEN environment variable for localhost authentication to prevent dns rebinding attacks.      |
-| `--verbose`                 | `bool`        |                     | Verbose output                                                                                                                                |
-| `--verify-signatures`       | `bool`        | `true`              | Verify signatures of Docker MCP server images                                                                                                 |
-| `--watch`                   | `bool`        | `true`              | Watch for changes and reconfigure the gateway                                                                                                 |
+| Name                        | Type             | Default             | Description                                                                                                                                   |
+|:----------------------------|:-----------------|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
+| `--additional-catalog`      | `stringSlice`    |                     | Additional catalog paths must resolve under ~/.docker/mcp/catalogs/                                                                           |
+| `--additional-config`       | `stringSlice`    |                     | Additional config paths to merge with the default config.yaml                                                                                 |
+| `--additional-registry`     | `stringSlice`    |                     | Additional registry paths to merge with the default registry.yaml                                                                             |
+| `--additional-tools-config` | `stringSlice`    |                     | Additional tools paths to merge with the default tools.yaml                                                                                   |
+| `--allow-unauthenticated`   | `bool`           |                     | Allow unauthenticated HTTP/SSE gateway requests                                                                                               |
+| `--block-network`           | `bool`           |                     | Block tools from accessing forbidden network resources                                                                                        |
+| `--block-secrets`           | `bool`           | `true`              | Block secrets from being/received sent to/from tools                                                                                          |
+| `--catalog`                 | `stringSlice`    | `[docker-mcp.yaml]` | Catalog paths must resolve under ~/.docker/mcp/catalogs/                                                                                      |
+| `--config`                  | `stringSlice`    | `[config.yaml]`     | Paths to the config files (absolute or relative to ~/.docker/mcp/)                                                                            |
+| `--cpus`                    | `int`            | `1`                 | CPUs allocated to each MCP Server (default is 1)                                                                                              |
+| `--debug-dns`               | `bool`           |                     | Debug DNS resolution                                                                                                                          |
+| `--dry-run`                 | `bool`           |                     | Start the gateway but do not listen for connections (useful for testing the configuration)                                                    |
+| `--enable-all-servers`      | `bool`           |                     | Enable all servers in the catalog (instead of using individual --servers options)                                                             |
+| `--host`                    | `string`         |                     | Host or IP address to bind TCP transports to                                                                                                  |
+| `--interceptor`             | `stringArray`    |                     | List of interceptors to use (format: when:type:path, e.g. 'before:exec:/bin/path')                                                            |
+| `--log-calls`               | `bool`           | `true`              | Log calls to the tools                                                                                                                        |
+| `--long-lived`              | `bool`           |                     | Containers are long-lived and will not be removed until the gateway is stopped, useful for stateful servers                                   |
+| `--mcp-registry`            | `stringSlice`    |                     | MCP registry URLs to fetch servers from (can be repeated)                                                                                     |
+| `--memory`                  | `string`         | `2Gb`               | Memory allocated to each MCP Server (default is 2Gb)                                                                                          |
+| `--oci-ref`                 | `stringArray`    |                     | OCI image references to use                                                                                                                   |
+| `--port`                    | `int`            | `0`                 | TCP port to listen on (default is to listen on stdio)                                                                                         |
+| `--registry`                | `stringSlice`    | `[registry.yaml]`   | Paths to the registry files (absolute or relative to ~/.docker/mcp/)                                                                          |
+| `--secrets`                 | `string`         | `docker-desktop`    | Colon separated paths to search for secrets. Can be `docker-desktop` or a path to a .env file (default to using Docker Desktop's secrets API) |
+| `--server-cpus`             | `stringToString` |                     | Override CPU limit for a server (name=cpus, repeatable; supports fractional CPUs)                                                             |
+| `--server-memory`           | `stringToString` |                     | Override memory limit for a server (name=memory, repeatable)                                                                                  |
+| `--servers`                 | `stringSlice`    |                     | Names of the servers to enable (if non empty, ignore --registry flag)                                                                         |
+| `--static`                  | `bool`           |                     | Enable static mode (aka pre-started servers)                                                                                                  |
+| `--tools`                   | `stringSlice`    |                     | List of tools to enable                                                                                                                       |
+| `--tools-config`            | `stringSlice`    | `[tools.yaml]`      | Paths to the tools files (absolute or relative to ~/.docker/mcp/)                                                                             |
+| `--transport`               | `string`         | `stdio`             | stdio, sse or streaming. Uses MCP_GATEWAY_AUTH_TOKEN environment variable for localhost authentication to prevent dns rebinding attacks.      |
+| `--verbose`                 | `bool`           |                     | Verbose output                                                                                                                                |
+| `--verify-signatures`       | `bool`           | `true`              | Verify signatures of Docker MCP server images                                                                                                 |
+| `--watch`                   | `bool`           | `true`              | Watch for changes and reconfigure the gateway                                                                                                 |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -117,3 +117,10 @@ Flags:
 ## Troubleshooting
 
 Look at our [Troubleshooting Guide](/docs/troubleshooting.md)
+
+## Per-server resource limits
+
+Set CPU and memory limits for individual containerized MCP servers with catalog
+`resources` entries or explicit `--server-cpus` / `--server-memory` overrides.
+See [Per-server container resource limits](server-resources.md) for precedence,
+validation, and examples.

--- a/docs/security.md
+++ b/docs/security.md
@@ -85,6 +85,9 @@ MCP server containers do not receive the user's host environment by default. The
 gateway passes only configured environment variables, server config values, and
 secrets declared for that server. Containers are started with Docker isolation,
 `no-new-privileges`, and configured CPU and memory limits.
+Catalog `resources` values may lower these limits but cannot raise them without
+an explicit operator `--server-cpus` or `--server-memory` override. See
+[per-server resource limits](server-resources.md) for precedence and scope.
 
 Host bind mounts from catalog or profile configuration are validated before they
 are passed to Docker. Named and anonymous Docker volumes are allowed. Host path

--- a/docs/server-resources.md
+++ b/docs/server-resources.md
@@ -1,0 +1,96 @@
+# Per-server container resource limits
+
+MCP servers have different resource needs. A code analysis server may need more
+CPU than a small API adapter. The gateway supports per-server CPU and memory
+limits for the MCP server containers it launches.
+
+Existing catalogs keep their behavior: `--cpus` (default `1`) and `--memory`
+(default `2Gb`) apply to each server unless a per-server limit is set. These are
+per-container limits, not reservations or a shared budget for the gateway.
+
+## Catalog limits
+
+A container server entry can declare an optional `resources` block:
+
+```yaml
+name: api-adapter
+type: server
+image: example/api-adapter:latest
+resources:
+  cpus: "0.25"
+  memory: "256m"
+```
+
+The same block works inside a profile's `snapshot.server`. It is preserved by
+JSON/YAML serialization of catalog entries and profile snapshots. It is not a
+server environment variable or a field under the server's `config` schema.
+
+Each omitted field inherits its global setting. CPU limits support decimal
+values, with a minimum of `0.01` and nanocpu precision (up to nine decimal
+places). Quote CPU values in YAML. Memory uses Docker size syntax, such as
+`256m`, `2g`, or `512MiB`, with a minimum of 6 MiB. Per-server limits must be
+positive; zero does not disable a limit.
+
+## Operator overrides
+
+Use repeatable flags to explicitly set a server's limits, including increases:
+
+```console
+docker mcp gateway run --profile development \
+  --server-cpus code-analysis=2 \
+  --server-memory code-analysis=4g \
+  --server-cpus api-adapter=0.25 \
+  --server-memory api-adapter=256m
+```
+
+Use the server name in the profile/catalog, not an image reference or a tool
+name. Overrides also apply when that server is added dynamically later in the
+session. Names do not have to be enabled at startup. Names are matched exactly;
+check spelling when configuring an override. Repeating the same name for the
+same flag uses the last value.
+
+Precedence is evaluated independently for CPU and memory:
+
+1. An explicit `--server-cpus name=value` or `--server-memory name=value` wins.
+2. Otherwise, a catalog value applies only if it does not exceed the global
+   limit for that resource.
+3. Otherwise, the global setting applies.
+
+A catalog request exceeding a global limit is rejected with the server name and
+the explicit override needed to authorize it. It is not silently clamped. This
+prevents imported catalog/profile data from increasing resource limits without
+an operator decision. Raising a server override does not raise other servers'
+limits. An override also lets an operator replace an invalid catalog value.
+
+The existing global opt-outs (`--cpus=0`, `--memory=0` or an empty memory setting)
+remain unchanged. A catalog can impose a positive limit where the global setting
+is unlimited.
+
+Operator overrides are validated before gateway startup I/O. Catalog values for
+active container servers are validated before image pulls, on configuration
+reload, and before client acquisition. Invalid dynamic additions fail before
+their image is pulled. Existing servers without `resources` retain their current
+container arguments.
+
+## Scope
+
+These limits apply to both short-lived and long-lived containerized MCP servers.
+They do not allocate resources to remote HTTP/SSE servers, containers managed
+externally with `--static`, the gateway itself, proxy sidecars, or legacy
+per-tool POCI containers. Those keep their existing behavior. Updating launch
+flags requires restarting the gateway; this feature does not resize running
+containers in place.
+
+## Verify with Docker
+
+A Docker-backed integration test checks the actual container `HostConfig` values.
+Supply a locally available image that includes `sleep`; the test never pulls it:
+
+```console
+MCP_RESOURCE_TEST_IMAGE=alpine:3.22 go test ./pkg/gateway \
+  -run '^TestIntegrationServerResourceLimits$' -count=1
+```
+
+Without `MCP_RESOURCE_TEST_IMAGE`, or with `go test -short`, this integration test
+is skipped. Unit tests cover limit precedence, validation, catalog round trips,
+container arguments, and rejection before Docker access.

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -22,6 +22,13 @@ type topLevel struct {
 
 // MCP Servers
 
+// Resources declares per-server container limits. The gateway bounds catalog
+// limits by operator configuration; these values do not grant extra resources.
+type Resources struct {
+	CPUs   string `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Memory string `yaml:"memory,omitempty" json:"memory,omitempty"`
+}
+
 type Server struct {
 	Name           string    `yaml:"name,omitempty" json:"name,omitempty" validate:"required,min=1"`
 	Type           string    `yaml:"type" json:"type" validate:"required,oneof=server remote poci"`
@@ -46,6 +53,9 @@ type Server struct {
 	Config         []any     `yaml:"config,omitempty" json:"config,omitempty"`
 	Prefix         string    `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 	Metadata       *Metadata `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+
+	Resources *Resources `yaml:"resources,omitempty" json:"resources,omitempty"`
+
 	// Policy describes the policy decision for this server.
 	Policy *policy.Decision `yaml:"policy,omitempty" json:"policy,omitempty"`
 }

--- a/pkg/gateway/activateprofile.go
+++ b/pkg/gateway/activateprofile.go
@@ -135,6 +135,13 @@ func (g *Gateway) ActivateProfile(ctx context.Context, ws workingset.WorkingSet)
 			return err
 		}
 		serverConfig := profileConfig.servers[serverName]
+		if err := g.validateServerResources(&catalog.ServerConfig{Name: serverName, Spec: serverConfig}); err != nil {
+			return err
+		}
+	}
+
+	for _, serverName := range serversToActivate {
+		serverConfig := profileConfig.servers[serverName]
 		validation := serverValidation{serverName: serverName}
 
 		// Check if all required secrets are set

--- a/pkg/gateway/clientpool.go
+++ b/pkg/gateway/clientpool.go
@@ -84,6 +84,9 @@ func (cp *clientPool) longLived(serverConfig *catalog.ServerConfig, config *clie
 }
 
 func (cp *clientPool) AcquireClient(ctx context.Context, serverConfig *catalog.ServerConfig, config *clientConfig) (mcpclient.Client, error) {
+	if err := cp.validateServerResources(serverConfig); err != nil {
+		return nil, err
+	}
 	var getter *clientGetter
 	c := ctx
 
@@ -322,14 +325,18 @@ func (cp *clientPool) runToolContainer(ctx context.Context, tool catalog.Tool, p
 }
 
 func (cp *clientPool) baseArgs(name string) []string {
+	return containerBaseArgs(name, catalog.Resources{CPUs: globalCPUs(cp.Cpus), Memory: cp.Memory})
+}
+
+func containerBaseArgs(name string, limits catalog.Resources) []string {
 	args := []string{"run"}
 
 	args = append(args, "--rm", "-i", "--init", "--security-opt", "no-new-privileges")
-	if cp.Cpus > 0 {
-		args = append(args, "--cpus", fmt.Sprintf("%d", cp.Cpus))
+	if limits.CPUs != "" {
+		args = append(args, "--cpus", limits.CPUs)
 	}
-	if cp.Memory != "" {
-		args = append(args, "--memory", cp.Memory)
+	if limits.Memory != "" {
+		args = append(args, "--memory", limits.Memory)
 	}
 	args = append(args, "--pull", "never")
 
@@ -350,7 +357,11 @@ func (cp *clientPool) baseArgs(name string) []string {
 }
 
 func (cp *clientPool) argsAndEnv(serverConfig *catalog.ServerConfig, targetConfig proxies.TargetConfig) ([]string, []string, error) {
-	args := cp.baseArgs(serverConfig.Name)
+	limits, err := cp.serverResources(serverConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	args := containerBaseArgs(serverConfig.Name, limits)
 	var env []string
 
 	// Security options

--- a/pkg/gateway/config.go
+++ b/pkg/gateway/config.go
@@ -32,6 +32,8 @@ type Options struct {
 	Watch                   bool
 	Cpus                    int
 	Memory                  string
+	ServerCPUs              map[string]string
+	ServerMemory            map[string]string
 	Static                  bool
 	OAuthInterceptorEnabled bool
 	McpOAuthDcrEnabled      bool

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -78,6 +78,15 @@ func addServerHandler(g *Gateway, clientConfig *clientConfig) mcp.ToolHandler {
 			}, nil
 		}
 
+		if serverConfig != nil {
+			if err := g.validateServerResources(serverConfig); err != nil {
+				return &mcp.CallToolResult{
+					IsError: true,
+					Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
+				}, nil
+			}
+		}
+
 		// Append the new server to the current serverNames if not already present
 		alreadyEnabled := slices.Contains(g.configuration.serverNames, serverName)
 		if !alreadyEnabled {

--- a/pkg/gateway/pull.go
+++ b/pkg/gateway/pull.go
@@ -15,6 +15,14 @@ import (
 var verifyDockerImageSignatures = signatures.Verify
 
 func (g *Gateway) pullAndVerify(ctx context.Context, configuration Configuration) error {
+	for _, name := range configuration.ServerNames() {
+		server, _, found := configuration.Find(name)
+		if found && server != nil {
+			if err := g.validateServerResources(server); err != nil {
+				return err
+			}
+		}
+	}
 	dockerImages := configuration.DockerImages()
 	if len(dockerImages) == 0 {
 		return nil

--- a/pkg/gateway/resources.go
+++ b/pkg/gateway/resources.go
@@ -1,0 +1,131 @@
+package gateway
+
+import (
+	"fmt"
+	"math/big"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/docker/go-units"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+)
+
+func globalCPUs(cpus int) string {
+	if cpus <= 0 {
+		return ""
+	}
+	return strconv.Itoa(cpus)
+}
+
+// ValidateResourceOverrides checks operator-supplied limits before any I/O.
+// Names need not be active at startup: overrides also apply to dynamic servers.
+func (o Options) ValidateResourceOverrides() error {
+	for _, field := range []struct {
+		flag   string
+		values map[string]string
+		parse  func(string) (int64, error)
+	}{{"server-cpus", o.ServerCPUs, parseResourceCPUs}, {"server-memory", o.ServerMemory, parseResourceMemory}} {
+		names := make([]string, 0, len(field.values))
+		for name := range field.values {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		for _, name := range names {
+			if name == "" || strings.TrimSpace(name) != name {
+				return fmt.Errorf("--%s: server name must be non-empty and have no surrounding whitespace", field.flag)
+			}
+			if _, err := field.parse(field.values[name]); err != nil {
+				return fmt.Errorf("--%s for server %q: %w", field.flag, name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (o Options) validateServerResources(server *catalog.ServerConfig) error {
+	// Remote and static servers are not containers launched by this gateway.
+	if o.Static || server.IsRemote() || server.Spec.Image == "" {
+		return nil
+	}
+	_, err := o.serverResources(server)
+	return err
+}
+
+func (o Options) serverResources(server *catalog.ServerConfig) (catalog.Resources, error) {
+	requested := catalog.Resources{}
+	if server.Spec.Resources != nil {
+		requested = *server.Spec.Resources
+	}
+	cpus, err := resolveResource(server.Name, "cpus", requested.CPUs, globalCPUs(o.Cpus), o.ServerCPUs, parseResourceCPUs)
+	if err != nil {
+		return catalog.Resources{}, err
+	}
+	memory, err := resolveResource(server.Name, "memory", requested.Memory, o.Memory, o.ServerMemory, parseResourceMemory)
+	if err != nil {
+		return catalog.Resources{}, err
+	}
+	return catalog.Resources{CPUs: cpus, Memory: memory}, nil
+}
+
+// An operator override is authoritative for that field. Catalog limits can only
+// reduce a bounded global default. Reject, rather than silently clamp, requests
+// above that default so the operator knows the workload may need more resources.
+func resolveResource(name, field, requested, fallback string, overrides map[string]string, parse func(string) (int64, error)) (string, error) {
+	if value, ok := overrides[name]; ok {
+		if _, err := parse(value); err != nil {
+			return "", fmt.Errorf("server %q --server-%s: %w", name, field, err)
+		}
+		return value, nil
+	}
+	if requested == "" {
+		return fallback, nil
+	}
+	value, err := parse(requested)
+	if err != nil {
+		return "", fmt.Errorf("server %q resources.%s: %w", name, field, err)
+	}
+	if fallback != "" {
+		// Docker accepts a zero global memory limit as unlimited. Preserve that
+		// opt-out while still requiring positive per-server limits.
+		if field == "memory" {
+			if bytes, err := units.RAMInBytes(fallback); err == nil && bytes == 0 {
+				return requested, nil
+			}
+		}
+		limit, err := parse(fallback)
+		if err != nil {
+			return "", fmt.Errorf("server %q: invalid global --%s: %w", name, field, err)
+		}
+		if value > limit {
+			return "", fmt.Errorf("server %q resources.%s=%q exceeds global --%s=%q; explicitly authorize it with --server-%s %s=%s", name, field, requested, field, fallback, field, name, requested)
+		}
+	}
+	return requested, nil
+}
+
+func parseResourceCPUs(value string) (int64, error) {
+	// Use exact arithmetic: Docker represents CPUs in nanocpus. Reject overflow
+	// and excess precision instead of rounding a limit or turning it into zero.
+	if value == "" || strings.Trim(value, "0123456789.") != "" {
+		return 0, fmt.Errorf("CPU limit %q must be a positive decimal number", value)
+	}
+	cpus, ok := new(big.Rat).SetString(value)
+	if !ok {
+		return 0, fmt.Errorf("invalid CPU limit %q", value)
+	}
+	nano := cpus.Mul(cpus, big.NewRat(1e9, 1))
+	if !nano.IsInt() || !nano.Num().IsInt64() || nano.Num().Int64() < 10_000_000 {
+		return 0, fmt.Errorf("CPU limit %q must be at least 0.01, fit in int64 nanocpus, and have at most 9 decimal places", value)
+	}
+	return nano.Num().Int64(), nil
+}
+
+func parseResourceMemory(value string) (int64, error) {
+	size, err := units.RAMInBytes(value)
+	if err != nil || size < 6*1024*1024 {
+		return 0, fmt.Errorf("memory limit %q must be a valid Docker size of at least 6MiB", value)
+	}
+	return size, nil
+}

--- a/pkg/gateway/resources_integration_test.go
+++ b/pkg/gateway/resources_integration_test.go
@@ -1,0 +1,67 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/gateway/proxies"
+)
+
+func TestIntegrationServerResourceLimits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires a Docker daemon and a local test image")
+	}
+	image := os.Getenv("MCP_RESOURCE_TEST_IMAGE")
+	if image == "" {
+		t.Skip("set MCP_RESOURCE_TEST_IMAGE to a local image with sleep, e.g. alpine:3.22")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// Do not pull an image as a side effect of running the test suite.
+	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", image).CombinedOutput()
+	require.NoError(t, err, string(out))
+	for _, tc := range []struct {
+		name      string
+		options   Options
+		resources *catalog.Resources
+		cpu       int64
+		memory    int64
+	}{
+		{name: "catalog", options: Options{Cpus: 1, Memory: "2g"}, resources: &catalog.Resources{CPUs: "0.25", Memory: "128m"}, cpu: 250_000_000, memory: 128 * 1024 * 1024},
+		{name: "operator", options: Options{Cpus: 1, Memory: "2g", ServerCPUs: map[string]string{"worker": "1.5"}, ServerMemory: map[string]string{"worker": "256m"}}, cpu: 1_500_000_000, memory: 256 * 1024 * 1024},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := &clientPool{Options: tc.options}
+			args, _, err := cp.argsAndEnv(&catalog.ServerConfig{Name: "worker", Spec: catalog.Server{Image: image, Resources: tc.resources}}, proxies.TargetConfig{})
+			require.NoError(t, err)
+			args = append(args, "--detach", image, "sleep", "60")
+			out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+			require.NoError(t, err, string(out))
+			id := strings.TrimSpace(string(out))
+			t.Cleanup(func() {
+				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cleanupCancel()
+				output, cleanupErr := exec.CommandContext(cleanupCtx, "docker", "rm", "-f", id).CombinedOutput()
+				assert.NoError(t, cleanupErr, string(output))
+			})
+			out, err = exec.CommandContext(ctx, "docker", "inspect", "--format", "{{json .HostConfig}}", id).CombinedOutput()
+			require.NoError(t, err, string(out))
+			var limits struct {
+				NanoCpus int64
+				Memory   int64
+			}
+			require.NoError(t, json.Unmarshal(out, &limits))
+			assert.Equal(t, tc.cpu, limits.NanoCpus)
+			assert.Equal(t, tc.memory, limits.Memory)
+		})
+	}
+}

--- a/pkg/gateway/resources_test.go
+++ b/pkg/gateway/resources_test.go
@@ -1,0 +1,182 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/gateway/proxies"
+	"github.com/docker/mcp-gateway/pkg/workingset"
+)
+
+func TestServerResourceLimits(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		requested *catalog.Resources
+		cpus      map[string]string
+		memory    map[string]string
+		want      catalog.Resources
+		wantErr   string
+	}{
+		{name: "legacy defaults", want: catalog.Resources{CPUs: "1", Memory: "2Gb"}},
+		{name: "empty block", requested: &catalog.Resources{}, want: catalog.Resources{CPUs: "1", Memory: "2Gb"}},
+		{name: "smaller server", requested: &catalog.Resources{CPUs: "0.5", Memory: "256m"}, want: catalog.Resources{CPUs: "0.5", Memory: "256m"}},
+		{name: "partial catalog", requested: &catalog.Resources{Memory: "512m"}, want: catalog.Resources{CPUs: "1", Memory: "512m"}},
+		{name: "equivalent units", requested: &catalog.Resources{CPUs: "1.0", Memory: "2048MiB"}, want: catalog.Resources{CPUs: "1.0", Memory: "2048MiB"}},
+		{name: "catalog cannot raise CPU", requested: &catalog.Resources{CPUs: "2"}, wantErr: "--server-cpus worker=2"},
+		{name: "catalog cannot raise memory", requested: &catalog.Resources{Memory: "4g"}, wantErr: "--server-memory worker=4g"},
+		{name: "explicit increase", requested: &catalog.Resources{CPUs: "2", Memory: "4g"}, cpus: map[string]string{"worker": "2"}, memory: map[string]string{"worker": "4g"}, want: catalog.Resources{CPUs: "2", Memory: "4g"}},
+		{name: "operator wins", requested: &catalog.Resources{CPUs: "8", Memory: "8g"}, cpus: map[string]string{"worker": "0.25"}, memory: map[string]string{"worker": "128m"}, want: catalog.Resources{CPUs: "0.25", Memory: "128m"}},
+		{name: "override without catalog block", cpus: map[string]string{"worker": "2.5"}, want: catalog.Resources{CPUs: "2.5", Memory: "2Gb"}},
+		{name: "override is scoped", cpus: map[string]string{"other": "8"}, requested: &catalog.Resources{CPUs: "2"}, wantErr: "exceeds global"},
+		{name: "fields independent", cpus: map[string]string{"worker": "2"}, requested: &catalog.Resources{Memory: "4g"}, wantErr: "--server-memory"},
+		{name: "cannot disable catalog CPU limit", requested: &catalog.Resources{CPUs: "0"}, wantErr: "resources.cpus"},
+		{name: "cannot disable catalog memory limit", requested: &catalog.Resources{Memory: "0"}, wantErr: "resources.memory"},
+		{name: "empty override rejected", cpus: map[string]string{"worker": ""}, wantErr: "--server-cpus"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := &clientPool{Options: Options{Cpus: 1, Memory: "2Gb", ServerCPUs: tc.cpus, ServerMemory: tc.memory}}
+			server := &catalog.ServerConfig{Name: "worker", Spec: catalog.Server{Image: "example/worker", Resources: tc.requested}}
+			args, _, err := cp.argsAndEnv(server, proxies.TargetConfig{})
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Nil(t, args)
+				return
+			}
+			require.NoError(t, err)
+			// Exercise the actual container argument path, not just the resolver.
+			assert.Equal(t, 1, countArg(args, "--cpus"))
+			assert.Equal(t, 1, countArg(args, "--memory"))
+			assert.Equal(t, tc.want.CPUs, args[7])
+			assert.Equal(t, tc.want.Memory, args[9])
+		})
+	}
+}
+
+func countArg(args []string, target string) int {
+	n := 0
+	for _, arg := range args {
+		if arg == target {
+			n++
+		}
+	}
+	return n
+}
+
+func TestResourceLimitValidation(t *testing.T) {
+	for _, value := range []string{"", "0", "-1", "NaN", "Inf", "1/2", "1e3", " 1", "1 ", "1.2.3", "0.001", "0.1234567891", "9223372037", "18446744074"} {
+		t.Run("cpu="+value, func(t *testing.T) {
+			o := Options{ServerCPUs: map[string]string{"worker": value}}
+			require.ErrorContains(t, o.ValidateResourceOverrides(), "--server-cpus")
+		})
+	}
+	for _, value := range []string{"", "0", "-1", "5m", "NaN", "Inf", "garbage", "999999999999999999999999999999g"} {
+		t.Run("memory="+value, func(t *testing.T) {
+			o := Options{ServerMemory: map[string]string{"worker": value}}
+			require.ErrorContains(t, o.ValidateResourceOverrides(), "--server-memory")
+		})
+	}
+	for _, name := range []string{"", " worker", "worker "} {
+		o := Options{ServerCPUs: map[string]string{name: "1"}}
+		require.ErrorContains(t, o.ValidateResourceOverrides(), "server name")
+	}
+	for _, value := range []string{"0.01", "0.123456789", "1", "2.5"} {
+		o := Options{ServerCPUs: map[string]string{"worker": value}, ServerMemory: map[string]string{"worker": "6MiB"}}
+		require.NoError(t, o.ValidateResourceOverrides())
+	}
+}
+
+func TestServerResourcesWithUnlimitedGlobals(t *testing.T) {
+	server := &catalog.ServerConfig{Name: "worker", Spec: catalog.Server{Resources: &catalog.Resources{CPUs: "2", Memory: "4g"}}}
+	for _, memory := range []string{"", "0"} {
+		o := Options{Memory: memory}
+		got, err := o.serverResources(server)
+		require.NoError(t, err)
+		assert.Equal(t, *server.Spec.Resources, got)
+	}
+}
+
+func TestInvalidResourcesFailBeforeDockerAccess(t *testing.T) {
+	server := catalog.Server{Image: "example/worker", Resources: &catalog.Resources{CPUs: "2"}}
+	g := &Gateway{Options: Options{Cpus: 1, Memory: "2g"}}
+	// No Docker client is provided: validation must happen before pull/inspect.
+	err := g.pullAndVerify(context.Background(), Configuration{serverNames: []string{"worker"}, servers: map[string]catalog.Server{"worker": server}})
+	require.ErrorContains(t, err, "--server-cpus worker=2")
+	cp := &clientPool{Options: g.Options}
+	// Dynamic acquisition must reject the same request before creating a client.
+	_, err = cp.AcquireClient(context.Background(), &catalog.ServerConfig{Name: "worker", Spec: server}, nil)
+	require.ErrorContains(t, err, "--server-cpus worker=2")
+}
+
+func TestResourceLimitsDoNotApplyToExternalServers(t *testing.T) {
+	o := Options{Cpus: 1, Memory: "2g"}
+	server := &catalog.ServerConfig{Name: "remote", Spec: catalog.Server{Remote: catalog.Remote{URL: "https://example.com/mcp"}, Resources: &catalog.Resources{CPUs: "invalid"}}}
+	require.NoError(t, o.validateServerResources(server))
+	server.Spec.Remote.URL = ""
+	server.Spec.Image = "example/worker"
+	o.Static = true
+	require.NoError(t, o.validateServerResources(server))
+}
+
+func TestCatalogResourceRoundTrip(t *testing.T) {
+	// Profiles and OCI catalog snapshots embed catalog.Server and use these codecs.
+	var server catalog.Server
+	require.NoError(t, yaml.Unmarshal([]byte("name: worker\ntype: server\nimage: example/worker\nresources:\n  cpus: '0.5'\n  memory: 256m\n"), &server))
+	require.NotNil(t, server.Resources)
+	for _, codec := range []struct {
+		name      string
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{{"json", json.Marshal, json.Unmarshal}, {"yaml", yaml.Marshal, yaml.Unmarshal}} {
+		t.Run(codec.name, func(t *testing.T) {
+			data, err := codec.marshal(server)
+			require.NoError(t, err)
+			var got catalog.Server
+			require.NoError(t, codec.unmarshal(data, &got))
+			assert.Equal(t, server.Resources, got.Resources)
+			data, err = codec.marshal(catalog.Server{Name: "legacy"})
+			require.NoError(t, err)
+			assert.NotContains(t, string(data), "resources")
+		})
+	}
+}
+
+func TestDynamicAddRejectsResourcesWithoutMutatingConfiguration(t *testing.T) {
+	g := &Gateway{
+		Options:      Options{Cpus: 1, Memory: "2g"},
+		policyClient: newMockPolicyClient(),
+		configuration: Configuration{
+			serverNames: []string{"existing"},
+			servers: map[string]catalog.Server{"worker": {
+				Image:     "example/worker",
+				Resources: &catalog.Resources{CPUs: "2"},
+			}},
+		},
+	}
+	result, err := addServerHandler(g, nil)(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: "mcp-add", Arguments: json.RawMessage(`{"name":"worker"}`)},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	assert.Contains(t, result.Content[0].(*mcp.TextContent).Text, "--server-cpus worker=2")
+	assert.Equal(t, []string{"existing"}, g.configuration.serverNames)
+}
+
+func TestProfileRejectsResourcesBeforeAnyImagePull(t *testing.T) {
+	g := &Gateway{Options: Options{Cpus: 1, Memory: "2g"}, policyClient: newMockPolicyClient()}
+	ws := workingset.WorkingSet{Name: "development", Servers: []workingset.Server{
+		{Type: workingset.ServerTypeImage, Snapshot: &workingset.ServerSnapshot{Server: catalog.Server{Name: "light", Image: "example/light"}}},
+		{Type: workingset.ServerTypeImage, Snapshot: &workingset.ServerSnapshot{Server: catalog.Server{Name: "heavy", Image: "example/heavy", Resources: &catalog.Resources{CPUs: "2"}}}},
+	}}
+	// Even the valid first server must not reach the nil Docker client.
+	require.ErrorContains(t, g.ActivateProfile(context.Background(), ws), "--server-cpus heavy=2")
+	assert.Empty(t, g.configuration.serverNames)
+}

--- a/pkg/gateway/run.go
+++ b/pkg/gateway/run.go
@@ -139,6 +139,9 @@ func (g *Gateway) filterByPolicy(ctx context.Context, cfg *Configuration) {
 }
 
 func (g *Gateway) Run(ctx context.Context) error {
+	if err := g.ValidateResourceOverrides(); err != nil {
+		return err
+	}
 	// Initialize telemetry
 	telemetry.Init()
 


### PR DESCRIPTION
**What I did**

Servers in the same catalog can have very different resource needs, but the gateway currently applies one CPU and memory setting to every container. This adds per-server limits while keeping existing defaults unchanged.

Catalog entries can declare `resources.cpus` and `resources.memory`. Operators can set explicit overrides with repeatable `--server-cpus name=value` and `--server-memory name=value` flags. CPU limits support fractional values.

There is one deliberate difference from the proposal in #492: catalog values cannot raise a bounded global limit on their own. An explicit operator override takes precedence for that resource; otherwise, the gateway rejects an oversized catalog request with an actionable error. This follows the existing trust model for imported catalogs and profiles.

Validation covers startup, dynamic additions, profile activation, and client acquisition. Invalid dynamic additions leave the active server list unchanged, and profile resource validation finishes before any image pulls. Remote/static servers and legacy POCI tool containers retain their existing behavior.

Includes regression tests, an opt-in Docker integration test that inspects the resulting container limits, usage documentation, and regenerated CLI reference docs.

**Validation**

- Built with Go 1.25.12.
- Focused resource, CLI, profile, dynamic-add, and existing container-argument tests pass.
- golangci-lint v2.8.0 reports no issues for Linux, macOS, and Windows.
- Ran the full short test suite and compared failures with the unmodified base. No new failures were found; existing socket-dependent tests fail in this execution environment.
- The Docker integration test is not yet run against a daemon. It can be run with a locally available image:

```sh
MCP_RESOURCE_TEST_IMAGE=alpine:3.22 go test ./pkg/gateway \
  -run '^TestIntegrationServerResourceLimits$' -count=1
```

Keeping this as a draft pending the Docker-backed check and feedback on the precedence rules.

**Related issue**

Related to #492.