### PR TITLE
fix(interceptors): serialize tool call protocol payloads

### DIFF
--- a/examples/interceptors/README.md
+++ b/examples/interceptors/README.md
@@ -17,9 +17,19 @@ docker compose up --build
 
 There are three types of interceptors, `exec`, `docker` and `http`.
 Interceptors can run `before` a tool call or `after` a tool call`.
-Those which run run `before` have access to the full tool call request and
+Those which run run `before` receive the tool call's protocol payload and
 can either let the call go through or bypass the call and return a custom response.
 Those which run run `after` have access to the tool call response.
+
+The `before` payload uses `method` and `params` keys, for example:
+
+```json
+{"method":"tools/call","params":{"name":"search","arguments":{"query":"example"}}}
+```
+
+Request `_meta`, when present, is retained inside `params`. SDK session objects,
+HTTP headers and transport callbacks are not included. Interceptors reading the
+SDK's previous `Params` field should use the lowercase `params` key instead.
 
 ## `exec`
 

--- a/pkg/interceptors/interceptors.go
+++ b/pkg/interceptors/interceptors.go
@@ -96,7 +96,12 @@ func (i *Interceptor) ToMiddleware() mcp.Middleware {
 			}
 
 			if i.When == "before" {
-				message, err := json.Marshal(req)
+				// Serialize the protocol payload, not SDK session/transport state.
+				// RequestExtra can contain callbacks that JSON cannot encode.
+				message, err := json.Marshal(struct {
+					Method string     `json:"method"`
+					Params mcp.Params `json:"params"`
+				}{Method: method, Params: req.GetParams()})
 				if err != nil {
 					return nil, fmt.Errorf("marshalling request: %w", err)
 				}

--- a/pkg/interceptors/request_payload_test.go
+++ b/pkg/interceptors/request_payload_test.go
@@ -1,0 +1,123 @@
+package interceptors
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBeforeInterceptorStreamableHTTP(t *testing.T) {
+	intercepted := make(chan []byte, 1)
+	endpoint := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		intercepted <- body
+	}))
+	defer endpoint.Close()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	i := Interceptor{When: "before", Type: "http", Argument: endpoint.URL}
+	server.AddReceivingMiddleware(i.ToMiddleware())
+	mcp.AddTool(server, &mcp.Tool{Name: "echo"}, func(_ context.Context, req *mcp.CallToolRequest, args struct {
+		Text string `json:"text"`
+	},
+	) (*mcp.CallToolResult, any, error) {
+		assert.NotNil(t, req.Extra)
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: args.Text}}}, nil, nil
+	})
+	transport := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, nil))
+	defer transport.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: transport.URL}, nil)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, session.Close()) }()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "echo", Arguments: map[string]any{"text": "hello"}})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "hello", result.Content[0].(*mcp.TextContent).Text)
+	select {
+	case body := <-intercepted:
+		assert.JSONEq(t, `{"method":"tools/call","params":{"name":"echo","arguments":{"text":"hello"}}}`, string(body))
+	default:
+		t.Fatal("tool call did not reach the interceptor")
+	}
+}
+
+func TestBeforeInterceptorRequestPayload(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		extra *mcp.RequestExtra
+	}{
+		{name: "stdio"},
+		{name: "empty extra", extra: &mcp.RequestExtra{}},
+		{name: "streaming", extra: &mcp.RequestExtra{
+			Header: http.Header{"Authorization": {"Bearer transport-secret"}},
+			CloseSSEStream: func(mcp.CloseSSEStreamArgs) {
+				t.Error("serialization must not call the transport callback")
+			},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, override := range []bool{false, true} {
+				t.Run(map[bool]string{false: "passthrough", true: "override"}[override], func(t *testing.T) {
+					bodies := make(chan []byte, 1)
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						body, err := io.ReadAll(r.Body)
+						assert.NoError(t, err)
+						bodies <- body
+						if override {
+							_, err = io.WriteString(w, `{"content":[{"type":"text","text":"intercepted"}]}`)
+							assert.NoError(t, err)
+						}
+					}))
+					defer server.Close()
+
+					req := &mcp.CallToolRequest{
+						Params: &mcp.CallToolParamsRaw{
+							Name:      "search",
+							Arguments: json.RawMessage(`{"query":"hello","options":{"limit":3},"enabled":false}`),
+							Meta:      mcp.Meta{"progressToken": "progress-1"},
+						},
+						Extra: tc.extra,
+					}
+					called := false
+					want := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "original"}}}
+					next := func(_ context.Context, method string, got mcp.Request) (mcp.Result, error) {
+						called = true
+						assert.Equal(t, "tools/call", method)
+						assert.Same(t, req, got)
+						return want, nil
+					}
+					interceptor := Interceptor{When: "before", Type: "http", Argument: server.URL}
+					result, err := interceptor.ToMiddleware()(next)(context.Background(), "tools/call", req)
+					require.NoError(t, err)
+					select {
+					case body := <-bodies:
+						assert.JSONEq(t, `{"method":"tools/call","params":{"name":"search","arguments":{"query":"hello","options":{"limit":3},"enabled":false},"_meta":{"progressToken":"progress-1"}}}`, string(body))
+					default:
+						t.Fatal("interceptor was not invoked")
+					}
+					assert.Equal(t, !override, called)
+					if override {
+						assert.Equal(t, "intercepted", result.(*mcp.CallToolResult).Content[0].(*mcp.TextContent).Text)
+					} else {
+						assert.Same(t, want, result)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What I did**

Before interceptors currently marshal the entire Go SDK request. On Streamable HTTP, `RequestExtra` contains a `CloseSSEStream` function field, which makes `encoding/json` reject the request before the interceptor or tool can run. Even an empty non-nil `RequestExtra` triggers this error.

Serialize only `{ "method": "tools/call", "params": ... }`, retaining tool arguments and request `_meta` while excluding SDK session objects and transport state. This applies to all three interceptor runners because serialization happens before runner dispatch. After-interceptor behavior is unchanged.

The lowercase `params` key matches the existing jq examples. This intentionally replaces the SDK-shaped uppercase `Params` key; the example README now documents that migration and the payload boundary.

Regression coverage uses a real HTTP interceptor for passthrough and short-circuit results, with nil, empty and callback-bearing transport extras. A separate end-to-end test initializes a real MCP Streamable HTTP client/server pair and calls a tool through the interceptor. It verifies the tool result and the intercepted payload without Docker or a model provider.

**Related issue**

Fixes #358. The earlier #360 is closed and unmerged; this change includes transport-level regression coverage and does not depend on that PR.

**Verification**

- Linux, Go 1.25.12: full-repository golangci-lint 2.8.0 (`run ./...`) reported **0 issues**, and the CLI build passed.
- Linux: interceptor package passed 10 consecutive runs. Modified Go files pass the repository's formatter checks.
- Linux full short suite: 34 packages passed; `TestReset`, `TestResetEmptyCatalogs`, and `TestDockerCatalogProtection` failed while downloading `https://desktop.docker.com/mcp/catalog/v2/catalog.yaml` (`connection reset by peer`). No tests were excluded or weakened. This is not a full-suite pass.
- Windows, Go 1.26.7: interceptor package tests passed.
- TDD: all six payload cases failed before the fix and passed after it.
- Mutation check: restoring `json.Marshal(req)` makes the real Streamable HTTP regression fail with the reported serialization error; restoring the fix makes the package pass again.
- Docker-backed integration tests were not run: the local Docker daemon is unavailable.
- A Windows full short-suite attempt encountered catalog/path/environment failures and was stopped; it is not reported as passing.
